### PR TITLE
fix version checking logic

### DIFF
--- a/nidaqmx/system/system.py
+++ b/nidaqmx/system/system.py
@@ -50,6 +50,11 @@ class System(object):
         """
         return DeviceCollection()
 
+
+    DriverVersion = collections.namedtuple(
+            'DriverVersion', ['major_version', 'minor_version',
+                              'update_version'])
+
     @property
     def driver_version(self):
         """
@@ -63,12 +68,8 @@ class System(object):
             - update_version (int): Indicates the update portion of the
               installed version of NI-DAQmx, such as 1 for version 9.0.1.
         """
-        DriverVersion = collections.namedtuple(
-            'DriverVersion', ['major_version', 'minor_version',
-                              'update_version'])
-
-        return DriverVersion(self._major_version, self._minor_version,
-                             self._update_version)
+        return System.DriverVersion(self._major_version, self._minor_version,
+                                    self._update_version)
 
     @property
     def global_channels(self):

--- a/nidaqmx/tests/test_lib.py
+++ b/nidaqmx/tests/test_lib.py
@@ -1,0 +1,29 @@
+import ctypes
+import pytest
+
+from nidaqmx._lib import DaqLibImporter
+from nidaqmx.system import System
+
+
+@staticmethod
+def _make_driver_version(*args):
+    return System.DriverVersion._make(args)
+
+
+class TestLib(object):
+    """
+    Contains a collection of pytest tests that validate the lib loading
+    functionality in the NI-DAQmx Python API.
+    """
+
+    def test_task_handle_type(self):
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(7,1,0)) == ctypes.c_uint
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(7,9,0)) == ctypes.c_uint
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(8,7,0)) == ctypes.c_uint
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(8,8,0)) == ctypes.c_uint
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(8,8,9)) == ctypes.c_uint
+
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(8,9,0)) == ctypes.c_void_p
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(8,9,1)) == ctypes.c_void_p
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(9,0,0)) == ctypes.c_void_p
+        assert DaqLibImporter._get_task_handle_type(_make_driver_version(21,8,0)) == ctypes.c_void_p


### PR DESCRIPTION
Version checking logic was bad for versions such as 7.9. I'm not sure if we ever released one of those, but just in case, let's fix it. Closes #102.