### PR TITLE
Fix #126 (`Task.write` does not handle certain inputs as expected)

### DIFF
--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -1170,20 +1170,18 @@ class Task(object):
         number_of_channels = len(channels_to_write.channel_names)
         write_chan_type = channels_to_write.chan_type
 
+        if isinstance(data, list):
+            data = numpy.asarray(data)
+
         element = None
         if number_of_channels == 1:
-            if isinstance(data, list):
-                if isinstance(data[0], list):
-                    self._raise_invalid_write_num_chans_error(
-                        number_of_channels, len(data))
-
-                number_of_samples_per_channel = len(data)
-                element = data[0]
-
-            elif isinstance(data, numpy.ndarray):
+            if isinstance(data, numpy.ndarray):
                 if len(data.shape) == 2:
-                    self._raise_invalid_write_num_chans_error(
-                        number_of_channels, data.shape[0])
+                    if data.shape[0] == 1:
+                        data = data[0]
+                    else:
+                        self._raise_invalid_write_num_chans_error(
+                            number_of_channels, data.shape[0])
 
                 number_of_samples_per_channel = len(data)
                 element = data[0]
@@ -1193,19 +1191,7 @@ class Task(object):
                 element = data
 
         else:
-            if isinstance(data, list):
-                if len(data) != number_of_channels:
-                    self._raise_invalid_write_num_chans_error(
-                        number_of_channels, len(data))
-
-                if isinstance(data[0], list):
-                    number_of_samples_per_channel = len(data[0])
-                    element = data[0][0]
-                else:
-                    number_of_samples_per_channel = 1
-                    element = data[0]
-
-            elif isinstance(data, numpy.ndarray):
+            if isinstance(data, numpy.ndarray):
                 if data.shape[0] != number_of_channels:
                     self._raise_invalid_write_num_chans_error(
                         number_of_channels, data.shape[0])


### PR DESCRIPTION
Fixes #126.

This PR changes the `write` method in the following ways:

- Lists are converted to numpy arrays in order to fix the error that is raised when mixing Python lists and numpy arrays, and also to simplify the code.
- An extra conditional fixes the strange "Number of Channels in Task: 1, Number of Channels in Data: 1" error (see https://github.com/ni/nidaqmx-python/pull/127/files#diff-52340ddf18f49fd7571bdf82b12b90c54ee8b0b8018f3ef93fa7ad13e2ad1bfcL1185-R1184).