### PR TITLE
mention similar packages in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
     * ...
 * ### Resolved Issues
     * [37: ai_raw example is bad](https://github.com/ni/nidaqmx-python/issues/37)
+    * [64: nidaqmx-python and pynidaqmx projects use the same package name](https://github.com/ni/nidaqmx-python/issues/64)
     * [65: ci_count_edges.py REQUIRES A START COMMAND](https://github.com/ni/nidaqmx-python/issues/65)
     * [100: How to clear task and create a new task with same name?](https://github.com/ni/nidaqmx-python/issues/100)
     * [102: handle types and daqmx versions](https://github.com/ni/nidaqmx-python/issues/102)

--- a/README.rst
+++ b/README.rst
@@ -29,12 +29,26 @@ Installation
 ============
 
 Running **nidaqmx** requires NI-DAQmx or NI-DAQmx Runtime. Visit the
-`ni.com/downloads <http://www.ni.com/downloads/>`_ to download the latest version 
-of NI-DAQmx.
+`ni.com/downloads <http://www.ni.com/downloads/>`_ to download the latest
+version of NI-DAQmx.
 
 **nidaqmx** can be installed with `pip <http://pypi.python.org/pypi/pip>`_::
 
   $ python -m pip install nidaqmx
+
+Similar Packages
+================
+
+There are similar packages available that also provide NI-DAQmx functionality in
+Python:
+
+- `daqmx <https://pypi.org/project/daqmx/>`_
+  (`slightlynybbled/daqmx on GitHub <https://github.com/slightlynybbled/daqmx>`_)
+  provides an abstraction of NI-DAQmx in the ``ni`` module.
+
+- PyLibNIDAQmx (`pearu/pylibnidaqmx on GitHub <https://github.com/pearu/pylibnidaqmx>`_)
+  provides an abstraction of NI-DAQmx in the ``nidaqmx`` module, which collides
+  with this package's module name.
 
 .. _usage-section:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 
 # -- Options for HTMLHelp output ------------------------------------------


### PR DESCRIPTION
Mention similar packages (including one that conflicts with our module name) in the documentation. Also fixed an invalid reference in our documentation config and fixed a bad word wrap. Closes #64.