### PR TITLE
nidaqmx: Use generated/nidaqmx/ instead of src/nidaqmx/

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -31,6 +31,6 @@ jobs:
         run: |
           poetry run ni-python-styleguide lint
       - name: Generate ni-daqmx files
-        run: poetry run python -m src/codegen --dest generated/nidaqmx
+        run: poetry run python src/codegen --dest generated/nidaqmx
       - name: Check for files dirtied by codegen
         run: git diff --exit-code

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -31,6 +31,6 @@ jobs:
         run: |
           poetry run ni-python-styleguide lint
       - name: Generate ni-daqmx files
-        run: poetry run python -m codegen --dest generated/nidaqmx
+        run: poetry run python -m src/codegen --dest generated/nidaqmx
       - name: Check for files dirtied by codegen
         run: git diff --exit-code

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -11,7 +11,8 @@ jobs:
       - ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7"]
+        # The codegen scripts require Python 3.8 or later.
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ begin development. Try to investigate these failures. If you're unable to do so,
 through our [GitHub issues page](http://github.com/ni/nidaqmx-python/issues).
 5. Write new tests that demonstrate your bug or feature. Ensure that these new tests fail.
 6. Make your change.
-7. Once the necessary changes are done, update the auto-generated code using ``poetry run python src/codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in ``generated`` folder.
+7. Once the necessary changes are done, update the auto-generated code using ``poetry run python src/codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in the ``generated`` folder.
+   > **Note**
+   > The codegen scripts require Python 3.8 or later.
 8. Run all the unit tests again (which include the tests you just added), and confirm that they all
 pass.
 9. Send a GitHub Pull Request to the main repository's master branch. GitHub Pull Requests are the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ begin development. Try to investigate these failures. If you're unable to do so,
 through our [GitHub issues page](http://github.com/ni/nidaqmx-python/issues).
 5. Write new tests that demonstrate your bug or feature. Ensure that these new tests fail.
 6. Make your change.
-7. Once the necessary changes are done, update the auto-generated code using ``poetry run python -m codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in ``generated`` folder.
+7. Once the necessary changes are done, update the auto-generated code using ``poetry run python -m src/codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in ``generated`` folder.
 8. Run all the unit tests again (which include the tests you just added), and confirm that they all
 pass.
 9. Send a GitHub Pull Request to the main repository's master branch. GitHub Pull Requests are the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ begin development. Try to investigate these failures. If you're unable to do so,
 through our [GitHub issues page](http://github.com/ni/nidaqmx-python/issues).
 5. Write new tests that demonstrate your bug or feature. Ensure that these new tests fail.
 6. Make your change.
-7. Once the necessary changes are done, update the auto-generated code using ``poetry run python -m src/codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in ``generated`` folder.
+7. Once the necessary changes are done, update the auto-generated code using ``poetry run python src/codegen --dest generated/nidaqmx``. This will ensure that the latest files are present in ``generated`` folder.
 8. Run all the unit tests again (which include the tests you just added), and confirm that they all
 pass.
 9. Send a GitHub Pull Request to the main repository's master branch. GitHub Pull Requests are the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ requirements:
 
 Before running any unit tests, an NI MAX configuration needs be imported. The MAX configuration
 simply contains some custom scales used during testing. The MAX configuration file is located at
-``nidaqmx\tests\max_config\nidaqmxMaxConfig.ini``. Refer to this [KB article](http://digital.ni.com/public.nsf/allkb/0E0D3D7C4AA8903886256B29000C9D5A)
+``tests\max_config\nidaqmxMaxConfig.ini``. Refer to this [KB article](http://digital.ni.com/public.nsf/allkb/0E0D3D7C4AA8903886256B29000C9D5A)
 for details on how to import a MAX Configuration.
 
 To run the **nidaqmx** unit tests in a specific version of Python, run the following command in the

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
 from nidaqmx._task_modules.read_functions import _read_raw

--- a/generated/nidaqmx/system/device.py
+++ b/generated/nidaqmx/system/device.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import (
     lib_importer, wrapped_ndpointer, enum_bitfield_to_list, ctypes_byte_str,

--- a/generated/nidaqmx/system/physical_channel.py
+++ b/generated/nidaqmx/system/physical_channel.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import (
     lib_importer, wrapped_ndpointer, enum_bitfield_to_list, ctypes_byte_str,

--- a/generated/nidaqmx/system/watchdog.py
+++ b/generated/nidaqmx/system/watchdog.py
@@ -17,6 +17,8 @@ from nidaqmx.system._watchdog_modules.expiration_states_collection import (
 from nidaqmx.utils import flatten_channel_string
 from nidaqmx.constants import (
     Edge, TriggerType, WDTTaskAction)
+from nidaqmx.types import (
+    AOExpirationState, COExpirationState, DOExpirationState)
 
 __all__ = ['WatchdogTask']
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,11 +23,12 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-cov = ["attrs[tests]", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
-dev = ["attrs[docs,tests]"]
+cov = ["attrs", "coverage-enable-subprocess", "coverage[toml] (>=5.3)"]
+dev = ["attrs"]
 docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope.interface"]
-tests = ["attrs[tests-no-zope]", "zope.interface"]
-tests-no-zope = ["cloudpickle", "cloudpickle", "hypothesis", "hypothesis", "mypy (>=0.971,<0.990)", "mypy (>=0.971,<0.990)", "pympler", "pympler", "pytest (>=4.3.0)", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-mypy-plugins", "pytest-xdist[psutil]", "pytest-xdist[psutil]"]
+tests = ["attrs", "zope.interface"]
+tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist"]
+tests_no_zope = ["cloudpickle", "hypothesis", "mypy (>=0.971,<0.990)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist"]
 
 [[package]]
 name = "babel"
@@ -118,7 +119,7 @@ toml = ["tomli"]
 name = "deprecation"
 version = "2.1.0"
 description = "A library to handle automated deprecations"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -216,7 +217,6 @@ python-versions = "*"
 
 [package.dependencies]
 pycodestyle = "*"
-setuptools = "*"
 
 [[package]]
 name = "idna"
@@ -299,7 +299,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 MarkupSafe = ">=0.9.2"
 
 [package.extras]
-babel = ["Babel"]
+babel = ["babel"]
 lingua = ["lingua"]
 testing = ["pytest"]
 
@@ -541,20 +541,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "setuptools"
-version = "67.6.1"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "six"
@@ -590,7 +577,6 @@ Jinja2 = ">=2.3"
 packaging = "*"
 Pygments = ">=2.0"
 requests = ">=2.5.0"
-setuptools = "*"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
@@ -787,7 +773,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+testing = ["big-o", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 docs = ["Sphinx", "sphinx_rtd_theme"]
@@ -795,7 +781,7 @@ docs = ["Sphinx", "sphinx_rtd_theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d829f2f2b8292fd0186beeb5fa53b8b6a20c7995d553c0eb38aa296f6c6b0f30"
+content-hash = "9b07b576533cf85d85c5cc8bb5988d68b7d0b705aec6a8c08eb021aa47b2b462"
 
 [metadata.files]
 alabaster = [
@@ -1231,10 +1217,6 @@ pytz = [
 requests = [
     {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
     {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
-]
-setuptools = [
-    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
-    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Hardware :: Hardware Drivers"
 ]
 exclude = ["nidaqmx/tests"]
-packages = [{ include = "nidaqmx", from = "src" }]
+packages = [{ include = "nidaqmx", from = "generated" }]
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -37,6 +37,7 @@ numpy = [
   {version=">=1.22", python="^3.8"},
 ]
 six = "^1.16"
+deprecation = ">=2.1"
 # This functionality was merged into python stdlib beginning in 3.8
 importlib_metadata = {version="^4.2", python="~3.7"}
 # Documentation, must be in main dependencies (but optional) list for
@@ -56,7 +57,6 @@ pykka = "^3.0"
 tox = "^3.24"
 click = "^8.1"
 Mako = "^1.2"
-deprecation = "^2.1"
 ni-python-styleguide = "^0.4"
 sphinx_rtd_theme = "1.0"
 

--- a/src/codegen/__main__.py
+++ b/src/codegen/__main__.py
@@ -3,6 +3,7 @@ import logging
 import pathlib
 import sys
 
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
 import click
 import codegen.generator as generator
 

--- a/src/codegen/__main__.py
+++ b/src/codegen/__main__.py
@@ -3,9 +3,10 @@ import logging
 import pathlib
 import sys
 
-sys.path.append(str(pathlib.Path(__file__).parent.parent))
 import click
-import codegen.generator as generator
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent))
+import codegen.generator as generator  # noqa E402: module level import not at top of file
 
 _logger = logging.getLogger(__name__)
 

--- a/src/codegen/__main__.py
+++ b/src/codegen/__main__.py
@@ -43,4 +43,4 @@ def main(dest, verbose, quiet):
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/src/codegen/__main__.py
+++ b/src/codegen/__main__.py
@@ -39,11 +39,7 @@ def main(dest, verbose, quiet):
     log_format = "[%(relativeCreated)6d] %(levelname)-5s %(funcName)s: %(message)s"
     logging.basicConfig(level=logging_level, format=log_format)
 
-    try:
-        generator.generate(dest)
-    except Exception:
-        _logger.exception("Failed to generate")
-        return 1
+    generator.generate(dest)
 
 
 if __name__ == "__main__":

--- a/src/codegen/generator.py
+++ b/src/codegen/generator.py
@@ -3,12 +3,11 @@ import logging
 import os
 import os.path
 import shutil
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import codegen.metadata as scrapigen_metadata
 from mako.lookup import TemplateLookup
 from mako.template import Template
-
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +48,11 @@ def generate(dest):
     codegen_metadata = _get_metadata()
 
     for info in codegen_metadata["script_info"]["modules"]:
-        _generate_file(codegen_metadata, info["templateFile"], dest / info["relativeOutputPath"])
+        _generate_file(
+            codegen_metadata,
+            PureWindowsPath(info["templateFile"]),
+            dest / PureWindowsPath(info["relativeOutputPath"]),
+        )
 
     _generate_file(codegen_metadata["enums"], "error_codes.mako", dest / "error_codes.py")
 

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -9,6 +9,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
 from nidaqmx._task_modules.read_functions import _read_raw

--- a/src/codegen/templates/system/device.py.mako
+++ b/src/codegen/templates/system/device.py.mako
@@ -12,6 +12,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import (
     lib_importer, wrapped_ndpointer, enum_bitfield_to_list, ctypes_byte_str,

--- a/src/codegen/templates/system/physical_channel.py.mako
+++ b/src/codegen/templates/system/physical_channel.py.mako
@@ -14,6 +14,7 @@
 
 import ctypes
 import numpy
+import deprecation
 
 from nidaqmx._lib import (
     lib_importer, wrapped_ndpointer, enum_bitfield_to_list, ctypes_byte_str,

--- a/src/codegen/templates/system/watchdog.py.mako
+++ b/src/codegen/templates/system/watchdog.py.mako
@@ -24,6 +24,8 @@ from nidaqmx.system._watchdog_modules.expiration_states_collection import (
 from nidaqmx.utils import flatten_channel_string
 from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
+from nidaqmx.types import (
+    AOExpirationState, COExpirationState, DOExpirationState)
 
 __all__ = ['WatchdogTask']
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use `generated/nidaqmx/` as the source for the `nidaqmx` package, instead of `src/nidaqmx/`.

Fix related issues:
- Move `deprecation` from dev-dependencies to dependencies
- Add missing `import deprecation`
- Add missing types (e.g. `AOExpirationState`) to `nidaqmx.system.watchdog`
- Make `codegen` module work outside of `PYTHONPATH`:
  - Use `python src/codegen` to invoke `codegen`
  - In `__main__.py`, add `codegen`'s parent directory to `sys.path`

### Why should this Pull Request be merged?

Test and ship latest codegen output.

### What testing has been done?

- Ran `poetry run python src/codegen --dest generated/nidaqmx`
- Ran `poetry run pytest`
  - Some new tests fail because `persisted_scale` isn't in main yet
  - Many tests report deprecation warnings