### PR TITLE
Addition of tests for export signal properties

### DIFF
--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -1,0 +1,81 @@
+"""Contains a collection of pytest tests that validates export signal properties."""
+
+import pytest
+
+import nidaqmx
+from nidaqmx.constants import ExportAction
+from nidaqmx.error_codes import DAQmxErrors
+from nidaqmx.errors import DaqError
+from nidaqmx.system.device import Device
+
+
+def test__export_signal__get_enum_property__returns_value(any_x_series_device: Device):
+    """Test to validate getter for export signal property of enum type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        assert task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+
+
+def test__export_signal__set_enum_property__returns_assigned_value(any_x_series_device: Device):
+    """Test to validate setter for export signal property of enum type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        value_to_set = ExportAction.LEVEL
+        task.export_signals.samp_clk_output_behavior = value_to_set
+
+        assert task.export_signals.samp_clk_output_behavior == value_to_set
+
+
+def test__export_signal__reset_enum_property__returns_initial_value(any_x_series_device: Device):
+    """Test to validate resetting export signal property of enum type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        del task.export_signals.samp_clk_output_behavior
+
+        assert task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+
+
+def test__export_signal__get_string_property__returns_value(any_x_series_device: Device):
+    """Test to validate getter for export signal property of string type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        assert task.export_signals.start_trig_output_term == ""
+
+
+def test__export_signal__set_invalid_routing_destination__throws_daqerror(
+    any_x_series_device: Device,
+):
+    """Test to validate setter for export signal property of string type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        task.export_signals.start_trig_output_term = "RTSI"
+
+        with pytest.raises(DaqError) as e:
+            _ = task.export_signals.start_trig_output_term
+        assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
+
+
+def test__export_signal__set_string_property__returns_assigned_value(any_x_series_device: Device):
+    """Test to validate setter for export signal property of string type."""
+    with nidaqmx.Task() as task:
+        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+
+        value_to_set = "RSE"
+        task.export_signals.start_trig_output_term = value_to_set
+
+        assert task.export_signals.start_trig_output_term == value_to_set
+
+
+def test__export_signal__reset_string_property__returns_initial_value(any_x_series_device: Device):
+    """Test to validate resetting export signal property of string type."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+
+        del task.export_signals.start_trig_output_term
+
+        assert task.export_signals.start_trig_output_term == ""

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -9,7 +9,7 @@ from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ai_voltage_task(any_x_series_device):
     """Gets AI voltage task."""
     with nidaqmx.Task() as task:
@@ -17,7 +17,7 @@ def ai_voltage_task(any_x_series_device):
         yield task
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ao_voltage_task(any_x_series_device):
     """Gets AO voltage task."""
     with nidaqmx.Task() as task:

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -24,6 +24,7 @@ def ao_voltage_task(any_x_series_device):
         task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
         yield task
 
+
 def test__export_signal__get_enum_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate getter for export signal property of enum type."""
     assert ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
@@ -59,7 +60,9 @@ def test__export_signal__set_invalid_routing_destination__throws_daqerror(
 
     with pytest.raises(DaqError) as exc_info:
         _ = ai_voltage_task.export_signals.start_trig_output_term
-    assert exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
+    assert (
+        exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
+    )
 
 
 def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_task: Task):

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -59,7 +59,7 @@ def test__ai_task__set_invalid_routing_destination__throws_daqerror(
     with pytest.raises(DaqError) as exc_info:
         ai_voltage_task.export_signals.start_trig_output_term = "RTSI"
         _ = ai_voltage_task.control(TaskMode.TASK_VERIFY)
-        
+
     assert (
         exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
     )

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -3,7 +3,7 @@
 import pytest
 
 import nidaqmx
-from nidaqmx.constants import ExportAction
+from nidaqmx.constants import ExportAction, TaskMode
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
@@ -56,10 +56,10 @@ def test__export_signal__set_invalid_routing_destination__throws_daqerror(
     ai_voltage_task: Task,
 ):
     """Test to validate setter for export signal property of string type."""
-    ai_voltage_task.export_signals.start_trig_output_term = "RTSI"
-
     with pytest.raises(DaqError) as exc_info:
-        _ = ai_voltage_task.export_signals.start_trig_output_term
+        ai_voltage_task.export_signals.start_trig_output_term = "RTSI"
+        _ = ai_voltage_task.control(TaskMode.TASK_VERIFY)
+        
     assert (
         exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
     )

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -33,6 +33,8 @@ def test__export_signal__reset_enum_property__returns_initial_value(any_x_series
     with nidaqmx.Task() as task:
         task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
+        task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
+
         del task.export_signals.samp_clk_output_behavior
 
         assert task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
@@ -74,7 +76,9 @@ def test__export_signal__set_string_property__returns_assigned_value(any_x_serie
 def test__export_signal__reset_string_property__returns_initial_value(any_x_series_device: Device):
     """Test to validate resetting export signal property of string type."""
     with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+
+        task.export_signals.start_trig_output_term = "DIFF"
 
         del task.export_signals.start_trig_output_term
 

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -9,7 +9,7 @@ from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def ai_voltage_task(any_x_series_device):
     """Gets AI voltage task."""
     with nidaqmx.Task() as task:
@@ -17,7 +17,7 @@ def ai_voltage_task(any_x_series_device):
         yield task
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def ao_voltage_task(any_x_series_device):
     """Gets AO voltage task."""
     with nidaqmx.Task() as task:
@@ -58,7 +58,7 @@ def test__ai_task__set_invalid_routing_destination__throws_daqerror(
     """Test to validate setter for export signal property of string type."""
     with pytest.raises(DaqError) as exc_info:
         ai_voltage_task.export_signals.start_trig_output_term = "RTSI"
-        _ = ai_voltage_task.control(TaskMode.TASK_VERIFY)
+        ai_voltage_task.control(TaskMode.TASK_VERIFY)
 
     assert (
         exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -25,12 +25,12 @@ def ao_voltage_task(any_x_series_device):
         yield task
 
 
-def test__export_signal__get_enum_property__returns_default_value(ai_voltage_task: Task):
+def test__ai_task__get_enum_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate getter for export signal property of enum type."""
     assert ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__set_enum_property__returns_assigned_value(ai_voltage_task: Task):
+def test__ai_task__set_enum_property__returns_assigned_value(ai_voltage_task: Task):
     """Test to validate setter for export signal property of enum type."""
     value_to_set = ExportAction.LEVEL
     ai_voltage_task.export_signals.samp_clk_output_behavior = value_to_set
@@ -38,7 +38,7 @@ def test__export_signal__set_enum_property__returns_assigned_value(ai_voltage_ta
     assert ai_voltage_task.export_signals.samp_clk_output_behavior == value_to_set
 
 
-def test__export_signal__reset_enum_property__returns_default_value(ai_voltage_task: Task):
+def test__ai_task__reset_enum_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate resetting export signal property of enum type."""
     ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
 
@@ -47,12 +47,12 @@ def test__export_signal__reset_enum_property__returns_default_value(ai_voltage_t
     assert ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__get_string_property__returns_default_value(ai_voltage_task: Task):
+def test__ai_task__get_string_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate getter for export signal property of string type."""
     assert ai_voltage_task.export_signals.start_trig_output_term == ""
 
 
-def test__export_signal__set_invalid_routing_destination__throws_daqerror(
+def test__ai_task__set_invalid_routing_destination__throws_daqerror(
     ai_voltage_task: Task,
 ):
     """Test to validate setter for export signal property of string type."""
@@ -65,7 +65,7 @@ def test__export_signal__set_invalid_routing_destination__throws_daqerror(
     )
 
 
-def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_task: Task):
+def test__ai_task__set_string_property__returns_assigned_value(ao_voltage_task: Task):
     """Test to validate setter for export signal property of string type."""
     value_to_set = "RSE"
     ao_voltage_task.export_signals.start_trig_output_term = value_to_set
@@ -73,7 +73,7 @@ def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_
     assert ao_voltage_task.export_signals.start_trig_output_term == value_to_set
 
 
-def test__export_signal__reset_string_property__returns_default_value(ao_voltage_task: Task):
+def test__ai_task__reset_string_property__returns_default_value(ao_voltage_task: Task):
     """Test to validate resetting export signal property of string type."""
     ao_voltage_task.export_signals.start_trig_output_term = "DIFF"
 

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -2,62 +2,78 @@
 
 import pytest
 
+import nidaqmx
 from nidaqmx.constants import ExportAction
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 
 
-def test__export_signal__get_enum_property__returns_value(ai_voltage_chan_task: Task):
+@pytest.fixture(scope="module")
+def ai_voltage_task(any_x_series_device):
+    """Gets AI voltage task."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        yield task
+
+
+@pytest.fixture(scope="module")
+def ao_voltage_task(any_x_series_device):
+    """Gets AO voltage task."""
+    with nidaqmx.Task() as task:
+        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+        yield task
+
+def test__export_signal__get_enum_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate getter for export signal property of enum type."""
-    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+    assert ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__set_enum_property__returns_assigned_value(ai_voltage_chan_task: Task):
+def test__export_signal__set_enum_property__returns_assigned_value(ai_voltage_task: Task):
     """Test to validate setter for export signal property of enum type."""
     value_to_set = ExportAction.LEVEL
-    ai_voltage_chan_task.export_signals.samp_clk_output_behavior = value_to_set
+    ai_voltage_task.export_signals.samp_clk_output_behavior = value_to_set
 
-    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == value_to_set
+    assert ai_voltage_task.export_signals.samp_clk_output_behavior == value_to_set
 
 
-def test__export_signal__reset_enum_property__returns_initial_value(ai_voltage_chan_task: Task):
+def test__export_signal__reset_enum_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate resetting export signal property of enum type."""
-    ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
+    ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
 
-    del ai_voltage_chan_task.export_signals.samp_clk_output_behavior
+    del ai_voltage_task.export_signals.samp_clk_output_behavior
 
-    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+    assert ai_voltage_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__get_string_property__returns_value(ai_voltage_chan_task: Task):
+def test__export_signal__get_string_property__returns_default_value(ai_voltage_task: Task):
     """Test to validate getter for export signal property of string type."""
-    assert ai_voltage_chan_task.export_signals.start_trig_output_term == ""
+    assert ai_voltage_task.export_signals.start_trig_output_term == ""
 
 
 def test__export_signal__set_invalid_routing_destination__throws_daqerror(
-    ai_voltage_chan_task: Task,
+    ai_voltage_task: Task,
 ):
     """Test to validate setter for export signal property of string type."""
-    ai_voltage_chan_task.export_signals.start_trig_output_term = "RTSI"
+    ai_voltage_task.export_signals.start_trig_output_term = "RTSI"
 
-    with pytest.raises(DaqError) as e:
-        _ = ai_voltage_chan_task.export_signals.start_trig_output_term
-    assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
+    with pytest.raises(DaqError) as exc_info:
+        _ = ai_voltage_task.export_signals.start_trig_output_term
+    assert exc_info.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
 
 
-def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_chan_task: Task):
+def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_task: Task):
     """Test to validate setter for export signal property of string type."""
     value_to_set = "RSE"
-    ao_voltage_chan_task.export_signals.start_trig_output_term = value_to_set
+    ao_voltage_task.export_signals.start_trig_output_term = value_to_set
 
-    assert ao_voltage_chan_task.export_signals.start_trig_output_term == value_to_set
+    assert ao_voltage_task.export_signals.start_trig_output_term == value_to_set
 
 
-def test__export_signal__reset_string_property__returns_initial_value(ao_voltage_chan_task: Task):
+def test__export_signal__reset_string_property__returns_default_value(ao_voltage_task: Task):
     """Test to validate resetting export signal property of string type."""
-    ao_voltage_chan_task.export_signals.start_trig_output_term = "DIFF"
+    ao_voltage_task.export_signals.start_trig_output_term = "DIFF"
 
-    del ao_voltage_chan_task.export_signals.start_trig_output_term
+    del ao_voltage_task.export_signals.start_trig_output_term
 
-    assert ao_voltage_chan_task.export_signals.start_trig_output_term == ""
+    assert ao_voltage_task.export_signals.start_trig_output_term == ""

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -2,84 +2,62 @@
 
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import ExportAction
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
-from nidaqmx.system.device import Device
+from nidaqmx.task import Task
 
 
-def test__export_signal__get_enum_property__returns_value(any_x_series_device: Device):
+def test__export_signal__get_enum_property__returns_value(ai_voltage_chan_task: Task):
     """Test to validate getter for export signal property of enum type."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-
-        assert task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__set_enum_property__returns_assigned_value(any_x_series_device: Device):
+def test__export_signal__set_enum_property__returns_assigned_value(ai_voltage_chan_task: Task):
     """Test to validate setter for export signal property of enum type."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    value_to_set = ExportAction.LEVEL
+    ai_voltage_chan_task.export_signals.samp_clk_output_behavior = value_to_set
 
-        value_to_set = ExportAction.LEVEL
-        task.export_signals.samp_clk_output_behavior = value_to_set
-
-        assert task.export_signals.samp_clk_output_behavior == value_to_set
+    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == value_to_set
 
 
-def test__export_signal__reset_enum_property__returns_initial_value(any_x_series_device: Device):
+def test__export_signal__reset_enum_property__returns_initial_value(ai_voltage_chan_task: Task):
     """Test to validate resetting export signal property of enum type."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
 
-        task.export_signals.samp_clk_output_behavior == ExportAction.INTERLOCKED
+    del ai_voltage_chan_task.export_signals.samp_clk_output_behavior
 
-        del task.export_signals.samp_clk_output_behavior
-
-        assert task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
+    assert ai_voltage_chan_task.export_signals.samp_clk_output_behavior == ExportAction.PULSE
 
 
-def test__export_signal__get_string_property__returns_value(any_x_series_device: Device):
+def test__export_signal__get_string_property__returns_value(ai_voltage_chan_task: Task):
     """Test to validate getter for export signal property of string type."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-
-        assert task.export_signals.start_trig_output_term == ""
+    assert ai_voltage_chan_task.export_signals.start_trig_output_term == ""
 
 
 def test__export_signal__set_invalid_routing_destination__throws_daqerror(
-    any_x_series_device: Device,
+    ai_voltage_chan_task: Task,
 ):
     """Test to validate setter for export signal property of string type."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    ai_voltage_chan_task.export_signals.start_trig_output_term = "RTSI"
 
-        task.export_signals.start_trig_output_term = "RTSI"
-
-        with pytest.raises(DaqError) as e:
-            _ = task.export_signals.start_trig_output_term
-        assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
+    with pytest.raises(DaqError) as e:
+        _ = ai_voltage_chan_task.export_signals.start_trig_output_term
+    assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_DESTINATION_TERMINAL_NAME_ROUTING
 
 
-def test__export_signal__set_string_property__returns_assigned_value(any_x_series_device: Device):
+def test__export_signal__set_string_property__returns_assigned_value(ao_voltage_chan_task: Task):
     """Test to validate setter for export signal property of string type."""
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    value_to_set = "RSE"
+    ao_voltage_chan_task.export_signals.start_trig_output_term = value_to_set
 
-        value_to_set = "RSE"
-        task.export_signals.start_trig_output_term = value_to_set
-
-        assert task.export_signals.start_trig_output_term == value_to_set
+    assert ao_voltage_chan_task.export_signals.start_trig_output_term == value_to_set
 
 
-def test__export_signal__reset_string_property__returns_initial_value(any_x_series_device: Device):
+def test__export_signal__reset_string_property__returns_initial_value(ao_voltage_chan_task: Task):
     """Test to validate resetting export signal property of string type."""
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    ao_voltage_chan_task.export_signals.start_trig_output_term = "DIFF"
 
-        task.export_signals.start_trig_output_term = "DIFF"
+    del ao_voltage_chan_task.export_signals.start_trig_output_term
 
-        del task.export_signals.start_trig_output_term
-
-        assert task.export_signals.start_trig_output_term == ""
+    assert ao_voltage_chan_task.export_signals.start_trig_output_term == ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,3 +202,19 @@ def persisted_task(request):
 def test_assets_directory() -> pathlib.Path:
     """Gets path to test_assets directory."""
     return pathlib.Path(__file__).parent / "test_assets"
+
+
+@pytest.fixture(scope="module")
+def ai_voltage_chan_task(any_x_series_device):
+    """Gets AI Channel task."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        yield task
+
+
+@pytest.fixture(scope="module")
+def ao_voltage_chan_task(any_x_series_device):
+    """Gets AO Channel task."""
+    with nidaqmx.Task() as task:
+        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+        yield task

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,19 +202,3 @@ def persisted_task(request):
 def test_assets_directory() -> pathlib.Path:
     """Gets path to test_assets directory."""
     return pathlib.Path(__file__).parent / "test_assets"
-
-
-@pytest.fixture(scope="module")
-def ai_voltage_chan_task(any_x_series_device):
-    """Gets AI Channel task."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        yield task
-
-
-@pytest.fixture(scope="module")
-def ao_voltage_chan_task(any_x_series_device):
-    """Gets AO Channel task."""
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        yield task


### PR DESCRIPTION
What does this Pull Request accomplish?
- Adds Tests for testing the different datatypes of export signal properties.
- The following file changes were made in the PR,
    - Added a new test file `test_export_signal_properties.py` which contains the tests
    -  Datatypes covered:
         - `int32`
         - `char[]`(String)

Why should this Pull Request be merged?
- Implements[Task 2330440](https://dev.azure.com/ni/DevCentral/_workitems/edit/2330440): Add or verify tests for Export Signal property and related data types

What testing has been made?
- After adding tests, ran `poetry run pytest` in `tests` directory and verified all the tests passed.
