### PR TITLE
Fix all examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 * ### Resolved Issues
     * ...
 * ### Major Changes
-    * ...
+    * Scrubbed all examples to ensure they all function correctly and use DAQmx best practices.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 * ### Merged Pull Requests
     * ...
 * ### Resolved Issues
+    * [37: ai_raw example is bad](https://github.com/ni/nidaqmx-python/issues/37)
+    * [65: ci_count_edges.py REQUIRES A START COMMAND](https://github.com/ni/nidaqmx-python/issues/65)
     * [117: Error in example](https://github.com/ni/nidaqmx-python/issues/117)
     * [131: task.write for COUNTER_OUTPUT - UsageTypeCO.PULSE_FREQUENCY has frequency and duty cycle reversed](https://github.com/ni/nidaqmx-python/issues/131)
     * [124: nidaqmx_examples/system_properties.py errors out as of version 0.5.7](https://github.com/ni/nidaqmx-python/issues/124)

--- a/nidaqmx_examples/ai_raw.py
+++ b/nidaqmx_examples/ai_raw.py
@@ -5,21 +5,22 @@ pp = pprint.PrettyPrinter(indent=4)
 
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_voltage_chan("cDAQ1Mod1/ai0")
+    in_stream = task.in_stream
 
     print('1 Channel 1 Sample Read Raw: ')
-    data = task.read_raw()
+    data = in_stream.read(number_of_samples_per_channel=1)
     pp.pprint(data)
 
     print('1 Channel N Samples Read Raw: ')
-    data = task.read_raw(number_of_samples_per_channel=8)
+    data = in_stream.read(number_of_samples_per_channel=8)
     pp.pprint(data)
 
     task.ai_channels.add_ai_voltage_chan("cDAQ1Mod1/ai1:3")
 
     print('N Channel 1 Sample Read Raw: ')
-    data = task.read_raw()
+    data = in_stream.read(number_of_samples_per_channel=1)
     pp.pprint(data)
 
     print('N Channel N Samples Read Raw: ')
-    data = task.read_raw(number_of_samples_per_channel=8)
+    data = in_stream.read(number_of_samples_per_channel=8)
     pp.pprint(data)

--- a/nidaqmx_examples/ai_voltage_sw_timed.py
+++ b/nidaqmx_examples/ai_voltage_sw_timed.py
@@ -26,4 +26,4 @@ with nidaqmx.Task() as task:
 
     print('N Channel N Samples Read: ')
     data = task.read(number_of_samples_per_channel=2)
-    print data
+    print(data)

--- a/nidaqmx_examples/ao_voltage_hw_timed.py
+++ b/nidaqmx_examples/ao_voltage_hw_timed.py
@@ -6,22 +6,16 @@ with nidaqmx.Task() as task:
 
     task.timing.cfg_samp_clk_timing(1000)
 
-    print('1 Channel 1 Sample Write: ')
-    print(task.write(1.0))
-    task.stop()
-
     print('1 Channel N Samples Write: ')
     print(task.write([1.1, 2.2, 3.3, 4.4, 5.5], auto_start=True))
+    task.wait_until_done()
     task.stop()
 
     task.ao_channels.add_ao_voltage_chan('Dev1/ao1:3')
-
-    print('N Channel 1 Sample Write: ')
-    print(task.write([1.1, 2.2, 3.3, 4.4]))
-    task.stop()
 
     print('N Channel N Samples Write: ')
     print(task.write([[1.1, 2.2, 3.3], [1.1, 2.2, 4.4],
                       [2.2, 3.3, 4.4], [2.2, 3.3, 4.4]],
                      auto_start=True))
+    task.wait_until_done()
     task.stop()

--- a/nidaqmx_examples/ci_count_edges.py
+++ b/nidaqmx_examples/ci_count_edges.py
@@ -8,6 +8,8 @@ pp = pprint.PrettyPrinter(indent=4)
 with nidaqmx.Task() as task:
     task.ci_channels.add_ci_count_edges_chan("Dev1/ctr0")
 
+    task.start()
+
     print('1 Channel 1 Sample Read: ')
     data = task.read()
     pp.pprint(data)

--- a/nidaqmx_examples/co_pulse_time.py
+++ b/nidaqmx_examples/co_pulse_time.py
@@ -1,19 +1,18 @@
 import nidaqmx
+import time
+from nidaqmx.constants import AcquisitionType
 from nidaqmx.types import CtrTime
 
 
 with nidaqmx.Task() as task:
-    task.co_channels.add_co_pulse_chan_time("Dev1/ctr1")
+    task.co_channels.add_co_pulse_chan_time("Dev1/ctr1", low_time=0.01, high_time=0.01)
+    task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+    task.start()
+
+    print('Waiting before changing pulse specification...')
+    time.sleep(2)
 
     sample = CtrTime(high_time=0.001, low_time=0.002)
 
     print('1 Channel 1 Sample Write: ')
     print(task.write(sample))
-
-    samples = []
-    for i in range(1, 5):
-        x = i/float(1000)
-        samples.append(CtrTime(high_time=x, low_time=x))
-
-    print('1 Channel N Samples Write: ')
-    print(task.write(samples, auto_start=True))

--- a/nidaqmx_examples/di_sw_timed.py
+++ b/nidaqmx_examples/di_sw_timed.py
@@ -28,4 +28,4 @@ with nidaqmx.Task() as task:
 
     print('N Channel N Samples Read: ')
     data = task.read(number_of_samples_per_channel=2)
-    print data
+    print(data)

--- a/nidaqmx_examples/every_n_samples_event.py
+++ b/nidaqmx_examples/every_n_samples_event.py
@@ -1,5 +1,6 @@
 import pprint
 import nidaqmx
+from nidaqmx.constants import AcquisitionType
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -7,26 +8,24 @@ pp = pprint.PrettyPrinter(indent=4)
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
 
-    task.timing.cfg_samp_clk_timing(1000)
+    task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
-    # Python 2.X does not have nonlocal keyword.
-    non_local_var = {'samples': []}
+    samples = []
 
     def callback(task_handle, every_n_samples_event_type,
                  number_of_samples, callback_data):
         print('Every N Samples callback invoked.')
 
-        samples = task.read(number_of_samples_per_channel=200)
-        non_local_var['samples'].extend(samples)
+        samples.extend(task.read(number_of_samples_per_channel=1000))
 
         return 0
 
     task.register_every_n_samples_acquired_into_buffer_event(
-        200, callback)
+        1000, callback)
 
     task.start()
 
     input('Running task. Press Enter to stop and see number of '
           'accumulated samples.\n')
 
-    print(len(non_local_var['samples']))
+    print(len(samples))


### PR DESCRIPTION
Scrubbed all examples to ensure they all function correctly and use DAQmx best practices.

* **ai_raw**: this example was completely wrong. Raw reads are exposed in `in_stream`.
   * Closes #37
* **ai_voltage_sw_timed**: Used Python 2 prints
* **ao_voltage_hw_timed**: Single sample writes on a timed task is a misuse of DAQmx, just delete that.
* **ci_count_edges**: Add start
   * Closes #65 
* **co_pulse_time**: This was doing a single pulse, but then writing to the task, which isn't a thing. It totally didn't work. It now is an implicit continuous pulse train that is modified during run.
* **di_voltage_sw_timed**: Used Python 2 prints
* **every_n_samples_event**: Updated to continuous and removed some weird python 2 workarounds that aren't necessary anymore. I also made it run slower.