### PR TITLE
fix exceptions in deleting a partially constructed task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 * ### Resolved Issues
     * [37: ai_raw example is bad](https://github.com/ni/nidaqmx-python/issues/37)
     * [65: ci_count_edges.py REQUIRES A START COMMAND](https://github.com/ni/nidaqmx-python/issues/65)
+    * [100: How to clear task and create a new task with same name?](https://github.com/ni/nidaqmx-python/issues/100)
     * [102: handle types and daqmx versions](https://github.com/ni/nidaqmx-python/issues/102)
     * [117: Error in example](https://github.com/ni/nidaqmx-python/issues/117)
     * [131: task.write for COUNTER_OUTPUT - UsageTypeCO.PULSE_FREQUENCY has frequency and duty cycle reversed](https://github.com/ni/nidaqmx-python/issues/131)

--- a/nidaqmx/task.py
+++ b/nidaqmx/task.py
@@ -93,7 +93,7 @@ class Task(object):
         self._initialize(self._handle)
 
     def __del__(self):
-        if self._handle is not None:
+        if self._handle:
             warnings.warn(
                 'Task of name "{0}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '

--- a/nidaqmx/tests/test_task.py
+++ b/nidaqmx/tests/test_task.py
@@ -1,0 +1,23 @@
+import pytest
+
+from nidaqmx import Task, DaqError
+from nidaqmx.error_codes import DAQmxErrors
+
+
+class TestTask(object):
+    """
+    Contains a collection of pytest tests that validate duplicate and partially
+    constructed tasks.
+    """
+
+    def test_task_duplicate(self):
+        with Task("task") as t:
+            with pytest.raises(DaqError) as dupe_exception:
+                u = Task("task")
+                # u is now partially constructed, and deleting it should be safe. This previously
+                # raised an exception which was uncatchable. pytest should fail with that, but it
+                # doesn't seem to be working. Regardless it will print a warning that contributors
+                # should see if it regresses.
+                del(u)
+            assert dupe_exception.value.error_code == DAQmxErrors.DUPLICATE_TASK.value
+


### PR DESCRIPTION
Tasks that failed to initialize would except in `__del__`. The check against a None `_task_handle` was bad since the handle is a valid `ctypes` instance. However, the `bool` conversion for both `ctypes.c_uint` and `ctypes.c_void_p` both handle 0/NULL appropriately, so we can use that. Closes #100