### PR TITLE
remove future imports

### DIFF
--- a/nidaqmx/__init__.py
+++ b/nidaqmx/__init__.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from nidaqmx.errors import DaqError, DaqWarning, DaqResourceWarning
 from nidaqmx.scale import Scale

--- a/nidaqmx/__init__.py
+++ b/nidaqmx/__init__.py
@@ -1,4 +1,3 @@
-
 from nidaqmx.errors import DaqError, DaqWarning, DaqResourceWarning
 from nidaqmx.scale import Scale
 from nidaqmx.task import Task

--- a/nidaqmx/_lib.py
+++ b/nidaqmx/_lib.py
@@ -1,4 +1,3 @@
-
 from ctypes.util import find_library
 import ctypes
 from numpy.ctypeslib import ndpointer

--- a/nidaqmx/_lib.py
+++ b/nidaqmx/_lib.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from ctypes.util import find_library
 import ctypes

--- a/nidaqmx/_task_modules/channel_collection.py
+++ b/nidaqmx/_task_modules/channel_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/_task_modules/channel_collection.py
+++ b/nidaqmx/_task_modules/channel_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/_task_modules/channels/__init__.py
+++ b/nidaqmx/_task_modules/channels/__init__.py
@@ -1,5 +1,3 @@
-
-
 __author__ = 'National Instruments'
 __all__ = ['channel']
 

--- a/nidaqmx/_task_modules/channels/__init__.py
+++ b/nidaqmx/_task_modules/channels/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 
 __author__ = 'National Instruments'

--- a/nidaqmx/_task_modules/read_functions.py
+++ b/nidaqmx/_task_modules/read_functions.py
@@ -1,4 +1,3 @@
-
 import collections
 import ctypes
 import numpy

--- a/nidaqmx/_task_modules/read_functions.py
+++ b/nidaqmx/_task_modules/read_functions.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import collections
 import ctypes

--- a/nidaqmx/_task_modules/write_functions.py
+++ b/nidaqmx/_task_modules/write_functions.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import numpy
 

--- a/nidaqmx/_task_modules/write_functions.py
+++ b/nidaqmx/_task_modules/write_functions.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import ctypes
 import numpy

--- a/nidaqmx/errors.py
+++ b/nidaqmx/errors.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import warnings
 

--- a/nidaqmx/errors.py
+++ b/nidaqmx/errors.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import warnings

--- a/nidaqmx/stream_readers.py
+++ b/nidaqmx/stream_readers.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import numpy
 from nidaqmx import DaqError

--- a/nidaqmx/stream_readers.py
+++ b/nidaqmx/stream_readers.py
@@ -1,4 +1,3 @@
-
 import numpy
 from nidaqmx import DaqError
 

--- a/nidaqmx/stream_writers.py
+++ b/nidaqmx/stream_writers.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import numpy
 from nidaqmx import DaqError

--- a/nidaqmx/stream_writers.py
+++ b/nidaqmx/stream_writers.py
@@ -1,4 +1,3 @@
-
 import numpy
 from nidaqmx import DaqError
 from nidaqmx._task_modules.write_functions import (

--- a/nidaqmx/system/__init__.py
+++ b/nidaqmx/system/__init__.py
@@ -1,4 +1,3 @@
-
 from nidaqmx.system.system import (
     System, AOPowerUpState, CDAQSyncConnection, DOPowerUpState,
     DOResistorPowerUpState)

--- a/nidaqmx/system/__init__.py
+++ b/nidaqmx/system/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from nidaqmx.system.system import (
     System, AOPowerUpState, CDAQSyncConnection, DOPowerUpState,

--- a/nidaqmx/system/_collections/device_collection.py
+++ b/nidaqmx/system/_collections/device_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/system/_collections/device_collection.py
+++ b/nidaqmx/system/_collections/device_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/system/_collections/persisted_channel_collection.py
+++ b/nidaqmx/system/_collections/persisted_channel_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/system/_collections/persisted_channel_collection.py
+++ b/nidaqmx/system/_collections/persisted_channel_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/system/_collections/persisted_scale_collection.py
+++ b/nidaqmx/system/_collections/persisted_scale_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/system/_collections/persisted_scale_collection.py
+++ b/nidaqmx/system/_collections/persisted_scale_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/system/_collections/persisted_task_collection.py
+++ b/nidaqmx/system/_collections/persisted_task_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/system/_collections/persisted_task_collection.py
+++ b/nidaqmx/system/_collections/persisted_task_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/system/_collections/physical_channel_collection.py
+++ b/nidaqmx/system/_collections/physical_channel_collection.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import six
 from collections.abc import Sequence

--- a/nidaqmx/system/_collections/physical_channel_collection.py
+++ b/nidaqmx/system/_collections/physical_channel_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import six

--- a/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
+++ b/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
@@ -1,4 +1,3 @@
-
 import six
 
 from nidaqmx.errors import DaqError

--- a/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
+++ b/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import six
 

--- a/nidaqmx/system/storage/__init__.py
+++ b/nidaqmx/system/storage/__init__.py
@@ -1,4 +1,3 @@
-
 from nidaqmx.system.storage.persisted_channel import PersistedChannel
 from nidaqmx.system.storage.persisted_scale import PersistedScale
 from nidaqmx.system.storage.persisted_task import PersistedTask

--- a/nidaqmx/system/storage/__init__.py
+++ b/nidaqmx/system/storage/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from nidaqmx.system.storage.persisted_channel import PersistedChannel
 from nidaqmx.system.storage.persisted_scale import PersistedScale

--- a/nidaqmx/system/storage/_alternate_task_constructor.py
+++ b/nidaqmx/system/storage/_alternate_task_constructor.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from nidaqmx.task import Task
 

--- a/nidaqmx/system/storage/_alternate_task_constructor.py
+++ b/nidaqmx/system/storage/_alternate_task_constructor.py
@@ -1,4 +1,3 @@
-
 from nidaqmx.task import Task
 
 

--- a/nidaqmx/system/storage/persisted_channel.py
+++ b/nidaqmx/system/storage/persisted_channel.py
@@ -1,4 +1,3 @@
-
 import ctypes
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32

--- a/nidaqmx/system/storage/persisted_channel.py
+++ b/nidaqmx/system/storage/persisted_channel.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 

--- a/nidaqmx/system/storage/persisted_scale.py
+++ b/nidaqmx/system/storage/persisted_scale.py
@@ -1,4 +1,3 @@
-
 import ctypes
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32

--- a/nidaqmx/system/storage/persisted_scale.py
+++ b/nidaqmx/system/storage/persisted_scale.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 

--- a/nidaqmx/system/storage/persisted_task.py
+++ b/nidaqmx/system/storage/persisted_task.py
@@ -1,4 +1,3 @@
-
 import ctypes
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32

--- a/nidaqmx/system/storage/persisted_task.py
+++ b/nidaqmx/system/storage/persisted_task.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 

--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import ctypes
 import numpy

--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -1,4 +1,3 @@
-
 import ctypes
 import numpy
 import six

--- a/nidaqmx/types.py
+++ b/nidaqmx/types.py
@@ -1,4 +1,3 @@
-
 import collections
 
 # region Task Counter IO namedtuples

--- a/nidaqmx/types.py
+++ b/nidaqmx/types.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import collections
 

--- a/nidaqmx/utils.py
+++ b/nidaqmx/utils.py
@@ -1,7 +1,3 @@
-﻿from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import re
 

--- a/nidaqmx/utils.py
+++ b/nidaqmx/utils.py
@@ -1,4 +1,3 @@
-
 import re
 
 from nidaqmx.errors import DaqError


### PR DESCRIPTION
# Overview

All these `__future__` imports are mandatory in our minimum Python version (3.7). Most of this was done in #136. 

Closes #132 

# Testing

All tests pass:
```
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  congratulations :)
```
