### PR TITLE
tox.ini: Enable testing with Python 3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py37, py38, py39, py310, report
+envlist = clean, py37, py38, py39, py310, py311, report
 
 [testenv]
 whitelist_externals = poetry


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enable running tests with Python 3.11.

### Why should this Pull Request be merged?

Support latest Python.

### What testing has been done?

- Installed Python 3.11 using `pyenv install --register 3.11.1`. The `--register` option is important, because Tox can't find the Python interpreter without it.
- Ran `poetry run tox -e py311`. The tests ran without errors.