### PR TITLE
remove: python2.7 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py34,py35,py36
 
 [testenv]
 install_command = pip install --pre -i http://ni-pypi.amer.corp.natinst.com --trusted-host ni-pypi.amer.corp.natinst.com {opts} {packages}


### PR DESCRIPTION
remove: python2.7 support since it reached EOL in January 2020

Signed-off-by: Rares POP <rares.pop@ni.com>