### PR TITLE
nidaqmx: Use in-project virtualenvs

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true


### PR DESCRIPTION
### What does this Pull Request accomplish?

Configure Poetry to use in-project virtualenvs.

### Why should this Pull Request be merged?

This configuration is recommended in NI's internal "Python Getting Started" page and is used by some of NI's other GitHub repos. 

Storing the virtualenv in the project's `.venv` subdirectory ensures that running `git clean` or deleting the local Git repo deletes the virtualenv.

### What testing has been done?

Ran `poetry build`, `poetry run pytest`, and `poetry run tox` and verified that they do a build, run tests, etc. (Some tests are failing on my test machine, but this doesn't seem related to venv location.)