### PR TITLE
fix: task.__del__ to use _saved_name

### DIFF
--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -102,7 +102,7 @@ class Task(object):
             warnings.warn(
                 'Task of name "{0}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '
-                'reserved.'.format(self.name), DaqResourceWarning)
+                'reserved.'.format(self._saved_name), DaqResourceWarning)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
My understanding is that when this is getting garbage collected, the python environment is shutting down and importing the _lib fails when trying to get the 'name' property. Basically the sys.meta_path is empty by the time is trying to load the daqmx dll.

Using the already saved name will prevent loading the dll on __del__.

Signed-off-by: Rares POP <rares.pop@ni.com>