### PR TITLE
Fixes issue #42

### DIFF
--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -929,7 +929,7 @@ class Task(object):
             ctypes.c_int32, lib_importer.task_handle, ctypes.c_int32,
             ctypes.c_void_p)
 
-        cfunc = lib_importer.daqlib.DAQmxRegisterSignalEvent
+        cfunc = lib_importer.windll.DAQmxRegisterSignalEvent
 
         with cfunc.arglock:
             if callback_method is not None:

--- a/nidaqmx/tests/test_events.py
+++ b/nidaqmx/tests/test_events.py
@@ -21,7 +21,7 @@ class TestEvents(object):
 
         samples_chunk = 100
         sample_rate = 5000
-
+    
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(
                 x_series_device.ai_physical_chans[0].name)
@@ -67,6 +67,69 @@ class TestEvents(object):
             # Unregister event callback function by passing None.
             task.register_every_n_samples_acquired_into_buffer_event(
                 samples_chunk, None)
+
+            task.start()
+            task.wait_until_done(timeout=2)
+
+            # Wait until done doesn't wait for all callbacks to be processed.
+            time.sleep(1)
+            task.stop()
+
+            assert non_local_var['samples_read'] == 0
+    
+    @pytest.mark.parametrize('seed', [generate_random_seed()])
+    def test_signal_event(self, x_series_device, seed):
+        # Reset the pseudorandom number generator with seed.
+        random.seed(seed)
+
+        samples_chunk = 100
+        sample_rate = 5000
+        
+        with nidaqmx.Task() as task:
+            task.ai_channels.add_ai_voltage_chan(
+                x_series_device.ai_physical_chans[0].name)
+
+            samples_multiple = random.randint(2, 5)
+            num_samples = samples_chunk * samples_multiple
+
+            task.timing.cfg_samp_clk_timing(
+                sample_rate, sample_mode=AcquisitionType.FINITE,
+                samps_per_chan=num_samples)
+
+            # Python 2.X does not have nonlocal keyword.
+            non_local_var = {'samples_read': 0}
+
+            def callback(task_handle, every_n_samples_event_type,
+                         number_of_samples, callback_data):
+                samples = task.read(
+                    number_of_samples_per_channel=samples_chunk, timeout=2.0)
+                non_local_var['samples_read'] += len(samples)
+                return 0
+            
+            task.register_signal_event(
+                nidaqmx.constants.Signal.CHANGE_DETECTION_EVENT, callback)
+
+            task.start()
+            task.wait_until_done(timeout=2)
+
+            # Wait until done doesn't wait for all callbacks to be processed.
+            time.sleep(1)
+            task.stop()
+
+            assert non_local_var['samples_read'] == num_samples
+
+            samples_multiple = random.randint(2, 5)
+            num_samples = samples_chunk * samples_multiple
+
+            task.timing.cfg_samp_clk_timing(
+                sample_rate, sample_mode=AcquisitionType.FINITE,
+                samps_per_chan=num_samples)
+
+            non_local_var = {'samples_read': 0}
+
+            # Unregister event callback function by passing None.
+            task.register_signal_event(
+                nidaqmx.constants.Signal.CHANGE_DETECTION_EVENT, None)
 
             task.start()
             task.wait_until_done(timeout=2)


### PR DESCRIPTION
instead of using daqlib property for DAQmxRegisterSignalEvent use windll. Fixes #42 

Sorry for the unfinished unittest - i didn't really copy how you reference the DAQmx Devices, but at least it should point the line ...