### PR TITLE
Fix for Linux where DAQmxGetSysNIDAQUpdateVersion is not available

### DIFF
--- a/nidaqmx/system/system.py
+++ b/nidaqmx/system/system.py
@@ -150,7 +150,7 @@ class System(object):
         try:
             cfunc = lib_importer.windll.DAQmxGetSysNIDAQUpdateVersion
         except DaqFunctionNotSupportedError:
-            cfunc = 0
+            return 0
         if cfunc.argtypes is None:
             with cfunc.arglock:
                 if cfunc.argtypes is None:

--- a/nidaqmx/system/system.py
+++ b/nidaqmx/system/system.py
@@ -150,7 +150,7 @@ class System(object):
         try:
             cfunc = lib_importer.windll.DAQmxGetSysNIDAQUpdateVersion
         except DaqFunctionNotSupportedError:
-            cfunc = lib_importer.windll.DAQmxGetSysNIDAQMinorVersion
+            cfunc = 0
         if cfunc.argtypes is None:
             with cfunc.arglock:
                 if cfunc.argtypes is None:

--- a/nidaqmx/system/system.py
+++ b/nidaqmx/system/system.py
@@ -8,7 +8,7 @@ import ctypes
 import numpy
 
 from nidaqmx._lib import (
-    lib_importer, wrapped_ndpointer, ctypes_byte_str, c_bool32)
+    lib_importer, wrapped_ndpointer, ctypes_byte_str, c_bool32, DaqFunctionNotSupportedError)
 from nidaqmx.errors import check_for_error, is_string_buffer_too_small
 from nidaqmx.system.device import Device
 from nidaqmx.system._collections.device_collection import DeviceCollection
@@ -147,7 +147,10 @@ class System(object):
         """
         val = ctypes.c_uint()
 
-        cfunc = lib_importer.windll.DAQmxGetSysNIDAQUpdateVersion
+        try:
+            cfunc = lib_importer.windll.DAQmxGetSysNIDAQUpdateVersion
+        except DaqFunctionNotSupportedError:
+            cfunc = lib_importer.windll.DAQmxGetSysNIDAQMinorVersion
         if cfunc.argtypes is None:
             with cfunc.arglock:
                 if cfunc.argtypes is None:


### PR DESCRIPTION
I have started using this module on Linux (with AI channels), and this is the only change that I add to do to make it work. Apparently, DAQmx on Linux does not have `DAQmxGetSysNIDAQUpdateVersion`. It seems to be enough to just fallback to `DAQmxGetSysNIDAQMinorVersion` in that case (although I am not sure that it means the same thing exactly).