### PR TITLE
add 21.8 power APIs to nidaqmx-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project will be documented in this file.
 * ### Resolved Issues
     * ...
 * ### Major Changes
-    * ...
+    * Added NI-DAQmx Power Channel APIs.
 
 ## 0.6.1
 

--- a/nidaqmx/_task_modules/ai_channel_collection.py
+++ b/nidaqmx/_task_modules/ai_channel_collection.py
@@ -1267,6 +1267,49 @@ class AIChannelCollection(ChannelCollection):
 
         return self._create_chan(physical_channel, name_to_assign_to_channel)
 
+    def add_ai_power_chan(
+            self, physical_channel, voltage_setpoint, current_setpoint,
+            output_enable, name_to_assign_to_channel=""):
+        """
+        Creates channel(s) to measure power.
+
+        Args:
+            physical_channel (str): Specifies the names of the physical
+                channels to use to create virtual channels. The DAQmx
+                physical channel constant lists all physical channels on
+                devices and modules installed in the system.
+            voltage_setpoint (float): Specifies in volts the constant
+                output voltage.
+            current_setpoint (float): Specifies in amperes the output
+                current.
+            output_enable (bool): Specifies whether to enable or disable
+                the output.
+            name_to_assign_to_channel (Optional[str]): Specifies a name
+                to assign to the virtual channel this function creates.
+                If you do not specify a value for this input, NI-DAQmx
+                uses the physical channel name as the virtual channel
+                name.
+        Returns:
+            nidaqmx._task_modules.channels.ai_channel.AIChannel:
+            
+            Indicates the newly created channel object.
+        """
+        cfunc = lib_importer.windll.DAQmxCreateAIPowerChan
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes_byte_str, ctypes.c_double, ctypes.c_double,
+                        c_bool32]
+
+        error_code = cfunc(
+            self._handle, physical_channel, name_to_assign_to_channel,
+            voltage_setpoint, current_setpoint, output_enable)
+        check_for_error(error_code)
+
+        return self._create_chan(physical_channel, name_to_assign_to_channel)
+
     def add_ai_pressure_bridge_polynomial_chan(
             self, physical_channel, name_to_assign_to_channel="",
             min_val=-100.0, max_val=100.0,

--- a/nidaqmx/_task_modules/in_stream.py
+++ b/nidaqmx/_task_modules/in_stream.py
@@ -1809,6 +1809,67 @@ class InStream(object):
         check_for_error(error_code)
 
     @property
+    def remote_sense_error_chans(self):
+        """
+        List[str]: Indicates a list of names of any remote sense error
+            virtual channels. You must read Remote Sense Error Channels
+            Exist before you read this property. Otherwise, you will
+            receive an error.
+        """
+        cfunc = lib_importer.windll.DAQmxGetRemoteSenseErrorChans
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes.c_char_p,
+                        ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = ctypes.create_string_buffer(temp_size)
+
+            size_or_code = cfunc(
+                self._handle, val, temp_size)
+
+            if is_string_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return unflatten_channel_string(val.value.decode('ascii'))
+
+    @property
+    def remote_sense_error_chans_exist(self):
+        """
+        bool: Indicates if the device detected something is wrong on
+            hardware or remote sense connection. You must read this
+            property before you read Remote Sense Error Channels. You
+            must disable the output and solve hardware connection issue
+            to clear the remote sense error status for all the channels
+            in the task.
+        """
+        val = c_bool32()
+
+        cfunc = lib_importer.windll.DAQmxGetRemoteSenseErrorChansExist
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes.POINTER(c_bool32)]
+
+        error_code = cfunc(
+            self._handle, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @property
     def sleep_time(self):
         """
         float: Specifies in seconds the amount of time to sleep after

--- a/nidaqmx/_task_modules/read_functions.py
+++ b/nidaqmx/_task_modules/read_functions.py
@@ -52,6 +52,58 @@ def _read_analog_scalar_f_64(task_handle, timeout):
     return value.value
 
 
+def _read_power_f_64(
+        task_handle, read_voltage_array, read_current_array, num_samps_per_chan,
+        timeout, fill_mode=FillMode.GROUP_BY_CHANNEL):
+    samps_per_chan_read = ctypes.c_int()
+
+    cfunc = lib_importer.windll.DAQmxReadPowerF64
+    if cfunc.argtypes is None:
+        with cfunc.arglock:
+            if cfunc.argtypes is None:
+                cfunc.argtypes = [
+                    lib_importer.task_handle, ctypes.c_int, ctypes.c_double,
+                    c_bool32,
+                    wrapped_ndpointer(dtype=numpy.float64, flags=('C', 'W')),
+                    wrapped_ndpointer(dtype=numpy.float64, flags=('C', 'W')),
+                    ctypes.c_uint, ctypes.POINTER(ctypes.c_int),
+                    ctypes.POINTER(c_bool32)]
+
+    error_code = cfunc(
+        task_handle, num_samps_per_chan, timeout, fill_mode.value,
+        read_voltage_array, read_current_array, numpy.prod(read_voltage_array.shape),
+        ctypes.byref(samps_per_chan_read), None)
+    check_for_error(error_code, samps_per_chan_read=samps_per_chan_read.value)
+
+    return samps_per_chan_read.value
+
+
+def _read_power_i_16(
+        task_handle, read_voltage_array, read_current_array, num_samps_per_chan,
+        timeout, fill_mode=FillMode.GROUP_BY_CHANNEL):
+    samps_per_chan_read = ctypes.c_int()
+
+    cfunc = lib_importer.windll.DAQmxReadPowerBinaryI16
+    if cfunc.argtypes is None:
+        with cfunc.arglock:
+            if cfunc.argtypes is None:
+                cfunc.argtypes = [
+                    lib_importer.task_handle, ctypes.c_int, ctypes.c_double,
+                    c_bool32,
+                    wrapped_ndpointer(dtype=numpy.int16, flags=('C', 'W')),
+                    wrapped_ndpointer(dtype=numpy.int16, flags=('C', 'W')),
+                    ctypes.c_uint, ctypes.POINTER(ctypes.c_int),
+                    ctypes.POINTER(c_bool32)]
+
+    error_code = cfunc(
+        task_handle, num_samps_per_chan, timeout, fill_mode.value,
+        read_voltage_array, read_current_array, numpy.prod(read_voltage_array.shape),
+        ctypes.byref(samps_per_chan_read), None)
+    check_for_error(error_code, samps_per_chan_read=samps_per_chan_read.value)
+
+    return samps_per_chan_read.value
+
+
 def _read_binary_i_16(
         task_handle, read_array, num_samps_per_chan, timeout,
         fill_mode=FillMode.GROUP_BY_CHANNEL):

--- a/nidaqmx/constants.py
+++ b/nidaqmx/constants.py
@@ -499,8 +499,8 @@ class Polarity(Enum):
 
 
 class PowerIdleOutputBehavior(Enum):
-    OUTPUT_DISABLED = 15600  #: The output of the module is disabled. Generating 0 V.
-    MAINTAIN_EXISTING_VALUE = 15601  #: Continue generating the current value.
+    OUTPUT_DISABLED = 15503  #: The output of the module is disabled. Generating 0 V.
+    MAINTAIN_EXISTING_VALUE = 12528  #: Continue generating the current value.
 
 
 class PowerOutputState(Enum):
@@ -508,11 +508,6 @@ class PowerOutputState(Enum):
     CONSTANT_CURRENT = 15501  #: Power module channel is in constant current mode.
     OVERVOLTAGE = 15502  #: Power module channel is overvoltage.
     OUTPUT_DISABLED = 15503  #: Power module channel output is disabled.
-
-
-class PowerRemoteSense(Enum):
-    LOCAL = 15700  #: Power module channel is in local sense.
-    REMOTE = 15701  #: Power module channel is in remote sense.
 
 
 class PowerUpChannelType(Enum):
@@ -558,6 +553,8 @@ class ProductCategory(Enum):
     SC_EXPRESS = 15886  #: SC Express.
     UNKNOWN = 12588  #: Unknown category.
     FIELD_DAQ = 16151  #: FieldDAQ.
+    TEST_SCALE_CHASSIS = 16180  #: TestScale chassis.
+    TEST_SCALE_MODULE = 16181  #: TestScale I/O module.
 
 
 class RTDType(Enum):
@@ -968,6 +965,7 @@ class UsageTypeAI(Enum):
     PRESSURE_BRIDGE = 15902  #: Pressure measurement using a bridge-based sensor.
     TEDS = 12531  #: Measurement type defined by TEDS.
     CHARGE = 16105  #: Charge measurement.
+    POWER = 16201  #: Power measurement.
 
 
 class UsageTypeAO(Enum):

--- a/nidaqmx/stream_readers.py
+++ b/nidaqmx/stream_readers.py
@@ -3,7 +3,8 @@ from nidaqmx import DaqError
 
 from nidaqmx.constants import READ_ALL_AVAILABLE
 from nidaqmx._task_modules.read_functions import (
-    _read_analog_f_64, _read_analog_scalar_f_64, _read_power_f_64,
+    _read_analog_f_64, _read_analog_scalar_f_64,
+    _read_power_f_64, _read_power_i_16,
     _read_binary_i_16, _read_binary_i_32,
     _read_binary_u_16, _read_binary_u_32,
     _read_digital_lines, _read_digital_u_8, _read_digital_u_16,
@@ -15,7 +16,8 @@ from nidaqmx.error_codes import DAQmxErrors
 
 __all__ = ['AnalogSingleChannelReader', 'AnalogMultiChannelReader',
            'AnalogUnscaledReader', 'CounterReader',
-           'DigitalSingleChannelReader', 'DigitalMultiChannelReader']
+           'DigitalSingleChannelReader', 'DigitalMultiChannelReader',
+           'PowerSingleChannelReader', 'PowerSingleChannelBinaryReader']
 
 
 class ChannelReaderBase(object):
@@ -702,6 +704,174 @@ class AnalogUnscaledReader(ChannelReaderBase):
 
         return _read_binary_u_32(
             self._handle, data, number_of_samples_per_channel,
+            timeout)
+
+
+class PowerSingleChannelReader(ChannelReaderBase):
+    """
+    Reads samples from an analog input power channel in an NI-DAQmx task.
+    """
+
+    def read_many_sample(
+            self, voltage_data, current_data, number_of_samples_per_channel=READ_ALL_AVAILABLE,
+            timeout=10.0):
+        """
+        Reads one or more floating-point samples from a single analog
+        input power channel in a task.
+
+        This read method accepts a preallocated NumPy array to hold the
+        samples requested, which can be advantageous for performance and
+        interoperability with NumPy and SciPy.
+
+        Passing in a preallocated array is valuable in continuous
+        acquisition scenarios, where the same array can be used
+        repeatedly in each call to the method.
+
+        Args:
+            voltage_data (numpy.ndarray): Specifies a preallocated 1D NumPy
+                array of floating-point values to hold the voltage samples
+                requested.
+
+                Each element in the array corresponds to a sample from
+                the channel. The size of the array must be large enough
+                to hold all requested samples from the channel in the
+                task; otherwise, an error is thrown.
+            current_data (numpy.ndarray): Specifies a preallocated 1D NumPy
+                array of floating-point values to hold the current samples
+                requested.
+
+                Each element in the array corresponds to a sample from
+                the channel. The size of the array must be large enough
+                to hold all requested samples from the channel in the
+                task; otherwise, an error is thrown.
+            number_of_samples_per_channel (Optional[int]): Specifies the
+                number of samples to read.
+
+                If you set this input to nidaqmx.constants.
+                READ_ALL_AVAILABLE, NI-DAQmx determines how many samples
+                to read based on if the task acquires samples
+                continuously or acquires a finite number of samples.
+
+                If the task acquires samples continuously and you set
+                this input to nidaqmx.constants.READ_ALL_AVAILABLE, this
+                method reads all the samples currently available in the
+                buffer.
+
+                If the task acquires a finite number of samples and you
+                set this input to nidaqmx.constants.READ_ALL_AVAILABLE,
+                the method waits for the task to acquire all requested
+                samples, then reads those samples. If you set the
+                "read_all_avail_samp" property to True, the method reads
+                the samples currently available in the buffer and does
+                not wait for the task to acquire all requested samples.
+            timeout (Optional[float]): Specifies the amount of time in
+                seconds to wait for samples to become available. If the
+                time elapses, the method returns an error and any
+                samples read before the timeout elapsed. The default
+                timeout is 10 seconds. If you set timeout to
+                nidaqmx.constants.WAIT_INFINITELY, the method waits
+                indefinitely. If you set timeout to 0, the method tries
+                once to read the requested samples and returns an error
+                if it is unable to.
+        Returns:
+            int:
+
+            Indicates the number of samples acquired by each channel.
+            NI-DAQmx returns a single value because this value is the
+            same for all channels.
+        """
+        number_of_samples_per_channel = (
+            self._task._calculate_num_samps_per_chan(
+                number_of_samples_per_channel))
+
+        self._verify_array(voltage_data, number_of_samples_per_channel, False, True)
+        self._verify_array(current_data, number_of_samples_per_channel, False, True)
+
+        return _read_power_f_64(
+            self._handle, voltage_data, current_data, number_of_samples_per_channel,
+            timeout)
+
+
+class PowerSingleChannelBinaryReader(ChannelReaderBase):
+    """
+    Reads binary samples from an analog input power channel in an NI-DAQmx task.
+    """
+
+    def read_many_sample(
+            self, voltage_data, current_data, number_of_samples_per_channel=READ_ALL_AVAILABLE,
+            timeout=10.0):
+        """
+        Reads one or more binary int16 samples from a single analog
+        input power channel in a task.
+
+        This read method accepts a preallocated NumPy array to hold the
+        samples requested, which can be advantageous for performance and
+        interoperability with NumPy and SciPy.
+
+        Passing in a preallocated array is valuable in continuous
+        acquisition scenarios, where the same array can be used
+        repeatedly in each call to the method.
+
+        Args:
+            voltage_data (numpy.ndarray): Specifies a preallocated 1D NumPy
+                array of i16 values to hold the voltage samples requested.
+
+                Each element in the array corresponds to a sample from
+                the channel. The size of the array must be large enough
+                to hold all requested samples from the channel in the
+                task; otherwise, an error is thrown.
+            current_data (numpy.ndarray): Specifies a preallocated 1D NumPy
+                array of i16 values to hold the current samples requested.
+
+                Each element in the array corresponds to a sample from
+                the channel. The size of the array must be large enough
+                to hold all requested samples from the channel in the
+                task; otherwise, an error is thrown.
+            number_of_samples_per_channel (Optional[int]): Specifies the
+                number of samples to read.
+
+                If you set this input to nidaqmx.constants.
+                READ_ALL_AVAILABLE, NI-DAQmx determines how many samples
+                to read based on if the task acquires samples
+                continuously or acquires a finite number of samples.
+
+                If the task acquires samples continuously and you set
+                this input to nidaqmx.constants.READ_ALL_AVAILABLE, this
+                method reads all the samples currently available in the
+                buffer.
+
+                If the task acquires a finite number of samples and you
+                set this input to nidaqmx.constants.READ_ALL_AVAILABLE,
+                the method waits for the task to acquire all requested
+                samples, then reads those samples. If you set the
+                "read_all_avail_samp" property to True, the method reads
+                the samples currently available in the buffer and does
+                not wait for the task to acquire all requested samples.
+            timeout (Optional[float]): Specifies the amount of time in
+                seconds to wait for samples to become available. If the
+                time elapses, the method returns an error and any
+                samples read before the timeout elapsed. The default
+                timeout is 10 seconds. If you set timeout to
+                nidaqmx.constants.WAIT_INFINITELY, the method waits
+                indefinitely. If you set timeout to 0, the method tries
+                once to read the requested samples and returns an error
+                if it is unable to.
+        Returns:
+            int:
+
+            Indicates the number of samples acquired by each channel.
+            NI-DAQmx returns a single value because this value is the
+            same for all channels.
+        """
+        number_of_samples_per_channel = (
+            self._task._calculate_num_samps_per_chan(
+                number_of_samples_per_channel))
+
+        self._verify_array(voltage_data, number_of_samples_per_channel, False, True)
+        self._verify_array(current_data, number_of_samples_per_channel, False, True)
+
+        return _read_power_i_16(
+            self._handle, voltage_data, current_data, number_of_samples_per_channel,
             timeout)
 
 

--- a/nidaqmx/stream_readers.py
+++ b/nidaqmx/stream_readers.py
@@ -3,8 +3,9 @@ from nidaqmx import DaqError
 
 from nidaqmx.constants import READ_ALL_AVAILABLE
 from nidaqmx._task_modules.read_functions import (
-    _read_analog_f_64, _read_analog_scalar_f_64, _read_binary_i_16,
-    _read_binary_i_32, _read_binary_u_16, _read_binary_u_32,
+    _read_analog_f_64, _read_analog_scalar_f_64, _read_power_f_64,
+    _read_binary_i_16, _read_binary_i_32,
+    _read_binary_u_16, _read_binary_u_32,
     _read_digital_lines, _read_digital_u_8, _read_digital_u_16,
     _read_digital_scalar_u_32, _read_digital_u_32, _read_counter_scalar_f_64,
     _read_counter_scalar_u_32, _read_counter_f_64_ex, _read_counter_u_32_ex,

--- a/nidaqmx/tests/fixtures.py
+++ b/nidaqmx/tests/fixtures.py
@@ -42,6 +42,17 @@ def bridge_device():
 
 
 @pytest.fixture(scope="module")
+def sim_power_device():
+    system = nidaqmx.system.System.local()
+
+    for device in system.devices:
+        if device.dev_is_simulated and UsageTypeAI.POWER in device.ai_meas_types:
+            return device
+
+    return None
+
+
+@pytest.fixture(scope="module")
 def multi_threading_test_devices():
     system = nidaqmx.system.System.local()
 

--- a/nidaqmx/tests/max_config/nidaqmxMaxConfig.ini
+++ b/nidaqmx/tests/max_config/nidaqmxMaxConfig.ini
@@ -1,6 +1,6 @@
 ﻿[DAQmx]
 MajorVersion = 21
-MinorVersion = 3
+MinorVersion = 8
 
 [DAQmxScale double_gain_scale]
 Lin.Slope = 2
@@ -67,4 +67,16 @@ ProductNum = 0x7435C4C4
 BusType = PCIe
 PCI.BusNum = 0x0
 PCI.DevNum = 0x0
+
+[DAQmxCDAQChassis tsChassisTester]
+ProductType = TS-15000
+DevSerialNum = 0x0
+DevIsSimulated = 1
+
+[DAQmxCDAQModule tsPowerTester]
+ProductType = TS-15200
+DevSerialNum = 0x0
+DevIsSimulated = 1
+CompactDAQ.ChassisDevName = tsChassisTester
+CompactDAQ.SlotNum = 1
 

--- a/nidaqmx/tests/test_stream_analog_readers_writers.py
+++ b/nidaqmx/tests/test_stream_analog_readers_writers.py
@@ -10,10 +10,10 @@ import nidaqmx
 from nidaqmx.constants import Edge
 from nidaqmx.utils import flatten_channel_string
 from nidaqmx.stream_readers import (
-    AnalogSingleChannelReader, AnalogMultiChannelReader)
+    AnalogSingleChannelReader, AnalogMultiChannelReader, PowerSingleChannelReader, PowerSingleChannelBinaryReader)
 from nidaqmx.stream_writers import (
     AnalogSingleChannelWriter, AnalogMultiChannelWriter)
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import sim_power_device, x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -246,3 +246,61 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
 
             numpy.testing.assert_allclose(
                 values_read, values_to_test, rtol=0.05, atol=0.005)
+
+    @pytest.mark.parametrize('seed', [generate_random_seed()])
+    def test_power_many_sample(self, sim_power_device, seed):
+        # Reset the pseudorandom number generator with seed.
+        random.seed(seed)
+
+        pwr_phys_chan = f"{sim_power_device.name}/power"
+        voltage_setpoint = 0.0
+        current_setpoint = 0.03
+        output_enable = False
+        number_of_samples_per_channel = 10
+        voltage_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64)
+        current_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64)
+
+        with nidaqmx.Task() as read_task:
+            read_task.ai_channels.add_ai_power_chan(
+                pwr_phys_chan, voltage_setpoint, current_setpoint, output_enable,
+                name_to_assign_to_channel="PowerChannel")
+
+            reader = PowerSingleChannelReader(read_task.in_stream)
+
+            read_task.start()
+            reader.read_many_sample(
+                voltage_data, current_data,
+                number_of_samples_per_channel=number_of_samples_per_channel)
+
+            # Simulated loads are 0.
+            assert all(sample == 0.0 for sample in voltage_data)
+            assert all(sample == 0.0 for sample in current_data)
+
+    @pytest.mark.parametrize('seed', [generate_random_seed()])
+    def test_power_many_sample_binary(self, sim_power_device, seed):
+        # Reset the pseudorandom number generator with seed.
+        random.seed(seed)
+
+        pwr_phys_chan = f"{sim_power_device.name}/power"
+        voltage_setpoint = 0.0
+        current_setpoint = 0.03
+        output_enable = False
+        number_of_samples_per_channel = 10
+        voltage_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.int16)
+        current_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.int16)
+
+        with nidaqmx.Task() as read_task:
+            read_task.ai_channels.add_ai_power_chan(
+                pwr_phys_chan, voltage_setpoint, current_setpoint, output_enable,
+                name_to_assign_to_channel="PowerChannel")
+
+            reader = PowerSingleChannelBinaryReader(read_task.in_stream)
+
+            read_task.start()
+            reader.read_many_sample(
+                voltage_data, current_data,
+                number_of_samples_per_channel=number_of_samples_per_channel)
+
+            # Simulated loads are 0.
+            assert all(sample == 0 for sample in voltage_data)
+            assert all(sample == 0 for sample in current_data)

--- a/nidaqmx/types.py
+++ b/nidaqmx/types.py
@@ -13,6 +13,13 @@ CtrTime = collections.namedtuple(
 
 # endregion
 
+# region Power IO namedtuples
+
+PowerMeasurement = collections.namedtuple(
+    'PowerMeasurement', ['voltage', 'current'])
+
+# endregion
+
 # region Watchdog namedtuples
 
 AOExpirationState = collections.namedtuple(

--- a/nidaqmx_examples/pwr_hw_timed.py
+++ b/nidaqmx_examples/pwr_hw_timed.py
@@ -1,0 +1,18 @@
+import pprint
+import nidaqmx
+from nidaqmx.constants import AcquisitionType
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_power_chan("TS1Mod1/power")
+    
+    task.timing.cfg_samp_clk_timing(
+        100, sample_mode=AcquisitionType.CONTINUOUS)
+
+    for iter in range(10):
+        data = task.read(number_of_samples_per_channel=10)
+
+        print(f'Data (iter {iter}): ')
+        pp.pprint(data)

--- a/nidaqmx_examples/pwr_hw_timed_stream.py
+++ b/nidaqmx_examples/pwr_hw_timed_stream.py
@@ -1,0 +1,28 @@
+import pprint
+import nidaqmx
+import numpy
+from nidaqmx.constants import AcquisitionType
+from nidaqmx.stream_readers import PowerSingleChannelReader
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_power_chan("TS1Mod1/power")
+    
+    task.timing.cfg_samp_clk_timing(
+        100, sample_mode=AcquisitionType.CONTINUOUS)
+
+    stream = PowerSingleChannelReader(task.in_stream)
+    number_of_samples_per_channel = 10
+    voltage_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64)
+    current_data = numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64)
+
+    for iter in range(10):
+        stream.read_many_sample(voltage_data, current_data, number_of_samples_per_channel=number_of_samples_per_channel)
+
+        print(f'Voltage Data (iter {iter}): ')
+        pp.pprint(voltage_data)
+
+        print(f'Current Data (iter {iter}): ')
+        pp.pprint(current_data)

--- a/nidaqmx_examples/pwr_sw_timed.py
+++ b/nidaqmx_examples/pwr_sw_timed.py
@@ -1,0 +1,19 @@
+import pprint
+import nidaqmx
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_power_chan("TS1Mod1/power")
+
+    print('1 Channel 1 Sample Read: ')
+    data = task.read()
+    pp.pprint(data)
+
+    data = task.read(number_of_samples_per_channel=1)
+    pp.pprint(data)
+
+    print('1 Channel N Samples Read: ')
+    data = task.read(number_of_samples_per_channel=8)
+    pp.pprint(data)


### PR DESCRIPTION
Add Python support for the Power APIs introduced in [NI-DAQmx 21.8](https://www.ni.com/en-us/support/downloads/drivers/download.ni-daqmx.html#).

* Added `add_ai_power_chan` to `ai_channel_collection`
* Added new attributes to `ai_channel` and `in_stream`
* Added basic power read and stream power reads
* Added tests for all the above features
* Added a few power-specific examples

# Testing

All new and old tests pass.

```
$ poetry run pytest -v -k "power"
================================================= test session starts =================================================
platform win32 -- Python 3.10.4, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- C:\Users\Administrator\AppData\Local\pypoetry\Cache\virtualenvs\nidaqmx-b5grGcjs-py3.10\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\Administrator\nidaqmx-python
collected 107 items / 101 deselected / 6 selected

nidaqmx/tests/test_channel_creation.py::TestAnalogCreateChannels::test_create_ai_power_chan[7416630927349040032] PASSED [ 16%]
nidaqmx/tests/test_power_up_states.py::TestPowerUpStates::test_digital_power_up_states PASSED                    [ 33%]
nidaqmx/tests/test_read_write.py::TestCounterReadWrite::test_power_1_samp[5100989704223536947] PASSED            [ 50%]
nidaqmx/tests/test_read_write.py::TestCounterReadWrite::test_power_n_samp[915630325859214553] PASSED             [ 66%]
nidaqmx/tests/test_stream_analog_readers_writers.py::TestAnalogMultiChannelReaderWriter::test_power_many_sample[5780310504946337488] PASSED [ 83%]
nidaqmx/tests/test_stream_analog_readers_writers.py::TestAnalogMultiChannelReaderWriter::test_power_many_sample_binary[4293904891499515428] PASSED [100%]
```

And on all supported Python versions.

```
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  congratulations :)
```