### PR TITLE
fix #9 missing path to nidaqmx module in sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../'))
 
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
Fixes issue #9, where building of the Sphinx doc fails.

By adding `../` to the PATH during the Sphinx doc build, sphinx can find the module source even if the package was not previously installed.