### PR TITLE
update testing to allow for some simulation

### DIFF
--- a/nidaqmx/tests/fixtures.py
+++ b/nidaqmx/tests/fixtures.py
@@ -1,5 +1,6 @@
 import pytest
 import nidaqmx.system
+from enum import Enum
 from nidaqmx.constants import ProductCategory, UsageTypeAI
 
 
@@ -11,23 +12,53 @@ class NoFixtureDetectedError(Error):
     pass
 
 
-@pytest.fixture(scope="module")
-def x_series_device():
+class DeviceType(Enum):
+    ANY = (-1,)
+    REAL = (0,)
+    SIMULATED = 1
+
+
+def _x_series_device(device_type):
     system = nidaqmx.system.System.local()
 
     for device in system.devices:
-        if (not device.dev_is_simulated and
-                device.product_category == ProductCategory.X_SERIES_DAQ and
-                len(device.ao_physical_chans) >= 2 and
-                len(device.ai_physical_chans) >= 4 and
-                len(device.do_lines) >= 8 and
-                (len(device.di_lines) == len(device.do_lines)) and
-                len(device.ci_physical_chans) >= 4):
+        device_type_match = (
+            device_type == DeviceType.ANY
+            or (device_type == DeviceType.REAL and not device.dev_is_simulated)
+            or (device_type == DeviceType.SIMULATED and device.dev_is_simulated)
+        )
+        if (
+            device_type_match
+            and device.product_category == ProductCategory.X_SERIES_DAQ
+            and len(device.ao_physical_chans) >= 2
+            and len(device.ai_physical_chans) >= 4
+            and len(device.do_lines) >= 8
+            and len(device.di_lines) == len(device.do_lines)
+            and len(device.ci_physical_chans) >= 4
+        ):
             return device
 
-    raise NoFixtureDetectedError(
-        'Could not detect a device that meets the requirements to be an '
-        'X Series fixture. Cannot proceed to run tests.')
+    pytest.skip(
+        "Could not detect a device that meets the requirements to be an X Series fixture of type "
+        f"{device_type}. Cannot proceed to run tests. Import the NI MAX configuration file located "
+        "at nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these devices."
+    )
+    return None
+
+
+@pytest.fixture(scope="module")
+def any_x_series_device():
+    return _x_series_device(DeviceType.ANY)
+
+
+@pytest.fixture(scope="module")
+def real_x_series_device():
+    return _x_series_device(DeviceType.REAL)
+
+
+@pytest.fixture(scope="module")
+def sim_x_series_device():
+    return _x_series_device(DeviceType.SIMULATED)
 
 
 @pytest.fixture(scope="module")
@@ -38,6 +69,11 @@ def bridge_device():
         if UsageTypeAI.BRIDGE in device.ai_meas_types:
             return device
 
+    pytest.skip(
+        "Could not detect a device that meets the requirements to be a bridge device. Cannot "
+        "proceed to run tests. Import the NI MAX configuration file located at "
+        "nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these devices."
+    )
     return None
 
 
@@ -49,6 +85,11 @@ def sim_power_device():
         if device.dev_is_simulated and UsageTypeAI.POWER in device.ai_meas_types:
             return device
 
+    pytest.skip(
+        "Could not detect a device that meets the requirements to be a simulated power device. "
+        "Cannot proceed to run tests. Import the NI MAX configuration file located at "
+        "nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these devices."
+    )
     return None
 
 
@@ -60,8 +101,15 @@ def sim_power_devices():
     for device in system.devices:
         if device.dev_is_simulated and UsageTypeAI.POWER in device.ai_meas_types:
             devices.append(device)
+            if len(devices) == 2:
+                return devices
 
-    return devices
+    pytest.skip(
+        "Could not detect two or more devices that meets the requirements to be a simulated power "
+        "device. Cannot proceed to run tests. Import the NI MAX configuration file located at "
+        "nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these devices."
+    )
+    return None
 
 
 @pytest.fixture(scope="module")
@@ -70,16 +118,18 @@ def multi_threading_test_devices():
 
     devices = []
     for device in system.devices:
-        if (device.dev_is_simulated and
-                device.product_category == ProductCategory.X_SERIES_DAQ and
-                len(device.ai_physical_chans) >= 1):
+        if (
+            device.dev_is_simulated
+            and device.product_category == ProductCategory.X_SERIES_DAQ
+            and len(device.ai_physical_chans) >= 1
+        ):
             devices.append(device)
             if len(devices) == 4:
                 return devices
 
-    raise NoFixtureDetectedError(
-        'Could not detect 4 simulated X Series devices so as to meet the '
-        'requirements to be a multi-threading test test fixture. Cannot '
-        'proceed to run tests. Import the NI MAX configuration file located '
-        'at nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these '
-        'devices.')
+    pytest.skip(
+        "Could not detect 4 simulated X Series devices for multithreading tests.  Cannot proceed "
+        "to run tests. Import the NI MAX configuration file located at "
+        "nidaqmx\\tests\\max_config\\nidaqmxMaxConfig.ini to create these devices."
+    )
+    return None

--- a/nidaqmx/tests/test_channel_creation.py
+++ b/nidaqmx/tests/test_channel_creation.py
@@ -9,7 +9,7 @@ from nidaqmx.constants import (
     CurrentShuntResistorLocation, TemperatureUnits, RTDType,
     ResistanceConfiguration, ExcitationSource, ResistanceUnits, StrainUnits,
     StrainGageBridgeType, BridgeConfiguration)
-from nidaqmx.tests.fixtures import sim_power_device, x_series_device
+from nidaqmx.tests.fixtures import sim_power_device, any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -24,11 +24,11 @@ class TestAnalogCreateChannels(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_voltage_chan(self, x_series_device, seed):
+    def test_create_ai_voltage_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_voltage_chan(
@@ -48,11 +48,11 @@ class TestAnalogCreateChannels(object):
                     "double_gain_scale")
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_current_chan(self, x_series_device, seed):
+    def test_create_ai_current_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_current_chan(
@@ -73,11 +73,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_current_shunt_resistance == 100.0
 
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_create_ai_voltage_rms_chan(self, x_series_device, seed):
+    # def test_create_ai_voltage_rms_chan(self, any_x_series_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
-    #     ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+    #     ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
     #
     #     with nidaqmx.Task() as task:
     #         ai_channel = task.ai_channels.add_ai_voltage_rms_chan(
@@ -93,11 +93,11 @@ class TestAnalogCreateChannels(object):
     #         assert ai_channel.ai_custom_scale.name == ""
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_rtd_chan(self, x_series_device, seed):
+    def test_create_ai_rtd_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_rtd_chan(
@@ -121,11 +121,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_rtd_r_0 == 100.0
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_iex(self, x_series_device, seed):
+    def test_create_ai_thrmstr_chan_iex(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_thrmstr_chan_iex(
@@ -151,11 +151,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_thrmstr_c == 0.000000102
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_vex(self, x_series_device, seed):
+    def test_create_ai_thrmstr_chan_vex(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_thrmstr_chan_vex(
@@ -182,11 +182,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_thrmstr_r_1 == 5000.0
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_resistance_chan(self, x_series_device, seed):
+    def test_create_ai_resistance_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_resistance_chan(
@@ -207,11 +207,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_excit_val == 0.002
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_ai_strain_gage_chan(self, x_series_device, seed):
+    def test_ai_strain_gage_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_strain_gage_chan(
@@ -239,11 +239,11 @@ class TestAnalogCreateChannels(object):
             assert ai_channel.ai_lead_wire_resistance == 0.1
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_ai_voltage_chan_with_excit(self, x_series_device, seed):
+    def test_create_ai_voltage_chan_with_excit(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(

--- a/nidaqmx/tests/test_channel_creation.py
+++ b/nidaqmx/tests/test_channel_creation.py
@@ -189,12 +189,13 @@ class TestAnalogCreateChannels(object):
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
         with nidaqmx.Task() as task:
+            # Note: 1000 ohms @ 5 mA = 5V range, which exists on most X Series devices.
             ai_channel = task.ai_channels.add_ai_resistance_chan(
                 ai_phys_chan, name_to_assign_to_channel="ResistanceChannel",
                 min_val=-1000.0, max_val=1000.0, units=ResistanceUnits.OHMS,
                 resistance_config=ResistanceConfiguration.TWO_WIRE,
                 current_excit_source=ExcitationSource.EXTERNAL,
-                current_excit_val=0.002, custom_scale_name="")
+                current_excit_val=0.005, custom_scale_name="")
 
             assert ai_channel.physical_channel.name == ai_phys_chan
             assert ai_channel.name == "ResistanceChannel"
@@ -204,7 +205,7 @@ class TestAnalogCreateChannels(object):
             assert (ai_channel.ai_resistance_cfg ==
                     ResistanceConfiguration.TWO_WIRE)
             assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 0.002
+            assert ai_channel.ai_excit_val == 0.005
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
     def test_ai_strain_gage_chan(self, any_x_series_device, seed):

--- a/nidaqmx/tests/test_channels.py
+++ b/nidaqmx/tests/test_channels.py
@@ -4,7 +4,7 @@ import six
 import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import TaskMode
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device, real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -14,51 +14,51 @@ class TestChannels(object):
     objects in the NI-DAQmx Python API.
     """
 
-    def test_ai_channel(self, x_series_device):
+    def test_ai_channel(self, any_x_series_device):
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name, max_val=10)
+                any_x_series_device.ai_physical_chans[0].name, max_val=10)
 
             # Test property default value.
             assert ai_channel.ai_max == 10
 
-    def test_ao_channel(self, x_series_device):
+    def test_ao_channel(self, any_x_series_device):
         with nidaqmx.Task() as task:
             ao_channel = task.ao_channels.add_ao_voltage_chan(
-                x_series_device.ao_physical_chans[0].name, max_val=5)
+                any_x_series_device.ao_physical_chans[0].name, max_val=5)
 
             # Test property default value.
             assert ao_channel.ao_max == 5
 
-    def test_ci_channel(self, x_series_device):
+    def test_ci_channel(self, real_x_series_device):
         with nidaqmx.Task() as task:
             ci_channel = task.ci_channels.add_ci_count_edges_chan(
-                x_series_device.ci_physical_chans[0].name, initial_count=10)
+                real_x_series_device.ci_physical_chans[0].name, initial_count=10)
 
             task.control(TaskMode.TASK_COMMIT)
 
             assert ci_channel.ci_count == 10
 
-    def test_co_channel(self, x_series_device):
+    def test_co_channel(self, any_x_series_device):
         with nidaqmx.Task() as task:
             co_channel = task.co_channels.add_co_pulse_chan_freq(
-                x_series_device.co_physical_chans[0].name, freq=5000)
+                any_x_series_device.co_physical_chans[0].name, freq=5000)
 
             task.control(TaskMode.TASK_COMMIT)
 
             numpy.testing.assert_allclose(
                 [co_channel.co_pulse_freq], [5000], rtol=0.05)
 
-    def test_di_channel(self, x_series_device):
+    def test_di_channel(self, any_x_series_device):
         with nidaqmx.Task() as task:
             di_channel = task.di_channels.add_di_chan(
-                x_series_device.di_lines[0].name)
+                any_x_series_device.di_lines[0].name)
 
             assert di_channel.di_num_lines == 1
 
-    def test_do_channel(self, x_series_device):
+    def test_do_channel(self, any_x_series_device):
         with nidaqmx.Task() as task:
             do_channel = task.do_channels.add_do_chan(
-                x_series_device.do_lines[0].name)
+                any_x_series_device.do_lines[0].name)
 
             assert do_channel.do_num_lines == 1

--- a/nidaqmx/tests/test_container_operations.py
+++ b/nidaqmx/tests/test_container_operations.py
@@ -52,10 +52,11 @@ class TestContainerOperations(object):
 
             # Test that setting property on concatenated channel changes the
             # property values of the individual channels.
-            ai_channel_1.ai_max = 0.1
-            ai_channel_1.ai_min = -0.1
-            assert ai_channel_2.ai_max == 0.1
-            assert ai_channel_2.ai_min == -0.1
+            # Note: 0.2V range exists on most X Series devices.
+            ai_channel_1.ai_max = 0.2
+            ai_channel_1.ai_min = -0.2
+            assert ai_channel_2.ai_max == 0.2
+            assert ai_channel_2.ai_min == -0.2
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
     def test_equality_operations(self, any_x_series_device, seed):

--- a/nidaqmx/tests/test_container_operations.py
+++ b/nidaqmx/tests/test_container_operations.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 import nidaqmx
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.utils import flatten_channel_string
 
@@ -15,11 +15,11 @@ class TestContainerOperations(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_concatenate_operations(self, x_series_device, seed):
+    def test_concatenate_operations(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(x_series_device.ai_physical_chans, 2)
+        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
 
         with nidaqmx.Task() as task:
             ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
@@ -58,11 +58,11 @@ class TestContainerOperations(object):
             assert ai_channel_2.ai_min == -0.1
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_equality_operations(self, x_series_device, seed):
+    def test_equality_operations(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(x_series_device.ai_physical_chans, 2)
+        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
 
         with nidaqmx.Task() as task:
             ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
@@ -75,14 +75,14 @@ class TestContainerOperations(object):
             assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_hash_operations(self, x_series_device, seed):
+    def test_hash_operations(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(x_series_device.ai_physical_chans, 3)
+        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 3)
 
         with nidaqmx.Task() as task_1, nidaqmx.Task() as task_2:
             ai_channel_1 = task_1.ai_channels.add_ai_voltage_chan(

--- a/nidaqmx/tests/test_events.py
+++ b/nidaqmx/tests/test_events.py
@@ -4,7 +4,7 @@ import time
 
 import nidaqmx
 from nidaqmx.constants import AcquisitionType
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -15,7 +15,7 @@ class TestEvents(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_every_n_samples_event(self, x_series_device, seed):
+    def test_every_n_samples_event(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -24,7 +24,7 @@ class TestEvents(object):
 
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name)
+                any_x_series_device.ai_physical_chans[0].name)
 
             samples_multiple = random.randint(2, 5)
             num_samples = samples_chunk * samples_multiple

--- a/nidaqmx/tests/test_export_signals.py
+++ b/nidaqmx/tests/test_export_signals.py
@@ -3,7 +3,7 @@ import random
 
 import nidaqmx
 from nidaqmx.constants import Signal
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -18,12 +18,12 @@ class TestExportSignals(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_export_signals(self, x_series_device, seed):
+    def test_export_signals(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_chan = random.choice(x_series_device.ai_physical_chans)
-        pfi_line = random.choice(self._get_device_pfi_lines(x_series_device))
+        ai_chan = random.choice(any_x_series_device.ai_physical_chans)
+        pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(ai_chan.name)

--- a/nidaqmx/tests/test_invalid_reads.py
+++ b/nidaqmx/tests/test_invalid_reads.py
@@ -5,7 +5,7 @@ import random
 import nidaqmx
 from nidaqmx.errors import DaqError
 from nidaqmx.utils import flatten_channel_string
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -13,15 +13,15 @@ from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 # class TestInvalidReads(TestReadWriteBase):
 
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_one_chan_read_for_n_chan_task(self, x_series_device, seed):
+    # def test_one_chan_read_for_n_chan_task(self, any_x_series_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
     #     number_of_channels = random.randint(
-    #         2, len(x_series_device.ai_physical_chans))
+    #         2, len(any_x_series_device.ai_physical_chans))
     #
     #     ai_channels = random.sample(
-    #         x_series_device.ai_physical_chans, number_of_channels)
+    #         any_x_series_device.ai_physical_chans, number_of_channels)
     #
     #     with nidaqmx.Task() as task:
     #         task.ai_channels.add_ai_voltage_chan(
@@ -33,11 +33,11 @@ from nidaqmx.tests.test_read_write import TestDAQmxIOBase
     #         assert e.value.error_code == -200523
 
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_numpy_read_for_counter_pulse_task(self, x_series_device, seed):
+    # def test_numpy_read_for_counter_pulse_task(self, any_x_series_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
-    #     counter = random.choice(self._get_device_counters(x_series_device))
+    #     counter = random.choice(self._get_device_counters(any_x_series_device))
     #
     #     with nidaqmx.Task() as task:
     #         task.ci_channels.add_ci_pulse_chan_freq(counter)
@@ -47,15 +47,15 @@ from nidaqmx.tests.test_read_write import TestDAQmxIOBase
     #         assert e.value.error_code == -1
     #
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_numpy_read_incorrectly_shaped_data(self, x_series_device, seed):
+    # def test_numpy_read_incorrectly_shaped_data(self, any_x_series_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
     #     # Randomly select physical channels to test.
     #     number_of_channels = random.randint(
-    #         2, len(x_series_device.ai_physical_chans))
+    #         2, len(any_x_series_device.ai_physical_chans))
     #     channels_to_test = random.sample(
-    #         x_series_device.ai_physical_chans, number_of_channels)
+    #         any_x_series_device.ai_physical_chans, number_of_channels)
     #     number_of_samples = random.randint(50, 100)
     #
     #     with nidaqmx.Task() as task:

--- a/nidaqmx/tests/test_invalid_writes.py
+++ b/nidaqmx/tests/test_invalid_writes.py
@@ -5,22 +5,22 @@ import random
 import nidaqmx
 from nidaqmx.errors import DaqError
 from nidaqmx.utils import flatten_channel_string
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
 class TestInvalidWrites(object):
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_insufficient_write_data(self, x_series_device, seed):
+    def test_insufficient_write_data(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
         number_of_channels = random.randint(
-            2, len(x_series_device.ao_physical_chans))
+            2, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(
-            x_series_device.ao_physical_chans, number_of_channels)
+            any_x_series_device.ao_physical_chans, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.ao_channels.add_ao_voltage_chan(
@@ -40,15 +40,15 @@ class TestInvalidWrites(object):
             assert e.value.error_code == -200524
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_insufficient_numpy_write_data(self, x_series_device, seed):
+    def test_insufficient_numpy_write_data(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
         number_of_channels = random.randint(
-            2, len(x_series_device.ao_physical_chans))
+            2, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(
-            x_series_device.ao_physical_chans, number_of_channels)
+            any_x_series_device.ao_physical_chans, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.ao_channels.add_ao_voltage_chan(
@@ -64,15 +64,15 @@ class TestInvalidWrites(object):
             assert e.value.error_code == -200524
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_extraneous_write_data(self, x_series_device, seed):
+    def test_extraneous_write_data(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
         number_of_channels = random.randint(
-            1, len(x_series_device.ao_physical_chans))
+            1, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(
-            x_series_device.ao_physical_chans, number_of_channels)
+            any_x_series_device.ao_physical_chans, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.ao_channels.add_ao_voltage_chan(
@@ -92,15 +92,15 @@ class TestInvalidWrites(object):
             assert e.value.error_code == -200524
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_extraneous_numpy_write_data(self, x_series_device, seed):
+    def test_extraneous_numpy_write_data(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
         number_of_channels = random.randint(
-            1, len(x_series_device.ao_physical_chans))
+            1, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(
-            x_series_device.ao_physical_chans, number_of_channels)
+            any_x_series_device.ao_physical_chans, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.ao_channels.add_ao_voltage_chan(
@@ -122,15 +122,15 @@ class TestInvalidWrites(object):
             assert e.value.error_code == -200524
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_numpy_write_incorrectly_shaped_data(self, x_series_device, seed):
+    def test_numpy_write_incorrectly_shaped_data(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
         number_of_channels = random.randint(
-            2, len(x_series_device.ao_physical_chans))
+            2, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(
-            x_series_device.ao_physical_chans, number_of_channels)
+            any_x_series_device.ao_physical_chans, number_of_channels)
         number_of_samples = random.randint(50, 100)
 
         with nidaqmx.Task() as task:

--- a/nidaqmx/tests/test_power_up_states.py
+++ b/nidaqmx/tests/test_power_up_states.py
@@ -6,7 +6,7 @@ import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import PowerUpStates
 from nidaqmx.system.system import DOPowerUpState
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -16,11 +16,11 @@ class TestPowerUpStates(object):
     states functions in the Python NI-DAQmx API.
     """
 
-    def test_digital_power_up_states(self, x_series_device):
+    def test_digital_power_up_states(self, real_x_series_device):
         # The power up state for digital lines for an X Series device has to
         # be set for the whole port.
-        do_port = x_series_device.do_ports[0].name
-        do_line = next(d.name for d in x_series_device.do_lines if
+        do_port = real_x_series_device.do_ports[0].name
+        do_line = next(d.name for d in real_x_series_device.do_lines if
                        do_port in d.name)
 
         system = nidaqmx.system.System.local()
@@ -29,10 +29,10 @@ class TestPowerUpStates(object):
         state_to_set = DOPowerUpState(
             physical_channel=do_port, power_up_state=PowerUpStates.LOW)
         system.set_digital_power_up_states(
-            x_series_device.name, [state_to_set])
+            real_x_series_device.name, [state_to_set])
 
         # Getting power up states returns state for all channels on device.
-        all_states = system.get_digital_power_up_states(x_series_device.name)
+        all_states = system.get_digital_power_up_states(real_x_series_device.name)
 
         # Find power states for all the digital lines that belong to the port.
         port_states = [p for p in all_states if do_port in p.physical_channel]
@@ -45,10 +45,10 @@ class TestPowerUpStates(object):
         state_to_set = DOPowerUpState(
             physical_channel=do_port, power_up_state=PowerUpStates.TRISTATE)
         system.set_digital_power_up_states(
-            x_series_device.name, [state_to_set])
+            real_x_series_device.name, [state_to_set])
 
         all_states = system.get_digital_power_up_states(
-            x_series_device.name)
+            real_x_series_device.name)
         port_states = [p for p in all_states if do_port in p.physical_channel]
 
         for state in port_states:

--- a/nidaqmx/tests/test_properties.py
+++ b/nidaqmx/tests/test_properties.py
@@ -6,7 +6,7 @@ import nidaqmx
 import nidaqmx.system
 from nidaqmx import DaqError
 from nidaqmx.constants import AcquisitionType, UsageTypeAI
-from nidaqmx.tests.fixtures import x_series_device, bridge_device
+from nidaqmx.tests.fixtures import any_x_series_device, bridge_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -16,15 +16,15 @@ class TestPropertyBasicDataTypes(object):
     setter and deleter methods for different basic data types.
     """
 
-    def test_boolean_property(self, x_series_device):
+    def test_boolean_property(self, any_x_series_device):
 
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name)
+                any_x_series_device.ai_physical_chans[0].name)
 
             task.timing.cfg_samp_clk_timing(1000)
             task.triggers.start_trigger.cfg_dig_edge_start_trig(
-                '/{0}/Ctr0InternalOutput'.format(x_series_device.name))
+                '/{0}/Ctr0InternalOutput'.format(any_x_series_device.name))
 
             # Test property initial value.
             assert not task.triggers.start_trigger.retriggerable
@@ -37,11 +37,11 @@ class TestPropertyBasicDataTypes(object):
             del task.triggers.start_trigger.retriggerable
             assert not task.triggers.start_trigger.retriggerable
 
-    def test_enum_property(self, x_series_device):
+    def test_enum_property(self, any_x_series_device):
 
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name)
+                any_x_series_device.ai_physical_chans[0].name)
 
             task.timing.cfg_samp_clk_timing(
                 1000, sample_mode=AcquisitionType.CONTINUOUS)
@@ -60,11 +60,11 @@ class TestPropertyBasicDataTypes(object):
             assert (task.timing.samp_quant_samp_mode ==
                     AcquisitionType.CONTINUOUS)
 
-    def test_float_property(self, x_series_device):
+    def test_float_property(self, any_x_series_device):
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name, max_val=5)
+                any_x_series_device.ai_physical_chans[0].name, max_val=5)
 
             # Test property default value.
             assert ai_channel.ai_max == 5
@@ -82,13 +82,13 @@ class TestPropertyBasicDataTypes(object):
             assert e.value.error_code == -200695
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_int_property(self, x_series_device, seed):
+    def test_int_property(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         with nidaqmx.Task() as task:
             task.ci_channels.add_ci_count_edges_chan(
-                x_series_device.ci_physical_chans[0].name)
+                any_x_series_device.ci_physical_chans[0].name)
 
             # Test property default value.
             assert task.in_stream.offset == 0
@@ -106,11 +106,11 @@ class TestPropertyBasicDataTypes(object):
             del task.in_stream.offset
             assert task.in_stream.offset == 0
 
-    def test_string_property(self, x_series_device):
+    def test_string_property(self, any_x_series_device):
 
         with nidaqmx.Task() as task:
             ai_channel = task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name)
+                any_x_series_device.ai_physical_chans[0].name)
 
             # Test property default value.
             assert ai_channel.description == ''
@@ -125,13 +125,13 @@ class TestPropertyBasicDataTypes(object):
             assert ai_channel.description == ''
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_uint_property(self, x_series_device, seed):
+    def test_uint_property(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         with nidaqmx.Task() as task:
             task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name)
+                any_x_series_device.ai_physical_chans[0].name)
 
             task.timing.cfg_samp_clk_timing(1000)
 
@@ -157,16 +157,16 @@ class TestPropertyListDataTypes(object):
     list data types.
     """
 
-    def test_list_of_strings_property(self, x_series_device):
+    def test_list_of_strings_property(self, any_x_series_device):
 
-        terminals = x_series_device.terminals
+        terminals = any_x_series_device.terminals
 
         assert isinstance(terminals, list)
         assert isinstance(terminals[0], six.string_types)
 
-    def test_list_of_enums_property(self, x_series_device):
+    def test_list_of_enums_property(self, any_x_series_device):
 
-        terminals = x_series_device.ai_meas_types
+        terminals = any_x_series_device.ai_meas_types
 
         assert isinstance(terminals, list)
         assert isinstance(terminals[0], UsageTypeAI)

--- a/nidaqmx/tests/test_read_exceptions.py
+++ b/nidaqmx/tests/test_read_exceptions.py
@@ -11,7 +11,7 @@ from nidaqmx.constants import (
     AcquisitionType, BusType, Level, TaskMode)
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.utils import flatten_channel_string
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -24,9 +24,9 @@ class TestReadExceptions(object):
     loopback routes on the device.
     """
 
-    def test_timeout(self, x_series_device):
+    def test_timeout(self, real_x_series_device):
         # USB streaming is very tricky.
-        if not (x_series_device.bus_type == BusType.PCIE or x_series_device.bus_type == BusType.PXIE):
+        if not (real_x_series_device.bus_type == BusType.PCIE or real_x_series_device.bus_type == BusType.PXIE):
             pytest.skip("Requires a plugin device.")
 
         samples_to_read = 75
@@ -38,7 +38,7 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate,
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate,
                 idle_state=Level.LOW)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give,
@@ -46,10 +46,10 @@ class TestReadExceptions(object):
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             read_task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
+                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
             read_task.timing.cfg_samp_clk_timing(
                 sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS)
 
@@ -76,9 +76,9 @@ class TestReadExceptions(object):
             number_of_samples_expected = (clocks_to_give - samples_to_read)
             assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-    def test_timeout_raw(self, x_series_device):
+    def test_timeout_raw(self, real_x_series_device):
         # USB streaming is very tricky.
-        if not (x_series_device.bus_type == BusType.PCIE or x_series_device.bus_type == BusType.PXIE):
+        if not (real_x_series_device.bus_type == BusType.PCIE or real_x_series_device.bus_type == BusType.PXIE):
             pytest.skip("Requires a plugin device.")
 
         samples_to_read = 75
@@ -90,7 +90,7 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate,
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate,
                 idle_state=Level.LOW)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give,
@@ -98,10 +98,10 @@ class TestReadExceptions(object):
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             read_task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
+                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
             read_task.timing.cfg_samp_clk_timing(
                 sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS)
 
@@ -131,9 +131,9 @@ class TestReadExceptions(object):
             number_of_samples_expected = (clocks_to_give - samples_to_read)
             assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-    def test_timeout_stream(self, x_series_device):
+    def test_timeout_stream(self, real_x_series_device):
         # USB streaming is very tricky.
-        if not (x_series_device.bus_type == BusType.PCIE or x_series_device.bus_type == BusType.PXIE):
+        if not (real_x_series_device.bus_type == BusType.PCIE or real_x_series_device.bus_type == BusType.PXIE):
             pytest.skip("Requires a plugin device.")
 
         samples_to_read = 75
@@ -147,7 +147,7 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate,
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate,
                 idle_state=Level.LOW)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give,
@@ -155,10 +155,10 @@ class TestReadExceptions(object):
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             read_task.ai_channels.add_ai_voltage_chan(
-                x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
+                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10)
             read_task.timing.cfg_samp_clk_timing(
                 sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS)
 

--- a/nidaqmx/tests/test_read_write.py
+++ b/nidaqmx/tests/test_read_write.py
@@ -11,7 +11,7 @@ import nidaqmx
 from nidaqmx.constants import (
     Edge, TriggerType, AcquisitionType, LineGrouping, Level, TaskMode)
 from nidaqmx.utils import flatten_channel_string
-from nidaqmx.tests.fixtures import sim_power_device, sim_power_devices, x_series_device
+from nidaqmx.tests.fixtures import sim_power_device, sim_power_devices, real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed, POWER_ABS_EPSILON
 
 
@@ -70,13 +70,13 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_1_chan_1_samp(self, x_series_device, seed):
+    def test_1_chan_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
@@ -105,13 +105,13 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             assert len(value_read) == 1
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_n_chan_1_samp(self, x_series_device, seed):
+    def test_n_chan_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
 
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(
@@ -146,7 +146,7 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             assert isinstance(value_read[0], list)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_1_chan_n_samp(self, x_series_device, seed):
+    def test_1_chan_n_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -155,7 +155,7 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, \
@@ -164,14 +164,14 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate,
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate,
                 idle_state=Level.LOW)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=number_of_samples)
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
                 loopback_channel_pair.output_channel, max_val=10, min_val=-10)
@@ -203,7 +203,7 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
                 values_read, values_to_test, rtol=0.05, atol=0.005)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_n_chan_n_samp(self, x_series_device, seed):
+    def test_n_chan_n_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -212,7 +212,7 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
 
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(
@@ -223,13 +223,13 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate)
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=number_of_samples)
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
                 flatten_channel_string(
@@ -276,11 +276,11 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_bool_1_chan_1_samp(self, x_series_device, seed):
+    def test_bool_1_chan_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        do_line = random.choice(x_series_device.do_lines).name
+        do_line = random.choice(real_x_series_device.do_lines).name
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -304,12 +304,12 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
             assert len(value_read) == 1
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_bool_n_chan_1_samp(self, x_series_device, seed):
+    def test_bool_n_chan_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        number_of_channels = random.randint(2, len(x_series_device.do_lines))
-        do_lines = random.sample(x_series_device.do_lines, number_of_channels)
+        number_of_channels = random.randint(2, len(real_x_series_device.do_lines))
+        do_lines = random.sample(real_x_series_device.do_lines, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -333,11 +333,11 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
             assert isinstance(value_read[0], list)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_uint_1_chan_1_samp(self, x_series_device, seed):
+    def test_uint_1_chan_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        do_port = random.choice(x_series_device.do_ports)
+        do_port = random.choice(real_x_series_device.do_ports)
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -362,15 +362,15 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
             assert len(value_read) == 1
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_uint_multi_port(self, x_series_device, seed):
-        if len([d.do_port_width <= 16 for d in x_series_device.do_ports]) < 2:
+    def test_uint_multi_port(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 16 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip('task.read() accepts max of 32 bits for digital uint reads.')
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_ports = random.sample(
-            [d for d in x_series_device.do_ports if d.do_port_width <= 16], 2)
+            [d for d in real_x_series_device.do_ports if d.do_port_width <= 16], 2)
 
         total_port_width = sum([d.do_port_width for d in do_ports])
 
@@ -402,7 +402,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_count_edges_1_samp(self, x_series_device, seed):
+    def test_count_edges_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -410,7 +410,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         frequency = random.uniform(5000, 50000)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -438,7 +438,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             assert value_read[0] == number_of_pulses
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_count_edges_n_samp(self, x_series_device, seed):
+    def test_count_edges_n_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -446,7 +446,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         frequency = random.uniform(5000, 50000)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 3)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, \
                 nidaqmx.Task() as sample_clk_task:
@@ -492,7 +492,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             assert value_read == expected_values
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_pulse_freq_1_samp(self, x_series_device, seed):
+    def test_pulse_freq_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -501,7 +501,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         starting_edge = random.choice([Edge.RISING, Edge.FALLING])
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -526,7 +526,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.01)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_pulse_time_1_samp(self, x_series_device, seed):
+    def test_pulse_time_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -535,7 +535,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         starting_edge = random.choice([Edge.RISING, Edge.FALLING])
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_time(
@@ -560,7 +560,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             assert numpy.isclose(value_read.low_time, low_time, rtol=0.01)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_pulse_ticks_1_samp(self, x_series_device, seed):
+    def test_pulse_ticks_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -569,19 +569,19 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         starting_edge = random.choice([Edge.RISING, Edge.FALLING])
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                '/{0}/100kHzTimebase'.format(x_series_device.name),
+                '/{0}/100kHzTimebase'.format(real_x_series_device.name),
                 high_ticks=high_ticks, low_ticks=low_ticks)
             write_task.timing.cfg_implicit_timing(
                 sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1], source_terminal='/{0}/100kHzTimebase'.format(
-                    x_series_device.name),
+                    real_x_series_device.name),
                 min_val=100, max_val=1000)
             read_task.ci_channels.all.ci_pulse_ticks_term = (
                 '/{0}InternalOutput'.format(counters[0]))

--- a/nidaqmx/tests/test_stream_analog_readers_writers.py
+++ b/nidaqmx/tests/test_stream_analog_readers_writers.py
@@ -14,7 +14,7 @@ from nidaqmx.stream_readers import (
     AnalogSingleChannelReader, AnalogMultiChannelReader)
 from nidaqmx.stream_writers import (
     AnalogSingleChannelWriter, AnalogMultiChannelWriter)
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -37,13 +37,13 @@ class TestAnalogSingleChannelReaderWriter(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample(self, x_series_device, seed):
+    def test_one_sample(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
@@ -72,7 +72,7 @@ class TestAnalogSingleChannelReaderWriter(TestDAQmxIOBase):
                 values_read, values_to_test, rtol=0.05, atol=0.005)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample(self, x_series_device, seed):
+    def test_many_sample(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -81,7 +81,7 @@ class TestAnalogSingleChannelReaderWriter(TestDAQmxIOBase):
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, \
@@ -90,12 +90,12 @@ class TestAnalogSingleChannelReaderWriter(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate)
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=number_of_samples)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
                 loopback_channel_pair.output_channel, max_val=10, min_val=-10)
@@ -143,13 +143,13 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample(self, x_series_device, seed):
+    def test_one_sample(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
 
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(
@@ -182,7 +182,7 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
                 values_read, values_to_test, rtol=0.05, atol=0.005)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample(self, x_series_device, seed):
+    def test_many_sample(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -191,7 +191,7 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
 
         # Select a random loopback channel pair on the device.
         loopback_channel_pairs = self._get_analog_loopback_channels(
-            x_series_device)
+            real_x_series_device)
 
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(
@@ -202,12 +202,12 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                '{0}/ctr0'.format(x_series_device.name), freq=sample_rate)
+                '{0}/ctr0'.format(real_x_series_device.name), freq=sample_rate)
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=number_of_samples)
 
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
                 flatten_channel_string(

--- a/nidaqmx/tests/test_stream_counter_readers_writers.py
+++ b/nidaqmx/tests/test_stream_counter_readers_writers.py
@@ -7,7 +7,7 @@ from nidaqmx.constants import (
     Edge, TriggerType, AcquisitionType, Level, TaskMode)
 from nidaqmx.stream_readers import CounterReader
 from nidaqmx.stream_writers import CounterWriter
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -22,7 +22,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_uint32(self, x_series_device, seed):
+    def test_one_sample_uint32(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -30,7 +30,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         frequency = random.uniform(1000, 10000)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -53,7 +53,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             assert value_read == number_of_pulses
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_multi_sample_uint32(self, x_series_device, seed):
+    def test_multi_sample_uint32(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -61,7 +61,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         frequency = random.uniform(1000, 10000)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 3)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, \
                 nidaqmx.Task() as sample_clk_task:
@@ -110,7 +110,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             assert values_read.tolist() == expected_values
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_double(self, x_series_device, seed):
+    def test_one_sample_double(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -118,7 +118,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
         # Select random counters from the device.
         counters = random.sample(
-            self._get_device_counters(x_series_device), 2)
+            self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -143,7 +143,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
                 [value_read], [actual_frequency], rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_multi_sample_double(self, x_series_device, seed):
+    def test_multi_sample_double(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -152,7 +152,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
         # Select random counters from the device.
         counters = random.sample(
-            self._get_device_counters(x_series_device), 3)
+            self._get_device_counters(real_x_series_device), 3)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -184,7 +184,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
                 values_read, expected_values, rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_pulse_freq(self, x_series_device, seed):
+    def test_one_sample_pulse_freq(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -192,7 +192,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         duty_cycle = random.uniform(0.2, 0.8)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -217,7 +217,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_pulse_freq(self, x_series_device, seed):
+    def test_many_sample_pulse_freq(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -225,7 +225,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
         # Select random counters from the device.
         counters = random.sample(
-            self._get_device_counters(x_series_device), 2)
+            self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_freq(
@@ -273,7 +273,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
                 duty_cycles_read, duty_cycles_to_test[1:], rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_pulse_time(self, x_series_device, seed):
+    def test_one_sample_pulse_time(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -281,7 +281,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         low_time = random.uniform(0.0001, 0.001)
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_time(
@@ -305,7 +305,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             assert numpy.isclose(value_read.low_time, low_time, rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_pulse_time(self, x_series_device, seed):
+    def test_many_sample_pulse_time(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -313,7 +313,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
         # Select random counters from the device.
         counters = random.sample(
-            self._get_device_counters(x_series_device), 2)
+            self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_time(
@@ -362,7 +362,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
                 low_times_read, low_times_to_test[1:], rtol=0.05)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_pulse_ticks_1_samp(self, x_series_device, seed):
+    def test_pulse_ticks_1_samp(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -371,19 +371,19 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         starting_edge = random.choice([Edge.RISING, Edge.FALLING])
 
         # Select random counters from the device.
-        counters = random.sample(self._get_device_counters(x_series_device), 2)
+        counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                '/{0}/100kHzTimebase'.format(x_series_device.name),
+                '/{0}/100kHzTimebase'.format(real_x_series_device.name),
                 high_ticks=high_ticks, low_ticks=low_ticks)
             write_task.timing.cfg_implicit_timing(
                 sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1], source_terminal='/{0}/100kHzTimebase'.format(
-                    x_series_device.name),
+                    real_x_series_device.name),
                 min_val=100, max_val=1000)
             read_task.ci_channels.all.ci_pulse_ticks_term = (
                 '/{0}InternalOutput'.format(counters[0]))
@@ -403,7 +403,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
                 value_read.low_tick, low_ticks, rtol=0.05, atol=1)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_pulse_ticks(self, x_series_device, seed):
+    def test_many_sample_pulse_ticks(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -411,12 +411,12 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
         # Select random counters from the device.
         counters = random.sample(
-            self._get_device_counters(x_series_device), 2)
+            self._get_device_counters(real_x_series_device), 2)
 
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                '/{0}/100kHzTimebase'.format(x_series_device.name),
+                '/{0}/100kHzTimebase'.format(real_x_series_device.name),
                 idle_state=Level.HIGH)
             write_task.timing.cfg_implicit_timing(
                 samps_per_chan=number_of_samples + 1)
@@ -424,7 +424,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1], source_terminal='/{0}/100kHzTimebase'.format(
-                    x_series_device.name),
+                    real_x_series_device.name),
                 min_val=100, max_val=1000)
             read_task.ci_channels.all.ci_pulse_ticks_term = (
                 '/{0}InternalOutput'.format(counters[0]))

--- a/nidaqmx/tests/test_stream_digital_readers_writers.py
+++ b/nidaqmx/tests/test_stream_digital_readers_writers.py
@@ -11,7 +11,7 @@ from nidaqmx.stream_readers import (
     DigitalSingleChannelReader, DigitalMultiChannelReader)
 from nidaqmx.stream_writers import (
     DigitalSingleChannelWriter, DigitalMultiChannelWriter)
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 from nidaqmx.utils import flatten_channel_string
@@ -27,11 +27,11 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_one_line(self, x_series_device, seed):
+    def test_one_sample_one_line(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        do_line = random.choice(x_series_device.do_lines).name
+        do_line = random.choice(real_x_series_device.do_lines).name
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -52,12 +52,12 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_multi_line(self, x_series_device, seed):
+    def test_one_sample_multi_line(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        number_of_lines = random.randint(2, len(x_series_device.do_lines))
-        do_lines = random.sample(x_series_device.do_lines, number_of_lines)
+        number_of_lines = random.randint(2, len(real_x_series_device.do_lines))
+        do_lines = random.sample(real_x_series_device.do_lines, number_of_lines)
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -81,15 +81,15 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_byte(self, x_series_device, seed):
-        if not any([d.do_port_width <= 8 for d in x_series_device.do_ports]):
+    def test_one_sample_port_byte(self, real_x_series_device, seed):
+        if not any([d.do_port_width <= 8 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 8 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_port = random.choice(
-            [d for d in x_series_device.do_ports if d.do_port_width <= 8])
+            [d for d in real_x_series_device.do_ports if d.do_port_width <= 8])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -111,15 +111,15 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_uint16(self, x_series_device, seed):
-        if not any([d.do_port_width <= 16 for d in x_series_device.do_ports]):
+    def test_one_sample_port_uint16(self, real_x_series_device, seed):
+        if not any([d.do_port_width <= 16 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 16 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_port = random.choice(
-            [do for do in x_series_device.do_ports if do.do_port_width <= 16])
+            [do for do in real_x_series_device.do_ports if do.do_port_width <= 16])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -141,15 +141,15 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_uint32(self, x_series_device, seed):
-        if not any([d.do_port_width <= 32 for d in x_series_device.do_ports]):
+    def test_one_sample_port_uint32(self, real_x_series_device, seed):
+        if not any([d.do_port_width <= 32 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 32 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_port = random.choice(
-            [do for do in x_series_device.do_ports if do.do_port_width <= 32])
+            [do for do in real_x_series_device.do_ports if do.do_port_width <= 32])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -171,8 +171,8 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_byte(self, x_series_device, seed):
-        if not any([d.do_port_width <= 8 for d in x_series_device.do_ports]):
+    def test_many_sample_port_byte(self, real_x_series_device, seed):
+        if not any([d.do_port_width <= 8 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 8 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -180,7 +180,7 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
         do_port = random.choice(
-            [d for d in x_series_device.do_ports if d.do_port_width <= 8])
+            [d for d in real_x_series_device.do_ports if d.do_port_width <= 8])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -212,8 +212,8 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, expected_values)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_uint16(self, x_series_device, seed):        
-        if not any([d.do_port_width <= 16 for d in x_series_device.do_ports]):
+    def test_many_sample_port_uint16(self, real_x_series_device, seed):        
+        if not any([d.do_port_width <= 16 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 16 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -221,7 +221,7 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
         do_port = random.choice(
-            [d for d in x_series_device.do_ports if d.do_port_width <= 16])
+            [d for d in real_x_series_device.do_ports if d.do_port_width <= 16])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -253,8 +253,8 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, expected_values)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_uint32(self, x_series_device, seed):
-        if not any([d.do_port_width <= 32 for d in x_series_device.do_ports]):
+    def test_many_sample_port_uint32(self, real_x_series_device, seed):
+        if not any([d.do_port_width <= 32 for d in real_x_series_device.do_ports]):
             pytest.skip("Requires digital port with at most 32 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -262,7 +262,7 @@ class TestDigitalSingleChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
         do_port = random.choice(
-            [d for d in x_series_device.do_ports if d.do_port_width <= 32])
+            [d for d in real_x_series_device.do_ports if d.do_port_width <= 32])
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -303,12 +303,12 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
     loopback routes on the device.
     """
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_one_line(self, x_series_device, seed):
+    def test_one_sample_one_line(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        number_of_channels = random.randint(2, len(x_series_device.do_lines))
-        do_lines = random.sample(x_series_device.do_lines, number_of_channels)
+        number_of_channels = random.randint(2, len(real_x_series_device.do_lines))
+        do_lines = random.sample(real_x_series_device.do_lines, number_of_channels)
 
         with nidaqmx.Task() as task:
             task.do_channels.add_do_chan(
@@ -332,16 +332,16 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_multi_line(self, x_series_device, seed):
+    def test_one_sample_multi_line(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         num_lines = random.randint(2, 4)
         number_of_channels = random.randint(
-            2, int(numpy.floor(len(x_series_device.do_lines) /
+            2, int(numpy.floor(len(real_x_series_device.do_lines) /
                            float(num_lines))))
 
-        all_lines = random.sample(x_series_device.do_lines,
+        all_lines = random.sample(real_x_series_device.do_lines,
                                   num_lines * number_of_channels)
 
         with nidaqmx.Task() as task:
@@ -370,14 +370,14 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_byte(self, x_series_device, seed):        
-        if len([d.do_port_width <= 8 for d in x_series_device.do_ports]) < 2:
+    def test_one_sample_port_byte(self, real_x_series_device, seed):        
+        if len([d.do_port_width <= 8 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 8 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 8]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)
@@ -405,14 +405,14 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_uint16(self, x_series_device, seed):
-        if len([d.do_port_width <= 16 for d in x_series_device.do_ports]) < 2:
+    def test_one_sample_port_uint16(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 16 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 16 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 16]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)
@@ -440,14 +440,14 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_one_sample_port_uint32(self, x_series_device, seed):
-        if len([d.do_port_width <= 32 for d in x_series_device.do_ports]) < 2:
+    def test_one_sample_port_uint32(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 32 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 32 lines.")
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 32]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)
@@ -475,8 +475,8 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, values_to_test)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_byte(self, x_series_device, seed):
-        if len([d.do_port_width <= 8 for d in x_series_device.do_ports]) < 2:
+    def test_many_sample_port_byte(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 8 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 8 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -484,7 +484,7 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 8]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)
@@ -524,8 +524,8 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, expected_values)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_uint16(self, x_series_device, seed):
-        if len([d.do_port_width <= 16 for d in x_series_device.do_ports]) < 2:
+    def test_many_sample_port_uint16(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 16 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 16 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -533,7 +533,7 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 16]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)
@@ -573,8 +573,8 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
             numpy.testing.assert_array_equal(values_read, expected_values)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_many_sample_port_uint32(self, x_series_device, seed):
-        if len([d.do_port_width <= 32 for d in x_series_device.do_ports]) < 2:
+    def test_many_sample_port_uint32(self, real_x_series_device, seed):
+        if len([d.do_port_width <= 32 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("Requires 2 digital ports with at most 32 lines.")
 
         # Reset the pseudorandom number generator with seed.
@@ -582,7 +582,7 @@ class TestDigitalMultiChannelReaderWriter(TestDAQmxIOBase):
 
         number_of_samples = random.randint(2, 20)
 
-        all_ports = [d for d in x_series_device.do_ports if
+        all_ports = [d for d in real_x_series_device.do_ports if
                      d.do_port_width <= 32]
         number_of_channels = random.randint(2, len(all_ports))
         do_ports = random.sample(all_ports, number_of_channels)

--- a/nidaqmx/tests/test_system_collections.py
+++ b/nidaqmx/tests/test_system_collections.py
@@ -13,7 +13,7 @@ from nidaqmx.system._collections.persisted_scale_collection import (
     PersistedScaleCollection)
 from nidaqmx.system._collections.physical_channel_collection import (
     PhysicalChannelCollection)
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 
 
 class TestSystemCollections(object):
@@ -72,8 +72,8 @@ class TestSystemCollections(object):
             # Test specific property on object.
             assert isinstance(global_channels[0].author, six.string_types)
 
-    def test_physical_channel_collection_property(self, x_series_device):
-        phys_chans = x_series_device.ai_physical_chans
+    def test_physical_channel_collection_property(self, any_x_series_device):
+        phys_chans = any_x_series_device.ai_physical_chans
 
         assert isinstance(phys_chans, PhysicalChannelCollection)
         assert isinstance(phys_chans, collections.abc.Sequence)

--- a/nidaqmx/tests/test_teds.py
+++ b/nidaqmx/tests/test_teds.py
@@ -4,7 +4,7 @@ import random
 
 import nidaqmx
 from nidaqmx.constants import TerminalConfiguration, TEDSUnits
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -15,11 +15,11 @@ class TestTEDS(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_create_teds_ai_voltage_chan(self, x_series_device, seed):
+    def test_create_teds_ai_voltage_chan(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(x_series_device.ai_physical_chans)
+        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans)
 
         # Generate path to a virtual TEDS file.
         teds_file_path = os.path.join(

--- a/nidaqmx/tests/test_triggers.py
+++ b/nidaqmx/tests/test_triggers.py
@@ -4,7 +4,7 @@ import random
 import nidaqmx
 from nidaqmx import DaqError
 from nidaqmx.constants import TriggerType, Edge, AcquisitionType, TaskMode
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 from nidaqmx.tests.test_read_write import TestDAQmxIOBase
 
@@ -16,11 +16,11 @@ class TestTriggers(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_arm_start_trigger(self, x_series_device, seed):
+    def test_arm_start_trigger(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(x_series_device))
+        counter = random.choice(self._get_device_counters(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.co_channels.add_co_pulse_chan_freq(counter)
@@ -35,11 +35,11 @@ class TestTriggers(TestDAQmxIOBase):
                     TriggerType.NONE)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_handshake_trigger(self, x_series_device, seed):
+    def test_handshake_trigger(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(x_series_device))
+        counter = random.choice(self._get_device_counters(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.co_channels.add_co_pulse_chan_freq(counter)
@@ -50,11 +50,11 @@ class TestTriggers(TestDAQmxIOBase):
             assert e.value.error_code == -200452
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_pause_trigger(self, x_series_device, seed):
+    def test_pause_trigger(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(x_series_device))
+        counter = random.choice(self._get_device_counters(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.co_channels.add_co_pulse_chan_freq(counter)
@@ -72,11 +72,11 @@ class TestTriggers(TestDAQmxIOBase):
                     TriggerType.NONE)
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_reference_trigger(self, x_series_device, seed):
+    def test_reference_trigger(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(x_series_device))
+        counter = random.choice(self._get_device_counters(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.co_channels.add_co_pulse_chan_freq(counter)
@@ -87,12 +87,12 @@ class TestTriggers(TestDAQmxIOBase):
             assert e.value.error_code == -200452
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_start_trigger(self, x_series_device, seed):
+    def test_start_trigger(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(x_series_device))
-        pfi_line = random.choice(self._get_device_pfi_lines(x_series_device))
+        counter = random.choice(self._get_device_counters(any_x_series_device))
+        pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
 
         with nidaqmx.Task() as task:
             task.co_channels.add_co_pulse_chan_freq(counter)

--- a/nidaqmx/tests/test_utils.py
+++ b/nidaqmx/tests/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 import random
 
 from nidaqmx.utils import flatten_channel_string, unflatten_channel_string
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import any_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -13,7 +13,7 @@ class TestUtils(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_flatten_channel_string(self, x_series_device, seed):
+    def test_flatten_channel_string(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
@@ -24,7 +24,7 @@ class TestUtils(object):
         assert flatten_channel_string([]) == ''
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_unflatten_channel_string(self, x_series_device, seed):
+    def test_unflatten_channel_string(self, any_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 

--- a/nidaqmx/tests/test_watchdog.py
+++ b/nidaqmx/tests/test_watchdog.py
@@ -6,7 +6,7 @@ import nidaqmx
 import nidaqmx.system
 from nidaqmx.system.watchdog import DOExpirationState
 from nidaqmx.constants import Level
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -17,14 +17,14 @@ class TestWatchdog(object):
     """
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_watchdog_task(self, x_series_device, seed):
+    def test_watchdog_task(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        do_line = random.choice(x_series_device.do_lines)
+        do_line = random.choice(real_x_series_device.do_lines)
 
         with nidaqmx.system.WatchdogTask(
-                x_series_device.name, timeout=0.5) as task:
+                real_x_series_device.name, timeout=0.5) as task:
             expir_states = [DOExpirationState(
                 physical_channel=do_line.name,
                 expiration_state=Level.TRISTATE)]
@@ -52,14 +52,14 @@ class TestWatchdog(object):
             task.stop()
 
     @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_watchdog_expir_state(self, x_series_device, seed):
+    def test_watchdog_expir_state(self, real_x_series_device, seed):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        do_line = random.choice(x_series_device.do_lines)
+        do_line = random.choice(real_x_series_device.do_lines)
 
         with nidaqmx.system.WatchdogTask(
-                x_series_device.name, timeout=0.1) as task:
+                real_x_series_device.name, timeout=0.1) as task:
             expir_states = [DOExpirationState(
                 physical_channel=do_line.name,
                 expiration_state=Level.TRISTATE)]

--- a/nidaqmx/tests/test_write_exceptions.py
+++ b/nidaqmx/tests/test_write_exceptions.py
@@ -11,7 +11,7 @@ from nidaqmx.constants import (
     AcquisitionType, BusType, RegenerationMode)
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.utils import flatten_channel_string
-from nidaqmx.tests.fixtures import x_series_device
+from nidaqmx.tests.fixtures import real_x_series_device
 from nidaqmx.tests.helpers import generate_random_seed
 
 
@@ -24,9 +24,9 @@ class TestWriteExceptions(object):
     loopback routes on the device.
     """
 
-    def test_overwrite(self, x_series_device):
+    def test_overwrite(self, real_x_series_device):
         # USB streaming is very tricky.
-        if not (x_series_device.bus_type == BusType.PCIE or x_series_device.bus_type == BusType.PXIE):
+        if not (real_x_series_device.bus_type == BusType.PCIE or real_x_series_device.bus_type == BusType.PXIE):
             pytest.skip("Requires a plugin device.")
 
         number_of_samples = 100
@@ -36,10 +36,10 @@ class TestWriteExceptions(object):
 
         with nidaqmx.Task() as write_task:
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
-                x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10)
+                real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10)
             write_task.timing.cfg_samp_clk_timing(
                 sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS,
                 samps_per_chan=number_of_samples)
@@ -68,9 +68,9 @@ class TestWriteExceptions(object):
             # need to get into the nitty gritty device details on how much.
             assert timeout_exception.value.samps_per_chan_written > 0
 
-    def test_overwrite_during_prime(self, x_series_device):
+    def test_overwrite_during_prime(self, real_x_series_device):
         # USB streaming is very tricky.
-        if not (x_series_device.bus_type == BusType.PCIE or x_series_device.bus_type == BusType.PXIE):
+        if not (real_x_series_device.bus_type == BusType.PCIE or real_x_series_device.bus_type == BusType.PXIE):
             pytest.skip("Requires a plugin device.")
 
         number_of_samples = 100
@@ -81,10 +81,10 @@ class TestWriteExceptions(object):
 
         with nidaqmx.Task() as write_task:
             samp_clk_terminal = '/{0}/Ctr0InternalOutput'.format(
-                x_series_device.name)
+                real_x_series_device.name)
 
             write_task.ao_channels.add_ao_voltage_chan(
-                x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10)
+                real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10)
             write_task.timing.cfg_samp_clk_timing(
                 sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS,
                 samps_per_chan=number_of_samples)


### PR DESCRIPTION
Update the tests to specify if they need a real or simulated device. Instead of failing tests that can't find an appropriate device, skip them.

Tested with a real USB-6343 and only simulated devices. Everything either passes or skips as expected.