### PR TITLE
fix enum bitfields

### DIFF
--- a/nidaqmx/constants.py
+++ b/nidaqmx/constants.py
@@ -833,8 +833,8 @@ class TerminalConfiguration(Enum):
     DEFAULT = -1  #: Default.
     RSE = 10083  #: Referenced Single-Ended.
     NRSE = 10078  #: Non-Referenced Single-Ended.
-    BAL_DIFF = 10106  #: Differential.
-    PSEUDODIFFERENTIAL = 12529  #: Pseudodifferential.
+    DIFF = 10106  #: Differential.
+    PSEUDO_DIFF = 12529  #: Pseudodifferential.
 
 
 class ThermocoupleType(Enum):
@@ -1084,7 +1084,7 @@ class _Callback(Enum):
 class _CouplingTypes(Enum):
     AC = 1  #: Device supports AC coupling
     DC = 2  #: Device supports DC coupling
-    GROUND = 4  #: Device supports ground coupling
+    GND = 4  #: Device supports ground coupling
     HF_REJECT = 8  #: Device supports High Frequency Reject coupling
     LF_REJECT = 16  #: Device supports Low Frequency Reject coupling
     NOISE_REJECT = 32  #: Device supports Noise Reject coupling

--- a/nidaqmx/tests/test_enum_bitfields.py
+++ b/nidaqmx/tests/test_enum_bitfields.py
@@ -1,0 +1,73 @@
+import pytest
+from functools import partial
+
+from nidaqmx.constants import (
+    _CouplingTypes, Coupling, _TermCfg, TerminalConfiguration, _TriggerUsageTypes, TriggerUsage
+)
+from nidaqmx._lib import (
+    enum_bitfield_to_list, enum_list_to_bitfield
+)
+
+
+def test_coupling_bitfield():
+    _convert_from = partial(enum_bitfield_to_list, bitfield_enum_type=_CouplingTypes, actual_enum_type=Coupling)
+    _convert_to = partial(enum_list_to_bitfield, bitfield_enum_type=_CouplingTypes)
+
+    bitfield_value = \
+        _CouplingTypes.AC.value + \
+        _CouplingTypes.DC.value + \
+        _CouplingTypes.GND.value
+    expected_bitfield_list = [
+        Coupling.AC,
+        Coupling.DC,
+        Coupling.GND
+    ]
+    assert _convert_from(bitfield_value) == expected_bitfield_list
+    assert _convert_to(expected_bitfield_list) == bitfield_value
+
+
+def test_terminal_configuration_bitfield():
+    _convert_from = partial(enum_bitfield_to_list, bitfield_enum_type=_TermCfg, actual_enum_type=TerminalConfiguration)
+    _convert_to = partial(enum_list_to_bitfield, bitfield_enum_type=_TermCfg)
+
+    bitfield_value = \
+        _TermCfg.RSE.value + \
+        _TermCfg.NRSE.value + \
+        _TermCfg.DIFF.value + \
+        _TermCfg.PSEUDO_DIFF.value
+    expected_bitfield_list = [
+        TerminalConfiguration.RSE,
+        TerminalConfiguration.NRSE,
+        TerminalConfiguration.DIFF,
+        TerminalConfiguration.PSEUDO_DIFF
+    ]
+    assert _convert_from(bitfield_value) == expected_bitfield_list
+    assert _convert_to(expected_bitfield_list) == bitfield_value
+
+
+def test_trigger_usage_bitfield():
+    _convert_from = partial(enum_bitfield_to_list, bitfield_enum_type=_TriggerUsageTypes, actual_enum_type=TriggerUsage)
+    _convert_to = partial(enum_list_to_bitfield, bitfield_enum_type=_TriggerUsageTypes)
+
+    bitfield_value = \
+        _TriggerUsageTypes.ADVANCE.value + \
+        _TriggerUsageTypes.PAUSE.value + \
+        _TriggerUsageTypes.REFERENCE.value + \
+        _TriggerUsageTypes.START.value + \
+        _TriggerUsageTypes.HANDSHAKE.value + \
+        _TriggerUsageTypes.ARM_START.value
+    expected_bitfield_list = [TriggerUsage.ADVANCE,
+        TriggerUsage.PAUSE,
+        TriggerUsage.REFERENCE,
+        TriggerUsage.START,
+        TriggerUsage.HANDSHAKE,
+        TriggerUsage.ARM_START
+    ]
+    assert _convert_from(bitfield_value) == expected_bitfield_list
+    assert _convert_to(expected_bitfield_list) == bitfield_value
+
+
+
+
+
+


### PR DESCRIPTION
Enum bitfields didn't match their paired real enumeration in all cases. Fix this and add a test. Closes #181.