### PR TITLE
PR workflow: Delete generated/nidaqmx before running codegen

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           poetry run ni-python-styleguide lint
       - name: Generate ni-daqmx files
-        run: poetry run python src/codegen --dest generated/nidaqmx
+        run: |
+          rm -fr generated/nidaqmx
+          poetry run python src/codegen --dest generated/nidaqmx
       - name: Check for files dirtied by codegen
         run: git diff --exit-code


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update the PR workflow to delete `generated/nidaqmx/` before regenerating it.

### Why should this Pull Request be merged?

Extra/missing files will now cause the PR build to fail.

### What testing has been done?

None