### PR TITLE
Addition of tests for watchdog timer properties

### DIFF
--- a/tests/component/test_watchdog_properties.py
+++ b/tests/component/test_watchdog_properties.py
@@ -9,7 +9,7 @@ from nidaqmx.errors import DaqError, DAQmxErrors
 from nidaqmx.system.watchdog import DOExpirationState
 
 
-def test__watchdog__get_expired__returns_false(any_x_series_device):
+def test__watchdog_task__get_expired__returns_false(any_x_series_device):
     """Test to validate getter for boolean property."""
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
         task.start()
@@ -18,7 +18,7 @@ def test__watchdog__get_expired__returns_false(any_x_series_device):
 
 
 @pytest.mark.parametrize("device_by_name", ["cDAQ1"], indirect=True)
-def test__watchdog__set_boolean_property__returns_assigned_value(device_by_name):
+def test__watchdog_task__set_boolean_property__returns_assigned_value(device_by_name):
     """Test to validate setter for boolean property."""
     with nidaqmx.system.WatchdogTask(device_by_name.name, timeout=0.5) as task:
 
@@ -28,7 +28,7 @@ def test__watchdog__set_boolean_property__returns_assigned_value(device_by_name)
 
 
 @pytest.mark.parametrize("device_by_name", ["cDAQ1"], indirect=True)
-def test__watchdog__reset_boolean_property__returns_default_value(device_by_name):
+def test__watchdog_task__reset_boolean_property__returns_default_value(device_by_name):
     """Test to validate reset for boolean property."""
 
     with nidaqmx.system.WatchdogTask(device_by_name.name, timeout=0.5) as task:     
@@ -39,7 +39,7 @@ def test__watchdog__reset_boolean_property__returns_default_value(device_by_name
         assert not task.expir_trig_trig_on_network_conn_loss
 
 
-def test__watchdog__task_not_running_get_expired_property___throws_daqerror(any_x_series_device):
+def test__watchdog_task__task_not_running_get_expired_property___throws_daqerror(any_x_series_device):
     """Test to validate error case for boolean property."""
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
 
@@ -49,7 +49,7 @@ def test__watchdog__task_not_running_get_expired_property___throws_daqerror(any_
         assert exc_info.value.error_type == DAQmxErrors.CANNOT_GET_PROPERTY_WHEN_TASK_NOT_RESERVED_COMMITTED_OR_RUNNING
 
 
-def test__watchdog__get_enum_property__returns_value(any_x_series_device):
+def test__watchdog_task__get_enum_property__returns_value(any_x_series_device):
     """Test to validate getter for enum property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -61,7 +61,7 @@ def test__watchdog__get_enum_property__returns_value(any_x_series_device):
         assert task.expir_trig_dig_edge_edge == Edge.RISING
 
 
-def test__watchdog__set_enum_property__returns_assigned_value(any_x_series_device):
+def test__watchdog_task__set_enum_property__returns_assigned_value(any_x_series_device):
     """Test to validate setter for enum property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -75,7 +75,7 @@ def test__watchdog__set_enum_property__returns_assigned_value(any_x_series_devic
         assert task.expir_trig_dig_edge_edge == Edge.FALLING
 
 
-def test__watchdog__reset_enum_property__returns_default_value(any_x_series_device):
+def test__watchdog_task__reset_enum_property__returns_default_value(any_x_series_device):
     """Test to validate reset for enum property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -90,7 +90,7 @@ def test__watchdog__reset_enum_property__returns_default_value(any_x_series_devi
         assert task.expir_trig_dig_edge_edge == Edge.RISING
 
 
-def test__watchdog__get_float64_property__returns_value(any_x_series_device):
+def test__watchdog_task__get_float64_property__returns_value(any_x_series_device):
     """Test to validate getter for float property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -102,7 +102,7 @@ def test__watchdog__get_float64_property__returns_value(any_x_series_device):
         assert task.timeout == 0.5
 
 
-def test__watchdog__set_float64_property__returns_assigned_value(any_x_series_device):
+def test__watchdog_task__set_float64_property__returns_assigned_value(any_x_series_device):
     """Test to validate setter for float property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -116,7 +116,7 @@ def test__watchdog__set_float64_property__returns_assigned_value(any_x_series_de
         assert task.timeout == 2
 
 
-def test__watchdog__reset_float64_property__returns_default_value(any_x_series_device):
+def test__watchdog_task__reset_float64_property__returns_default_value(any_x_series_device):
     """Test to validate reset for float property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -130,7 +130,7 @@ def test__watchdog__reset_float64_property__returns_default_value(any_x_series_d
         assert task.timeout == 10
 
 
-def test__watchdog__get_string_property__returns_value(any_x_series_device):
+def test__watchdog_task__get_string_property__returns_value(any_x_series_device):
     """Test to validate getter for string property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -142,7 +142,7 @@ def test__watchdog__get_string_property__returns_value(any_x_series_device):
         assert task.expir_trig_dig_edge_src == ""
 
 
-def test__watchdog__set_string_property__returns_assigned_value(any_x_series_device):
+def test__watchdog_task__set_string_property__returns_assigned_value(any_x_series_device):
     """Test to validate setter for string property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
@@ -156,7 +156,7 @@ def test__watchdog__set_string_property__returns_assigned_value(any_x_series_dev
         assert task.expir_trig_dig_edge_src == "PFI0"
 
 
-def test__watchdog__reset_string_property__returns_default_value(any_x_series_device):
+def test__watchdog_task__reset_string_property__returns_default_value(any_x_series_device):
     """Test to validate reset for string property."""
     do_line = any_x_series_device.do_lines[0]
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:

--- a/tests/component/test_watchdog_properties.py
+++ b/tests/component/test_watchdog_properties.py
@@ -1,0 +1,169 @@
+"""Tests for validating watchdog properties."""
+
+import pytest
+
+import nidaqmx
+import nidaqmx.system
+from nidaqmx.constants import Level, Edge
+from nidaqmx.errors import DaqError, DAQmxErrors
+from nidaqmx.system.watchdog import DOExpirationState
+
+
+def test__watchdog__get_boolean_property__returns_false(any_x_series_device):
+    """Test to validate getter for boolean property."""
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        task.start()
+
+        assert not task.expired
+        task.stop()
+
+
+@pytest.mark.parametrize("device_by_name", ["cDAQ1"], indirect=True)
+def test__watchdog__set_boolean_property__returns_assigned_value(device_by_name):
+    """Test to validate setter for boolean property."""
+    with nidaqmx.system.WatchdogTask(device_by_name.name, timeout=0.5) as task:
+
+        task.expir_trig_trig_on_network_conn_loss = True
+
+        assert task.expir_trig_trig_on_network_conn_loss
+
+
+@pytest.mark.parametrize("device_by_name", ["cDAQ1"], indirect=True)
+def test__watchdog__reset_boolean_property__returns_default_value(device_by_name):
+    """Test to validate reset for boolean property."""
+
+    with nidaqmx.system.WatchdogTask(device_by_name.name, timeout=0.5) as task:     
+        task.expir_trig_trig_on_network_conn_loss = True
+
+        del task.expir_trig_trig_on_network_conn_loss
+
+        assert not task.expir_trig_trig_on_network_conn_loss
+
+
+def test__watchdog__task_not_running_get_expired_property___throws_daqerror(any_x_series_device):
+    """Test to validate error case for boolean property."""
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        try:
+            _ = task.expired
+        except DaqError as e:
+            assert e.error_type == DAQmxErrors.CANNOT_GET_PROPERTY_WHEN_TASK_NOT_RESERVED_COMMITTED_OR_RUNNING
+
+
+def test__watchdog__get_enum_property__returns_value(any_x_series_device):
+    """Test to validate getter for enum property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        assert task.expir_trig_dig_edge_edge == Edge.RISING
+
+
+def test__watchdog__set_enum_property__returns_assigned_value(any_x_series_device):
+    """Test to validate setter for enum property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        task.expir_trig_dig_edge_edge = Edge.FALLING
+
+        assert task.expir_trig_dig_edge_edge == Edge.FALLING
+
+
+def test__watchdog__reset_enum_property__returns_default_value(any_x_series_device):
+    """Test to validate reset for enum property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+        task.expir_trig_dig_edge_edge = Edge.FALLING
+
+        del task.expir_trig_dig_edge_edge
+        assert task.expir_trig_dig_edge_edge == Edge.RISING
+
+
+def test__watchdog__get_float64_property__returns_value(any_x_series_device):
+    """Test to validate getter for float property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        assert task.timeout == 0.5
+
+
+def test__watchdog__set_float64_property__returns_assigned_value(any_x_series_device):
+    """Test to validate setter for float property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        task.timeout = 2
+
+        assert task.timeout == 2
+
+
+def test__watchdog__reset_float64_property__returns_default_value(any_x_series_device):
+    """Test to validate reset for float property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        del task.timeout
+        
+        assert task.timeout == 10
+
+
+def test__watchdog__get_string_property__returns_value(any_x_series_device):
+    """Test to validate getter for string property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        assert task.expir_trig_dig_edge_src == ""
+
+
+def test__watchdog__set_string_property__returns_assigned_value(any_x_series_device):
+    """Test to validate setter for string property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        task.expir_trig_dig_edge_src = "PFI0"
+
+        assert task.expir_trig_dig_edge_src == "PFI0"
+
+
+def test__watchdog__reset_string_property__returns_default_value(any_x_series_device):
+    """Test to validate reset for string property."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+        task.expir_trig_dig_edge_src = "PFI0"
+
+        del task.expir_trig_dig_edge_src
+        assert task.expir_trig_dig_edge_src == ""

--- a/tests/component/test_watchdog_properties.py
+++ b/tests/component/test_watchdog_properties.py
@@ -9,13 +9,12 @@ from nidaqmx.errors import DaqError, DAQmxErrors
 from nidaqmx.system.watchdog import DOExpirationState
 
 
-def test__watchdog__get_boolean_property__returns_false(any_x_series_device):
+def test__watchdog__get_expired__returns_false(any_x_series_device):
     """Test to validate getter for boolean property."""
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
         task.start()
 
         assert not task.expired
-        task.stop()
 
 
 @pytest.mark.parametrize("device_by_name", ["cDAQ1"], indirect=True)
@@ -43,10 +42,11 @@ def test__watchdog__reset_boolean_property__returns_default_value(device_by_name
 def test__watchdog__task_not_running_get_expired_property___throws_daqerror(any_x_series_device):
     """Test to validate error case for boolean property."""
     with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
-        try:
+
+        with pytest.raises(DaqError) as exc_info:
             _ = task.expired
-        except DaqError as e:
-            assert e.error_type == DAQmxErrors.CANNOT_GET_PROPERTY_WHEN_TASK_NOT_RESERVED_COMMITTED_OR_RUNNING
+
+        assert exc_info.value.error_type == DAQmxErrors.CANNOT_GET_PROPERTY_WHEN_TASK_NOT_RESERVED_COMMITTED_OR_RUNNING
 
 
 def test__watchdog__get_enum_property__returns_value(any_x_series_device):
@@ -86,6 +86,7 @@ def test__watchdog__reset_enum_property__returns_default_value(any_x_series_devi
         task.expir_trig_dig_edge_edge = Edge.FALLING
 
         del task.expir_trig_dig_edge_edge
+
         assert task.expir_trig_dig_edge_edge == Edge.RISING
 
 
@@ -166,4 +167,5 @@ def test__watchdog__reset_string_property__returns_default_value(any_x_series_de
         task.expir_trig_dig_edge_src = "PFI0"
 
         del task.expir_trig_dig_edge_src
+        
         assert task.expir_trig_dig_edge_src == ""

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -116,3 +116,13 @@ DevIsSimulated = 1
 CompactDAQ.ChassisDevName = tsChassisTester
 CompactDAQ.SlotNum = 3
 
+[DAQmxCDAQChassis cDAQ1]
+ProductType = cDAQ-9185
+DevSerialNum = 0x0
+DevIsSimulated = 1
+BusType = TCP/IP
+TCPIP.Hostname = 
+TCPIP.EthernetIP = 0.0.0.0
+TCPIP.EthernetMAC = 00:00:00:00:00:00
+TCPIP.EthernetMDNSServiceInstance = 
+TCPIP.DevIsReserved = 0


### PR DESCRIPTION
**What does this Pull Request accomplish?**
- Adds Tests for testing the different datatypes of watchdog timer properties.
- The following file changes were made in the PR,
     -  Added a new test file `test_watchdog_properties.py` which contains the tests in this PR.
     - Added a Chassis `cDAQ1` to the `nidaqmxMaxConfig.ini` file.
     - Datatypes covered (`boolean`, `enum`, `float64`, `string`)

**Why should this Pull Request be merged?**
[Task 2330432](https://dev.azure.com/ni/DevCentral/_workitems/edit/2330432): Add or verify tests for Watchdog Timer property and related data types