### PR TITLE
Handle leading zeros in flatten/unflatten implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ All notable changes to this project will be documented in this file.
 
 * ### Merged Pull Requests
     * [211: Restructure the folder structure and add a basic code generator](https://github.com/ni/nidaqmx-python/pull/211)
+    * [217: Handle leading zeros in flatten/unflatten implementation](https://github.com/ni/nidaqmx-python/issues/217)
 * ### Resolved Issues
-    * ...
+    * [216: Can read channel_names of PersistedTask but not channels](https://github.com/ni/nidaqmx-python/issues/216)
 * ### Major Changes
     * Refactored the repository folder structure and added a code generator.
 

--- a/src/nidaqmx/utils.py
+++ b/src/nidaqmx/utils.py
@@ -159,7 +159,7 @@ def unflatten_channel_string(channel_names):
             # are at least the width of the first number. Otherwise, we don't
             # care.
             num_min_width = 0
-            if len(num_before_str.lstrip('0')) < len(num_before_str):
+            if num_before > 0 and len(num_before_str.lstrip('0')) < len(num_before_str):
                 num_min_width = len(num_before_str)
 
             num_after_str = m_after.group(2)

--- a/src/nidaqmx/utils.py
+++ b/src/nidaqmx/utils.py
@@ -22,6 +22,13 @@ def flatten_channel_string(channel_names):
     names to a single string prior to using the DAQmx Create Channel methods or
     instantiating a DAQmx Task object.
 
+    Note: For simplicity, this implementation is not fully compatible with the
+    NI-DAQmx driver implementation, which is generally more permissive. For
+    example, the driver is more graceful with whitespace padding. It was deemed
+    valuable to implement this natively in Python, so it can be leveraged in
+    workflows that don't have the driver installed. If we have specific examples
+    where this approximation is a, we can revisit this in the future.
+
     Args:
         channel_names (List[str]): The list of physical or virtual channel
             names.
@@ -119,6 +126,13 @@ def unflatten_channel_string(channel_names):
     physical or virtual channels into a list of physical or virtual channel
     names.
 
+    Note: For simplicity, this implementation is not fully compatible with the
+    NI-DAQmx driver implementation, which is generally more permissive. For
+    example, the driver is more graceful with whitespace padding. It was deemed
+    valuable to implement this natively in Python, so it can be leveraged in
+    workflows that don't have the driver installed. If we have specific examples
+    where this approximation is a, we can revisit this in the future.
+
     Args:
         channel_names (str): The list or range of physical or virtual channels.
         
@@ -155,15 +169,16 @@ def unflatten_channel_string(channel_names):
 
             num_before_str = m_before.group(2)
             num_before = int(num_before_str)
-            # If there are any leading 0s, we want to ensure our number strings
-            # are at least the width of the first number. Otherwise, we don't
-            # care.
+            num_after_str = m_after.group(2)
+            num_after = int(num_after_str)
+
             num_min_width = 0
+            # If there are any leading 0s in the first number, we want to ensure
+            # match that width. This is established precedence in the DAQmx
+            # algorithm.
             if num_before > 0 and len(num_before_str.lstrip('0')) < len(num_before_str):
                 num_min_width = len(num_before_str)
 
-            num_after_str = m_after.group(2)
-            num_after = int(num_after_str)
             num_max = max([num_before, num_after])
             num_min = min([num_before, num_after])
             number_of_channels = (num_max - num_min) + 1

--- a/src/nidaqmx/utils.py
+++ b/src/nidaqmx/utils.py
@@ -27,7 +27,7 @@ def flatten_channel_string(channel_names):
     example, the driver is more graceful with whitespace padding. It was deemed
     valuable to implement this natively in Python, so it can be leveraged in
     workflows that don't have the driver installed. If we have specific examples
-    where this approximation is a, we can revisit this in the future.
+    where this approximation is a problem, we can revisit this in the future.
 
     Args:
         channel_names (List[str]): The list of physical or virtual channel
@@ -131,7 +131,7 @@ def unflatten_channel_string(channel_names):
     example, the driver is more graceful with whitespace padding. It was deemed
     valuable to implement this natively in Python, so it can be leveraged in
     workflows that don't have the driver installed. If we have specific examples
-    where this approximation is a, we can revisit this in the future.
+    where this approximation is a problem, we can revisit this in the future.
 
     Args:
         channel_names (str): The list or range of physical or virtual channels.

--- a/src/nidaqmx/utils.py
+++ b/src/nidaqmx/utils.py
@@ -52,13 +52,16 @@ def flatten_channel_string(channel_names):
             previous = {
                 'base_name': channel_name,
                 'start_index': -1,
-                'end_index': -1
+                'start_index_str': "",
+                'end_index': -1,
+                'end_index_str': "",
                 }
         else:
             # If the channel name ends in a valid number, we may need to flatten
             # this channel with subsequent channels in the x:y format.
             current_base_name = m.group(1)
-            current_index = int(m.group(2))
+            current_index_str = m.group(2)
+            current_index = int(current_index_str)
 
             if current_base_name == previous['base_name'] and (
                 (current_index == previous['end_index'] + 1 and
@@ -69,6 +72,7 @@ def flatten_channel_string(channel_names):
                 # previous and it's end index differs by 1, change the end
                 # index value. It gets flattened later.
                 previous['end_index'] = current_index
+                previous['end_index_str'] = current_index_str
             else:
                 # If the current channel name has the same base name as the
                 # previous or it's end index differs by more than 1, it doesn't
@@ -78,7 +82,9 @@ def flatten_channel_string(channel_names):
                 previous = {
                     'base_name': current_base_name,
                     'start_index': current_index,
-                    'end_index': current_index
+                    'start_index_str': current_index_str,
+                    'end_index': current_index,
+                    'end_index_str': current_index_str,
                     }
 
     # Convert the final channel dictionary to a flattened string
@@ -98,11 +104,11 @@ def _channel_info_to_flattened_name(channel_info):
         return channel_info['base_name']
     elif channel_info['start_index'] == channel_info['end_index']:
         return '{0}{1}'.format(channel_info['base_name'],
-                               channel_info['start_index'])
+                               channel_info['start_index_str'])
     else:
         return '{0}{1}:{2}'.format(channel_info['base_name'],
-                                   channel_info['start_index'],
-                                   channel_info['end_index'])
+                                   channel_info['start_index_str'],
+                                   channel_info['end_index_str'])
 
                                    
 def unflatten_channel_string(channel_names):
@@ -147,8 +153,17 @@ def unflatten_channel_string(channel_names):
                 raise DaqError(_invalid_range_syntax_message,
                                error_code=-200498)
 
-            num_before = int(m_before.group(2))
-            num_after = int(m_after.group(2))
+            num_before_str = m_before.group(2)
+            num_before = int(num_before_str)
+            # If there are any leading 0s, we want to ensure our number strings
+            # are at least the width of the first number. Otherwise, we don't
+            # care.
+            num_min_width = 0
+            if len(num_before_str.lstrip('0')) < len(num_before_str):
+                num_min_width = len(num_before_str)
+
+            num_after_str = m_after.group(2)
+            num_after = int(num_after_str)
             num_max = max([num_before, num_after])
             num_min = min([num_before, num_after])
             number_of_channels = (num_max - num_min) + 1
@@ -159,8 +174,14 @@ def unflatten_channel_string(channel_names):
 
             colon_expanded_channel = []
             for i in range(number_of_channels):
-                colon_expanded_channel.append(
-                    '{0}{1}'.format(m_before.group(1), num_min + i))
+                current_number = num_min + i
+                if num_min_width > 0:
+                    # Using fstrings to create format strings. Braces for days!
+                    zero_padded_format_specifier = f"{{:0{num_min_width}d}}"
+                    current_number_str = zero_padded_format_specifier.format(current_number)
+                else:
+                    current_number_str = str(current_number)
+                colon_expanded_channel.append(f"{m_before.group(1)}{current_number_str}")
 
             if num_after < num_before:
                 colon_expanded_channel.reverse()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,6 @@ import pytest
 import random
 
 from nidaqmx.utils import flatten_channel_string, unflatten_channel_string
-from nidaqmx.tests.fixtures import any_x_series_device
-from nidaqmx.tests.helpers import generate_random_seed
 
 
 class TestUtils(object):
@@ -12,24 +10,22 @@ class TestUtils(object):
     functionality in the NI-DAQmx Python API.
     """
 
-    @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_flatten_channel_string(self, any_x_series_device, seed):
-        # Reset the pseudorandom number generator with seed.
-        random.seed(seed)
-
+    def test_flatten_channel_string(self):
         channels = ['Dev1/ai0', 'Dev1/ai1', 'Dev1/ai3', 'Dev2/ai0']
         flattened_channels = 'Dev1/ai0:1,Dev1/ai3,Dev2/ai0'
         assert flatten_channel_string(channels) == flattened_channels
 
         assert flatten_channel_string([]) == ''
 
-    @pytest.mark.parametrize('seed', [generate_random_seed()])
-    def test_unflatten_channel_string(self, any_x_series_device, seed):
-        # Reset the pseudorandom number generator with seed.
-        random.seed(seed)
-
+    def test_unflatten_channel_string(self):
         channels = ['Dev1/ai0', 'Dev1/ai1', 'Dev1/ai3', 'Dev2/ai0']
         flattened_channels = 'Dev1/ai0:1,Dev1/ai3,Dev2/ai0'
         assert unflatten_channel_string(flattened_channels) == channels
 
         assert unflatten_channel_string('') == []
+
+    def test_leading_zeros_flatten_and_unflatten(self):
+        unflattened_channels = ["EV01", "EV02"]
+        flattened_channels = 'EV01:02'
+        assert flatten_channel_string(unflattened_channels) == flattened_channels
+        assert unflatten_channel_string(flattened_channels) == unflattened_channels

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,20 +9,23 @@ class TestUtils(object):
     Contains a collection of pytest tests that validate the utilities
     functionality in the NI-DAQmx Python API.
     """
+    def test_basic_flatten_flatten_and_unflatten(self):
+        unflattened_channels = ['Dev1/ai0', 'Dev1/ai1', 'Dev1/ai2','Dev1/ai4', 'Dev2/ai0']
+        flattened_channels = 'Dev1/ai0:2,Dev1/ai4,Dev2/ai0'
+        assert flatten_channel_string(unflattened_channels) == flattened_channels
+        assert unflatten_channel_string(flattened_channels) == unflattened_channels
 
-    def test_flatten_channel_string(self):
-        channels = ['Dev1/ai0', 'Dev1/ai1', 'Dev1/ai3', 'Dev2/ai0']
-        flattened_channels = 'Dev1/ai0:1,Dev1/ai3,Dev2/ai0'
-        assert flatten_channel_string(channels) == flattened_channels
+    def test_backwards_flatten_flatten_and_unflatten(self):
+        unflattened_channels = ['Dev1/ai2', 'Dev1/ai1', 'Dev1/ai0', 'Dev1/ai4', 'Dev2/ai0']
+        flattened_channels = 'Dev1/ai2:0,Dev1/ai4,Dev2/ai0'
+        assert flatten_channel_string(unflattened_channels) == flattened_channels
+        assert unflatten_channel_string(flattened_channels) == unflattened_channels
 
-        assert flatten_channel_string([]) == ''
-
-    def test_unflatten_channel_string(self):
-        channels = ['Dev1/ai0', 'Dev1/ai1', 'Dev1/ai3', 'Dev2/ai0']
-        flattened_channels = 'Dev1/ai0:1,Dev1/ai3,Dev2/ai0'
-        assert unflatten_channel_string(flattened_channels) == channels
-
-        assert unflatten_channel_string('') == []
+    def test_empty_flatten_flatten_and_unflatten(self):
+        unflattened_channels = []
+        flattened_channels = ''
+        assert flatten_channel_string(unflattened_channels) == flattened_channels
+        assert unflatten_channel_string(flattened_channels) == unflattened_channels
 
     def test_leading_zeros_flatten_and_unflatten(self):
         unflattened_channels = ["EV01", "EV02"]


### PR DESCRIPTION
We should now correctly handle leading zeros in channel names during flatten and unflatten. I also cleaned up the tests and documented the fact that our Python-only impl is not fully compatible with the NI-DAQmx driver.

Closes #216 