### PR TITLE
nidaqmx: Remove Python 2.7 workarounds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ Please include **all** of the following information when opening an issue:
 
   $ python -c "import sys; print(sys.version)"
 
-- The versions of the **nidaqmx**, numpy, six and enum34 packages used::
+- The versions of the **nidaqmx** and numpy packages used::
 
   $ python -m pip list
 

--- a/generated/nidaqmx/_lib.py
+++ b/generated/nidaqmx/_lib.py
@@ -2,7 +2,6 @@ from ctypes.util import find_library
 import ctypes
 from numpy.ctypeslib import ndpointer
 import platform
-import six
 import sys
 import threading
 
@@ -37,13 +36,13 @@ class c_bool32(ctypes.c_uint):
     del _getter, _setter
 
 
-class CtypesByteString(object):
+class CtypesByteString:
     """
     Custom argtype that automatically converts unicode strings to ASCII
     strings in Python 3.
     """
     def from_param(self, param):
-        if isinstance(param, six.text_type):
+        if isinstance(param, str):
             param = param.encode('ascii')
         return ctypes.c_char_p(param)
 
@@ -117,7 +116,7 @@ def enum_list_to_bitfield(enum_list, bitfield_enum_type):
     return bitfield_value
 
 
-class DaqFunctionImporter(object):
+class DaqFunctionImporter:
     """
     Wraps the function getter function of a ctypes library.
 
@@ -139,12 +138,12 @@ class DaqFunctionImporter(object):
             return cfunc
         except AttributeError:
             raise DaqFunctionNotSupportedError(
-                'The NI-DAQmx function "{0}" is not supported in this '
+                'The NI-DAQmx function "{}" is not supported in this '
                 'version of NI-DAQmx. Visit ni.com/downloads to upgrade your '
                 'version of NI-DAQmx.'.format(function))
 
 
-class DaqLibImporter(object):
+class DaqLibImporter:
     """
     Encapsulates NI-DAQmx library importing and handle type parsing logic.
     """
@@ -190,19 +189,12 @@ class DaqLibImporter(object):
         cdll = None
 
         if sys.platform.startswith('win') or sys.platform.startswith('cli'):
-            lib_name = "nicaiu"
-
-            # Converting to ASCII to workaround issue in Python 2.7.13:
-            # https://bugs.python.org/issue29082
-            if sys.version_info < (3,):
-                lib_name = lib_name.encode('ascii')
-
             if 'iron' in platform.python_implementation().lower():
                 windll = ctypes.windll.nicaiu
                 cdll = ctypes.cdll.nicaiu
             else:
-                windll = ctypes.windll.LoadLibrary(lib_name)
-                cdll = ctypes.cdll.LoadLibrary(lib_name)
+                windll = ctypes.windll.LoadLibrary('nicaiu')
+                cdll = ctypes.cdll.LoadLibrary('nicaiu')
 
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')
@@ -216,7 +208,7 @@ class DaqLibImporter(object):
                     'contact National Instruments for support.')
         else:
             raise DaqNotFoundError(
-                'NI-DAQmx Python is not supported on this platform: {0}. '
+                'NI-DAQmx Python is not supported on this platform: {}. '
                 'Please direct any questions or feedback to National '
                 'Instruments.'.format(sys.platform))
 

--- a/generated/nidaqmx/_task_modules/ai_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/ai_channel_collection.py
@@ -29,7 +29,7 @@ class AIChannelCollection(ChannelCollection):
     Contains the collection of analog input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(AIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, physical_channel, name_to_assign_to_channel=''):
         """
@@ -49,7 +49,7 @@ class AIChannelCollection(ChannelCollection):
             num_channels = len(unflatten_channel_string(physical_channel))
 
             if num_channels > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_channels-1)
             else:
                 name = name_to_assign_to_channel

--- a/generated/nidaqmx/_task_modules/ao_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/ao_channel_collection.py
@@ -16,7 +16,7 @@ class AOChannelCollection(ChannelCollection):
     Contains the collection of analog output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(AOChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, physical_channel, name_to_assign_to_channel=''):
         """
@@ -36,7 +36,7 @@ class AOChannelCollection(ChannelCollection):
             num_channels = len(unflatten_channel_string(physical_channel))
 
             if num_channels > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_channels-1)
             else:
                 name = name_to_assign_to_channel

--- a/generated/nidaqmx/_task_modules/channel_collection.py
+++ b/generated/nidaqmx/_task_modules/channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -23,7 +22,7 @@ class ChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
         elif isinstance(item, Channel):
             items = item.channel_names
@@ -56,15 +55,15 @@ class ChannelCollection(Sequence):
             Indicates a channel object representing the subset of virtual
             channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             channel_names = self.channel_names[index]
         elif isinstance(index, slice):
             channel_names = flatten_channel_string(self.channel_names[index])
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             channel_names = index
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access channels.'
+                'Invalid index type "{}" used to access channels.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
         if channel_names:
@@ -72,7 +71,7 @@ class ChannelCollection(Sequence):
         else:
             raise DaqError(
                 'You cannot specify an empty index when indexing channels.\n'
-                'Index used: {0}'.format(index), DAQmxErrors.UNKNOWN)
+                'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
         return hash(self._handle.value)

--- a/generated/nidaqmx/_task_modules/channels/ai_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/ai_channel.py
@@ -40,7 +40,7 @@ class AIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'AIChannel(name={0})'.format(self._name)
+        return f'AIChannel(name={self._name})'
 
     @property
     def ai_ac_excit_freq(self):

--- a/generated/nidaqmx/_task_modules/channels/ao_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/ao_channel.py
@@ -23,7 +23,7 @@ class AOChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'AOChannel(name={0})'.format(self._name)
+        return f'AOChannel(name={self._name})'
 
     @property
     def ao_common_mode_offset(self):

--- a/generated/nidaqmx/_task_modules/channels/channel.py
+++ b/generated/nidaqmx/_task_modules/channels/channel.py
@@ -13,7 +13,7 @@ from nidaqmx.constants import (
     ChannelType, SyncUnlockBehavior, _Save)
 
 
-class Channel(object):
+class Channel:
     """
     Represents virtual channel or a list of virtual channels.
     """
@@ -33,7 +33,7 @@ class Channel(object):
     def __add__(self, other):
         if not isinstance(other, self.__class__):
             raise NotImplementedError(
-                'Cannot concatenate objects of type {0} and {1}'
+                'Cannot concatenate objects of type {} and {}'
                 .format(self.__class__, other.__class__))
 
         if self._handle != other._handle:
@@ -83,7 +83,7 @@ class Channel(object):
             yield Channel._factory(self._handle, channel_name)
 
     def __repr__(self):
-        return 'Channel(name={0})'.format(self.name)
+        return f'Channel(name={self.name})'
 
     @staticmethod
     def _factory(task_handle, virtual_or_physical_name):

--- a/generated/nidaqmx/_task_modules/channels/ci_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/ci_channel.py
@@ -25,7 +25,7 @@ class CIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'CIChannel(name={0})'.format(self._name)
+        return f'CIChannel(name={self._name})'
 
     @property
     def ci_ang_encoder_initial_angle(self):

--- a/generated/nidaqmx/_task_modules/channels/co_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/co_channel.py
@@ -20,7 +20,7 @@ class COChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'COChannel(name={0})'.format(self._name)
+        return f'COChannel(name={self._name})'
 
     @property
     def co_auto_incr_cnt(self):

--- a/generated/nidaqmx/_task_modules/channels/di_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/di_channel.py
@@ -19,7 +19,7 @@ class DIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'DIChannel(name={0})'.format(self._name)
+        return f'DIChannel(name={self._name})'
 
     @property
     def di_acquire_on(self):

--- a/generated/nidaqmx/_task_modules/channels/do_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/do_channel.py
@@ -19,7 +19,7 @@ class DOChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'DOChannel(name={0})'.format(self._name)
+        return f'DOChannel(name={self._name})'
 
     @property
     def do_data_xfer_mech(self):

--- a/generated/nidaqmx/_task_modules/ci_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/ci_channel_collection.py
@@ -19,7 +19,7 @@ class CIChannelCollection(ChannelCollection):
     Contains the collection of counter input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(CIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, counter, name_to_assign_to_channel=''):
         """
@@ -39,7 +39,7 @@ class CIChannelCollection(ChannelCollection):
             num_counters = len(unflatten_channel_string(counter))
 
             if num_counters > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_counters-1)
             else:
                 name = name_to_assign_to_channel

--- a/generated/nidaqmx/_task_modules/co_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/co_channel_collection.py
@@ -17,7 +17,7 @@ class COChannelCollection(ChannelCollection):
     Contains the collection of counter output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(COChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, counter, name_to_assign_to_channel=''):
         """
@@ -37,7 +37,7 @@ class COChannelCollection(ChannelCollection):
             num_counters = len(unflatten_channel_string(counter))
 
             if num_counters > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_counters-1)
             else:
                 name = name_to_assign_to_channel

--- a/generated/nidaqmx/_task_modules/di_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/di_channel_collection.py
@@ -17,7 +17,7 @@ class DIChannelCollection(ChannelCollection):
     Contains the collection of digital input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(DIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, lines, line_grouping, name_to_assign_to_lines=''):
         """
@@ -47,7 +47,7 @@ class DIChannelCollection(ChannelCollection):
         else:
             if name_to_assign_to_lines:
                 if num_lines > 1:
-                    name = '{0}0:{1}'.format(
+                    name = '{}0:{}'.format(
                         name_to_assign_to_lines, num_lines-1)
                 else:
                     name = name_to_assign_to_lines

--- a/generated/nidaqmx/_task_modules/do_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/do_channel_collection.py
@@ -17,7 +17,7 @@ class DOChannelCollection(ChannelCollection):
     Contains the collection of digital output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(DOChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, lines, line_grouping, name_to_assign_to_lines=''):
         """
@@ -47,7 +47,7 @@ class DOChannelCollection(ChannelCollection):
         else:
             if name_to_assign_to_lines:
                 if num_lines > 1:
-                    name = '{0}0:{1}'.format(
+                    name = '{}0:{}'.format(
                         name_to_assign_to_lines, num_lines-1)
                 else:
                     name = name_to_assign_to_lines

--- a/generated/nidaqmx/_task_modules/export_signals.py
+++ b/generated/nidaqmx/_task_modules/export_signals.py
@@ -11,7 +11,7 @@ from nidaqmx.constants import (
     Signal)
 
 
-class ExportSignals(object):
+class ExportSignals:
     """
     Represents the exported signal configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -14,7 +14,7 @@ from nidaqmx.constants import (
     READ_ALL_AVAILABLE, ReadRelativeTo, WaitMode)
 
 
-class InStream(object):
+class InStream:
     """
     Exposes an input data stream on a DAQmx task.
 
@@ -27,7 +27,7 @@ class InStream(object):
         self._handle = task._handle
         self._timeout = 10.0
 
-        super(InStream, self).__init__()
+        super().__init__()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -42,7 +42,7 @@ class InStream(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'InStream(task={0})'.format(self._task.name)
+        return f'InStream(task={self._task.name})'
 
     @property
     def timeout(self):

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -11,7 +11,7 @@ from nidaqmx.constants import (
     RegenerationMode, ResolutionType, WaitMode, WriteRelativeTo)
 
 
-class OutStream(object):
+class OutStream:
     """
     Exposes an output data stream on a DAQmx task.
 
@@ -25,7 +25,7 @@ class OutStream(object):
         self._auto_start = False
         self._timeout = 10.0
 
-        super(OutStream, self).__init__()
+        super().__init__()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -41,7 +41,7 @@ class OutStream(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'OutStream(task={0})'.format(self._task.name)
+        return f'OutStream(task={self._task.name})'
 
     @property
     def auto_start(self):

--- a/generated/nidaqmx/_task_modules/timing.py
+++ b/generated/nidaqmx/_task_modules/timing.py
@@ -14,7 +14,7 @@ from nidaqmx.constants import (
     UnderflowBehavior)
 
 
-class Timing(object):
+class Timing:
     """
     Represents the timing configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggering/arm_start_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/arm_start_trigger.py
@@ -12,7 +12,7 @@ from nidaqmx.constants import (
     Edge, Timescale, TriggerType)
 
 
-class ArmStartTrigger(object):
+class ArmStartTrigger:
     """
     Represents the arm start trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggering/handshake_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/handshake_trigger.py
@@ -11,7 +11,7 @@ from nidaqmx.constants import (
     Level, TriggerType)
 
 
-class HandshakeTrigger(object):
+class HandshakeTrigger:
     """
     Represents the handshake trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggering/pause_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/pause_trigger.py
@@ -13,7 +13,7 @@ from nidaqmx.constants import (
     WindowTriggerCondition2)
 
 
-class PauseTrigger(object):
+class PauseTrigger:
     """
     Represents the pause trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
@@ -13,7 +13,7 @@ from nidaqmx.constants import (
     WindowTriggerCondition1)
 
 
-class ReferenceTrigger(object):
+class ReferenceTrigger:
     """
     Represents the reference trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggering/start_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/start_trigger.py
@@ -13,7 +13,7 @@ from nidaqmx.constants import (
     Timescale, TriggerType, WindowTriggerCondition1)
 
 
-class StartTrigger(object):
+class StartTrigger:
     """
     Represents the start trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/_task_modules/triggers.py
+++ b/generated/nidaqmx/_task_modules/triggers.py
@@ -16,7 +16,7 @@ from nidaqmx.constants import (
     SyncType)
 
 
-class Triggers(object):
+class Triggers:
     """
     Represents the trigger configurations for a DAQmx task.
     """

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -24,9 +24,9 @@ class DaqError(Error):
             error_code (int): Specifies the NI-DAQmx error code.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqError, self).__init__(message)
+        super().__init__(message)
 
         self._error_code = int(error_code)
 
@@ -63,9 +63,9 @@ class DaqReadError(DaqError):
             error_code (int): Specifies the NI-DAQmx error code.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqReadError, self).__init__(message, error_code, task_name)
+        super().__init__(message, error_code, task_name)
 
         self._error_code = int(error_code)
         self._samps_per_chan_read = samps_per_chan_read
@@ -96,9 +96,9 @@ class DaqWriteError(DaqError):
             samps_per_chan_written (int): Specifies the number of samples written.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqWriteError, self).__init__(message, error_code, task_name)
+        super().__init__(message, error_code, task_name)
 
         self._error_code = int(error_code)
         self._samps_per_chan_written = samps_per_chan_written
@@ -127,8 +127,8 @@ class DaqWarning(Warning):
             message (string): Specifies the warning message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        super(DaqWarning, self).__init__(
-            '\nWarning {0} occurred.\n\n{1}'.format(error_code, message))
+        super().__init__(
+            f'\nWarning {error_code} occurred.\n\n{message}')
 
         self._error_code = int(error_code)
 
@@ -153,20 +153,7 @@ class DaqWarning(Warning):
         return self._error_type
 
 
-class _ResourceWarning(Warning):
-    """
-    Resource warning raised by any NI-DAQmx method.
-
-    Used in place of built-in ResourceWarning to allow Python 2.7 support.
-    """
-    pass
-
-
-# If ResourceWarning is in exceptions, it is also in the built-in namespace.
-try:
-    DaqResourceWarning = ResourceWarning
-except NameError:
-    DaqResourceWarning = _ResourceWarning
+DaqResourceWarning = ResourceWarning
 
 warnings.filterwarnings("always", category=DaqWarning)
 warnings.filterwarnings("always", category=DaqResourceWarning)

--- a/generated/nidaqmx/scale.py
+++ b/generated/nidaqmx/scale.py
@@ -12,7 +12,7 @@ from nidaqmx.constants import (
 __all__ = ['Scale']
 
 
-class Scale(object):
+class Scale:
     """
     Represents a DAQmx scale.
     """
@@ -37,7 +37,7 @@ class Scale(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Scale(name={0})'.format(self._name)
+        return f'Scale(name={self._name})'
 
     @property
     def name(self):

--- a/generated/nidaqmx/stream_readers.py
+++ b/generated/nidaqmx/stream_readers.py
@@ -21,7 +21,7 @@ __all__ = ['AnalogSingleChannelReader', 'AnalogMultiChannelReader',
            'PowerSingleChannelReader', 'PowerMultiChannelReader', 'PowerBinaryReader']
 
 
-class ChannelReaderBase(object):
+class ChannelReaderBase:
     """
     Defines base class for all NI-DAQmx stream readers.
     """
@@ -95,8 +95,8 @@ class ChannelReaderBase(object):
                 'NumPy array of the correct shape based on the number of '
                 'channels in task and the number of samples per channel '
                 'requested.\n\n'
-                'Shape of NumPy Array provided: {0}\n'
-                'Shape of NumPy Array required: {1}'
+                'Shape of NumPy Array provided: {}\n'
+                'Shape of NumPy Array required: {}'
                 .format(data.shape, array_shape),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 
@@ -139,8 +139,8 @@ class ChannelReaderBase(object):
                 'NumPy array of the correct shape based on the number of '
                 'channels in task and the number of digital lines per '
                 'channel.\n\n'
-                'Shape of NumPy Array provided: {0}\n'
-                'Shape of NumPy Array required: {1}'
+                'Shape of NumPy Array provided: {}\n'
+                'Shape of NumPy Array required: {}'
                 .format(data.shape, array_shape),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 

--- a/generated/nidaqmx/stream_writers.py
+++ b/generated/nidaqmx/stream_writers.py
@@ -14,7 +14,7 @@ __all__ = ['AnalogSingleChannelWriter', 'AnalogMultiChannelWriter',
            'DigitalSingleChannelWriter', 'DigitalMultiChannelWriter']
 
 
-class UnsetAutoStartSentinel(object):
+class UnsetAutoStartSentinel:
     pass
 
 
@@ -23,7 +23,7 @@ AUTO_START_UNSET = UnsetAutoStartSentinel()
 del UnsetAutoStartSentinel
 
 
-class ChannelWriterBase(object):
+class ChannelWriterBase:
     """
     Defines base class for all NI-DAQmx stream writers.
     """
@@ -180,8 +180,8 @@ class ChannelWriterBase(object):
                 'into this function is not shaped correctly. '
                 'You must pass in a NumPy array of the correct number of '
                 'dimensions based on the write method you use.\n\n'
-                'No. of dimensions of NumPy Array provided: {0}\n'
-                'No. of dimensions of NumPy Array required: {1}'
+                'No. of dimensions of NumPy Array provided: {}\n'
+                'No. of dimensions of NumPy Array required: {}'
                 .format(num_dimensions_in_data, num_dimensions_expected),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 

--- a/generated/nidaqmx/system/_collections/device_collection.py
+++ b/generated/nidaqmx/system/_collections/device_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class DeviceCollection(Sequence):
     def __contains__(self, item):
         device_names = self.device_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in device_names for i in items])
         elif isinstance(item, Device):
@@ -51,18 +50,18 @@ class DeviceCollection(Sequence):
             
             Indicates the subset of devices indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return Device(self.device_names[index])
         elif isinstance(index, slice):
             return [Device(name) for name in self.device_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             device_names = unflatten_channel_string(index)
             if len(device_names) == 1:
                 return Device(device_names[0])
             return [Device(name) for name in device_names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/generated/nidaqmx/system/_collections/persisted_channel_collection.py
+++ b/generated/nidaqmx/system/_collections/persisted_channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.global_channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in channel_names for i in items])
         elif isinstance(item, PersistedChannel):
@@ -52,19 +51,19 @@ class PersistedChannelCollection(Sequence):
             
             Indicates the of global channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedChannel(self.global_channel_names[index])
         elif isinstance(index, slice):
             return [PersistedChannel(name) for name in
                     self.global_channel_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedChannel(names[0])
             return [PersistedChannel(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/generated/nidaqmx/system/_collections/persisted_scale_collection.py
+++ b/generated/nidaqmx/system/_collections/persisted_scale_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedScaleCollection(Sequence):
     def __contains__(self, item):
         scale_names = self.scale_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in scale_names for i in items])
         elif isinstance(item, PersistedScale):
@@ -51,19 +50,19 @@ class PersistedScaleCollection(Sequence):
             
             Indicates the subset of custom scales indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedScale(self.scale_names[index])
         elif isinstance(index, slice):
             return [PersistedScale(name) for name in
                     self.scale_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedScale(names[0])
             return [PersistedScale(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/generated/nidaqmx/system/_collections/persisted_task_collection.py
+++ b/generated/nidaqmx/system/_collections/persisted_task_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedTaskCollection(Sequence):
     def __contains__(self, item):
         task_names = self.task_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in task_names for i in items])
         elif isinstance(item, PersistedTask):
@@ -51,19 +50,19 @@ class PersistedTaskCollection(Sequence):
             
             Indicates the subset of saved tasks indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedTask(self.task_names[index])
         elif isinstance(index, slice):
             return [PersistedTask(name) for name in
                     self.task_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedTask(names[0])
             return [PersistedTask(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/generated/nidaqmx/system/_collections/physical_channel_collection.py
+++ b/generated/nidaqmx/system/_collections/physical_channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -22,7 +21,7 @@ class PhysicalChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in channel_names for i in items])
         elif isinstance(item, PhysicalChannel):
@@ -57,15 +56,15 @@ class PhysicalChannelCollection(Sequence):
             
             Indicates the subset of physical channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PhysicalChannel(self.channel_names[index])
         elif isinstance(index, slice):
             return PhysicalChannel(self.channel_names[index])
-        elif isinstance(index, six.string_types):
-            return PhysicalChannel('{0}/{1}'.format(self._name, index))
+        elif isinstance(index, str):
+            return PhysicalChannel(f'{self._name}/{index}')
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
+++ b/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
@@ -10,7 +10,7 @@ from nidaqmx.constants import (
     Level, WatchdogAOExpirState, WatchdogCOExpirState)
 
 
-class ExpirationState(object):
+class ExpirationState:
     """
     Represents a DAQmx Watchdog expiration state.
     """

--- a/generated/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
+++ b/generated/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
@@ -1,10 +1,8 @@
-import six
-
 from nidaqmx.errors import DaqError
 from nidaqmx.system._watchdog_modules.expiration_state import ExpirationState
 
 
-class ExpirationStatesCollection(object):
+class ExpirationStatesCollection:
     """
     Contains the collection of expiration states for a DAQmx Watchdog Task.
     
@@ -36,9 +34,9 @@ class ExpirationStatesCollection(object):
             
             The object representing the indexed expiration state.
         """
-        if isinstance(index, six.string_types):
+        if isinstance(index, str):
             return ExpirationState(self._handle, index)
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access expiration states.'
+                'Invalid index type "{}" used to access expiration states.'
                 .format(type(index)), -1)

--- a/generated/nidaqmx/system/device.py
+++ b/generated/nidaqmx/system/device.py
@@ -22,7 +22,7 @@ from nidaqmx.constants import (
 __all__ = ['Device']
 
 
-class Device(object):
+class Device:
     """
     Represents a DAQmx device.
     """
@@ -47,7 +47,7 @@ class Device(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Device(name={0})'.format(self._name)
+        return f'Device(name={self._name})'
 
     @property
     def name(self):

--- a/generated/nidaqmx/system/physical_channel.py
+++ b/generated/nidaqmx/system/physical_channel.py
@@ -18,7 +18,7 @@ from nidaqmx.constants import (
 __all__ = ['PhysicalChannel']
 
 
-class PhysicalChannel(object):
+class PhysicalChannel:
     """
     Represents a DAQmx physical channel.
     """
@@ -43,7 +43,7 @@ class PhysicalChannel(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PhysicalChannel(name={0})'.format(self._name)
+        return f'PhysicalChannel(name={self._name})'
 
     @property
     def name(self):

--- a/generated/nidaqmx/system/storage/persisted_channel.py
+++ b/generated/nidaqmx/system/storage/persisted_channel.py
@@ -7,7 +7,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedChannel']
 
 
-class PersistedChannel(object):
+class PersistedChannel:
     """
     Represents a saved DAQmx global channel.
 
@@ -35,7 +35,7 @@ class PersistedChannel(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedChannel(name={0})'.format(self._name)
+        return f'PersistedChannel(name={self._name})'
 
     @property
     def author(self):

--- a/generated/nidaqmx/system/storage/persisted_scale.py
+++ b/generated/nidaqmx/system/storage/persisted_scale.py
@@ -8,7 +8,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedScale']
 
 
-class PersistedScale(object):
+class PersistedScale:
     """
     Represents a saved DAQmx custom scale.
 
@@ -36,7 +36,7 @@ class PersistedScale(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedScale(name={0})'.format(self._name)
+        return f'PersistedScale(name={self._name})'
 
     @property
     def author(self):

--- a/generated/nidaqmx/system/storage/persisted_task.py
+++ b/generated/nidaqmx/system/storage/persisted_task.py
@@ -7,7 +7,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedTask']
 
 
-class PersistedTask(object):
+class PersistedTask:
     """
     Represents a saved DAQmx task.
 
@@ -35,7 +35,7 @@ class PersistedTask(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedTask(name={0})'.format(self._name)
+        return f'PersistedTask(name={self._name})'
 
     @property
     def author(self):

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -25,7 +25,7 @@ from nidaqmx.types import (
 __all__ = ['System']
 
 
-class System(object):
+class System:
     """
     Represents a DAQmx system.
 

--- a/generated/nidaqmx/system/watchdog.py
+++ b/generated/nidaqmx/system/watchdog.py
@@ -23,7 +23,7 @@ from nidaqmx.types import (
 __all__ = ['WatchdogTask']
 
 
-class WatchdogTask(object):
+class WatchdogTask:
     """
     Represents the watchdog configurations for a DAQmx task.
     """
@@ -75,7 +75,7 @@ class WatchdogTask(object):
     def __del__(self):
         if self._handle is not None:
             warnings.warn(
-                'Task of name "{0}" was not explicitly closed before it was '
+                'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '
                 'reserved.'.format(self.name), DaqResourceWarning)
 
@@ -590,7 +590,7 @@ class WatchdogTask(object):
         """
         if self._handle is None:
             warnings.warn(
-                'Attempted to close NI-DAQmx task of name "{0}" but task was '
+                'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
 

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -1,6 +1,5 @@
 import ctypes
 import numpy
-import six
 import warnings
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
@@ -43,11 +42,11 @@ from nidaqmx.utils import unflatten_channel_string, flatten_channel_string
 __all__ = ['Task']
 
 
-class UnsetNumSamplesSentinel(object):
+class UnsetNumSamplesSentinel:
     pass
 
 
-class UnsetAutoStartSentinel(object):
+class UnsetAutoStartSentinel:
     pass
 
 
@@ -58,7 +57,7 @@ del UnsetNumSamplesSentinel
 del UnsetAutoStartSentinel
 
 
-class Task(object):
+class Task:
     """
     Represents a DAQmx Task.
     """
@@ -96,7 +95,7 @@ class Task(object):
     def __del__(self):
         if self._handle:
             warnings.warn(
-                'Task of name "{0}" was not explicitly closed before it was '
+                'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '
                 'reserved.'.format(self._saved_name), DaqResourceWarning)
 
@@ -118,7 +117,7 @@ class Task(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Task(name={0})'.format(self.name)
+        return f'Task(name={self.name})'
 
     @property
     def name(self):
@@ -455,7 +454,7 @@ class Task(object):
         """
         if self._handle is None:
             warnings.warn(
-                'Attempted to close NI-DAQmx task of name "{0}" but task was '
+                'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
 
@@ -1122,8 +1121,8 @@ class Task(object):
             'If you are using boolean data, make sure the array dimension '
             'for lines in the data matches the number of lines in the '
             'channel.\n\n'
-            'Number of Lines Per Channel in Task: {0}\n'
-            'Number of Lines Per Channel in Data: {1}'
+            'Number of Lines Per Channel in Task: {}\n'
+            'Number of Lines Per Channel in Data: {}'
             .format(num_lines_expected, num_lines_in_data),
             DAQmxErrors.NUM_LINES_MISMATCH_IN_READ_OR_WRITE,
             task_name=self.name)
@@ -1137,8 +1136,8 @@ class Task(object):
             'When writing, supply data for all channels in the task. '
             'Alternatively, modify the task to contain the same number of '
             'channels as the data written.\n\n'
-            'Number of Channels in Task: {0}\n'
-            'Number of Channels in Data: {1}'
+            'Number of Channels in Task: {}\n'
+            'Number of Channels in Data: {}'
             .format(number_of_channels, number_of_channels_in_data),
             DAQmxErrors.WRITE_NUM_CHANS_MISMATCH, task_name=self.name)
 
@@ -1285,7 +1284,7 @@ class Task(object):
                         'Write failed, because this write method only accepts '
                         'boolean samples when there is one digital line per '
                         'channel in a task.\n\n'
-                        'Requested sample type: {0}'.format(type(element)),
+                        'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
 
                 data = numpy.asarray(data, dtype=bool)
@@ -1293,13 +1292,13 @@ class Task(object):
                     self._handle, data, number_of_samples_per_channel,
                     auto_start, timeout)
             else:
-                if (not isinstance(element, six.integer_types) and
+                if (not isinstance(element, int) and
                         not isinstance(element, numpy.uint32)):
                     raise DaqError(
                         'Write failed, because this write method only accepts '
                         'unsigned 32-bit integer samples when there are '
                         'multiple digital lines per channel in a task.\n\n'
-                        'Requested sample type: {0}'.format(type(element)),
+                        'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
 
                 data = numpy.asarray(data, dtype=numpy.uint32)

--- a/generated/nidaqmx/utils.py
+++ b/generated/nidaqmx/utils.py
@@ -110,10 +110,10 @@ def _channel_info_to_flattened_name(channel_info):
     if channel_info['start_index'] == -1:
         return channel_info['base_name']
     elif channel_info['start_index'] == channel_info['end_index']:
-        return '{0}{1}'.format(channel_info['base_name'],
+        return '{}{}'.format(channel_info['base_name'],
                                channel_info['start_index_str'])
     else:
-        return '{0}{1}:{2}'.format(channel_info['base_name'],
+        return '{}{}:{}'.format(channel_info['base_name'],
                                    channel_info['start_index_str'],
                                    channel_info['end_index_str'])
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,7 +547,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -781,7 +781,7 @@ docs = ["Sphinx", "sphinx_rtd_theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "9b07b576533cf85d85c5cc8bb5988d68b7d0b705aec6a8c08eb021aa47b2b462"
+content-hash = "e1712ff89fa7c687142a4d4e037ab4c13fc9ba1a6b521bea7ae8b714cd9a3c76"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ numpy = [
   {version=">=1.20,<1.22", python="<3.8"},
   {version=">=1.22", python="^3.8"},
 ]
-six = "^1.16"
 deprecation = ">=2.1"
 # This functionality was merged into python stdlib beginning in 3.8
 importlib_metadata = {version="^4.2", python="~3.7"}

--- a/src/codegen/properties/attribute.py
+++ b/src/codegen/properties/attribute.py
@@ -265,9 +265,7 @@ class Attribute:
             and self.ctypes_data_type != "ctypes.c_char_p"
             and self.bitfield_enum is None
         ):
-            argtypes.append(
-                f"wrapped_ndpointer(dtype={self.ctypes_data_type}, flags=('C','W'))"
-            )
+            argtypes.append(f"wrapped_ndpointer(dtype={self.ctypes_data_type}, flags=('C','W'))")
 
         elif self.ctypes_data_type == "ctypes.c_char_p":
             argtypes.append(self.ctypes_data_type)

--- a/src/codegen/properties/attribute.py
+++ b/src/codegen/properties/attribute.py
@@ -266,14 +266,14 @@ class Attribute:
             and self.bitfield_enum is None
         ):
             argtypes.append(
-                "wrapped_ndpointer(dtype={0}, flags=('C','W'))".format(self.ctypes_data_type)
+                f"wrapped_ndpointer(dtype={self.ctypes_data_type}, flags=('C','W'))"
             )
 
         elif self.ctypes_data_type == "ctypes.c_char_p":
             argtypes.append(self.ctypes_data_type)
 
         else:
-            argtypes.append("ctypes.POINTER({0})".format(self.ctypes_data_type))
+            argtypes.append(f"ctypes.POINTER({self.ctypes_data_type})")
 
         if self.has_explicit_read_buffer_size:
             argtypes.append("ctypes.c_uint")
@@ -294,15 +294,15 @@ class Attribute:
         """Gets the return type of attributes to be used in description."""
         constants_path = "nidaqmx.constants"
         if self.is_enum and not self.is_list:
-            return ":class:`{0}.{1}`".format(constants_path, self.enum)
+            return f":class:`{constants_path}.{self.enum}`"
         elif self.is_object and not self.is_list:
-            return ":class:`{0}.{1}`".format(self.object_module_location, self.object_type)
+            return f":class:`{self.object_module_location}.{self.object_type}`"
         elif self.is_enum and self.is_list:
-            return "List[:class:`{0}.{1}`]".format(constants_path, self.enum)
+            return f"List[:class:`{constants_path}.{self.enum}`]"
         elif self.is_object and self.is_list:
-            return "List[:class:`{0}.{1}`]".format(self.object_module_location, self.object_type)
+            return f"List[:class:`{self.object_module_location}.{self.object_type}`]"
         elif self.is_list:
-            return "List[{0}]".format(self.python_data_type)
+            return f"List[{self.python_data_type}]"
         else:
             return self.python_data_type
 

--- a/src/codegen/templates/_task_modules/ai_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/ai_channel_collection.py.mako
@@ -26,7 +26,7 @@ class AIChannelCollection(ChannelCollection):
     Contains the collection of analog input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(AIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, physical_channel, name_to_assign_to_channel=''):
         """
@@ -46,7 +46,7 @@ class AIChannelCollection(ChannelCollection):
             num_channels = len(unflatten_channel_string(physical_channel))
 
             if num_channels > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_channels-1)
             else:
                 name = name_to_assign_to_channel

--- a/src/codegen/templates/_task_modules/ao_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/ao_channel_collection.py.mako
@@ -24,7 +24,7 @@ class AOChannelCollection(ChannelCollection):
     Contains the collection of analog output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(AOChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, physical_channel, name_to_assign_to_channel=''):
         """
@@ -44,7 +44,7 @@ class AOChannelCollection(ChannelCollection):
             num_channels = len(unflatten_channel_string(physical_channel))
 
             if num_channels > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_channels-1)
             else:
                 name = name_to_assign_to_channel

--- a/src/codegen/templates/_task_modules/channels/ai_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/ai_channel.py.mako
@@ -29,7 +29,7 @@ class AIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'AIChannel(name={0})'.format(self._name)
+        return f'AIChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/channels/ao_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/ao_channel.py.mako
@@ -27,7 +27,7 @@ class AOChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'AOChannel(name={0})'.format(self._name)
+        return f'AOChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/channels/channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/channel.py.mako
@@ -20,7 +20,7 @@ from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
 
 
-class Channel(object):
+class Channel:
     """
     Represents virtual channel or a list of virtual channels.
     """
@@ -40,7 +40,7 @@ class Channel(object):
     def __add__(self, other):
         if not isinstance(other, self.__class__):
             raise NotImplementedError(
-                'Cannot concatenate objects of type {0} and {1}'
+                'Cannot concatenate objects of type {} and {}'
                 .format(self.__class__, other.__class__))
 
         if self._handle != other._handle:
@@ -90,7 +90,7 @@ class Channel(object):
             yield Channel._factory(self._handle, channel_name)
 
     def __repr__(self):
-        return 'Channel(name={0})'.format(self.name)
+        return f'Channel(name={self.name})'
 
     @staticmethod
     def _factory(task_handle, virtual_or_physical_name):

--- a/src/codegen/templates/_task_modules/channels/ci_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/ci_channel.py.mako
@@ -27,7 +27,7 @@ class CIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'CIChannel(name={0})'.format(self._name)
+        return f'CIChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/channels/co_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/co_channel.py.mako
@@ -25,7 +25,7 @@ class COChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'COChannel(name={0})'.format(self._name)
+        return f'COChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/channels/di_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/di_channel.py.mako
@@ -24,7 +24,7 @@ class DIChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'DIChannel(name={0})'.format(self._name)
+        return f'DIChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/channels/do_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/do_channel.py.mako
@@ -24,7 +24,7 @@ class DOChannel(Channel):
     __slots__ = []
 
     def __repr__(self):
-        return 'DOChannel(name={0})'.format(self._name)
+        return f'DOChannel(name={self._name})'
 
 <%namespace name="property_template" file="/property_template.py.mako"/>\
 %for attribute in attributes:

--- a/src/codegen/templates/_task_modules/ci_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/ci_channel_collection.py.mako
@@ -25,7 +25,7 @@ class CIChannelCollection(ChannelCollection):
     Contains the collection of counter input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(CIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, counter, name_to_assign_to_channel=''):
         """
@@ -45,7 +45,7 @@ class CIChannelCollection(ChannelCollection):
             num_counters = len(unflatten_channel_string(counter))
 
             if num_counters > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_counters-1)
             else:
                 name = name_to_assign_to_channel

--- a/src/codegen/templates/_task_modules/co_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/co_channel_collection.py.mako
@@ -25,7 +25,7 @@ class COChannelCollection(ChannelCollection):
     Contains the collection of counter output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(COChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, counter, name_to_assign_to_channel=''):
         """
@@ -45,7 +45,7 @@ class COChannelCollection(ChannelCollection):
             num_counters = len(unflatten_channel_string(counter))
 
             if num_counters > 1:
-                name = '{0}0:{1}'.format(
+                name = '{}0:{}'.format(
                     name_to_assign_to_channel, num_counters-1)
             else:
                 name = name_to_assign_to_channel

--- a/src/codegen/templates/_task_modules/di_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/di_channel_collection.py.mako
@@ -25,7 +25,7 @@ class DIChannelCollection(ChannelCollection):
     Contains the collection of digital input channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(DIChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, lines, line_grouping, name_to_assign_to_lines=''):
         """
@@ -55,7 +55,7 @@ class DIChannelCollection(ChannelCollection):
         else:
             if name_to_assign_to_lines:
                 if num_lines > 1:
-                    name = '{0}0:{1}'.format(
+                    name = '{}0:{}'.format(
                         name_to_assign_to_lines, num_lines-1)
                 else:
                     name = name_to_assign_to_lines

--- a/src/codegen/templates/_task_modules/do_channel_collection.py.mako
+++ b/src/codegen/templates/_task_modules/do_channel_collection.py.mako
@@ -25,7 +25,7 @@ class DOChannelCollection(ChannelCollection):
     Contains the collection of digital output channels for a DAQmx Task.
     """
     def __init__(self, task_handle):
-        super(DOChannelCollection, self).__init__(task_handle)
+        super().__init__(task_handle)
 
     def _create_chan(self, lines, line_grouping, name_to_assign_to_lines=''):
         """
@@ -55,7 +55,7 @@ class DOChannelCollection(ChannelCollection):
         else:
             if name_to_assign_to_lines:
                 if num_lines > 1:
-                    name = '{0}0:{1}'.format(
+                    name = '{}0:{}'.format(
                         name_to_assign_to_lines, num_lines-1)
                 else:
                     name = name_to_assign_to_lines

--- a/src/codegen/templates/_task_modules/export_signals.py.mako
+++ b/src/codegen/templates/_task_modules/export_signals.py.mako
@@ -24,7 +24,7 @@ from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
 
 
-class ExportSignals(object):
+class ExportSignals:
     """
     Represents the exported signal configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -20,7 +20,7 @@ from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
 
 
-class InStream(object):
+class InStream:
     """
     Exposes an input data stream on a DAQmx task.
 
@@ -33,7 +33,7 @@ class InStream(object):
         self._handle = task._handle
         self._timeout = 10.0
 
-        super(InStream, self).__init__()
+        super().__init__()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -48,7 +48,7 @@ class InStream(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'InStream(task={0})'.format(self._task.name)
+        return f'InStream(task={self._task.name})'
 
     @property
     def timeout(self):

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -18,7 +18,7 @@ from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
 
 
-class OutStream(object):
+class OutStream:
     """
     Exposes an output data stream on a DAQmx task.
 
@@ -32,7 +32,7 @@ class OutStream(object):
         self._auto_start = False
         self._timeout = 10.0
 
-        super(OutStream, self).__init__()
+        super().__init__()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -48,7 +48,7 @@ class OutStream(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'OutStream(task={0})'.format(self._task.name)
+        return f'OutStream(task={self._task.name})'
 
     @property
     def auto_start(self):

--- a/src/codegen/templates/_task_modules/timing.py.mako
+++ b/src/codegen/templates/_task_modules/timing.py.mako
@@ -27,7 +27,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class Timing(object):
+class Timing:
     """
     Represents the timing configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggering/arm_start_trigger.py.mako
+++ b/src/codegen/templates/_task_modules/triggering/arm_start_trigger.py.mako
@@ -27,7 +27,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class ArmStartTrigger(object):
+class ArmStartTrigger:
     """
     Represents the arm start trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggering/handshake_trigger.py.mako
+++ b/src/codegen/templates/_task_modules/triggering/handshake_trigger.py.mako
@@ -24,7 +24,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class HandshakeTrigger(object):
+class HandshakeTrigger:
     """
     Represents the handshake trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggering/pause_trigger.py.mako
+++ b/src/codegen/templates/_task_modules/triggering/pause_trigger.py.mako
@@ -25,7 +25,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class PauseTrigger(object):
+class PauseTrigger:
     """
     Represents the pause trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggering/reference_trigger.py.mako
+++ b/src/codegen/templates/_task_modules/triggering/reference_trigger.py.mako
@@ -25,7 +25,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class ReferenceTrigger(object):
+class ReferenceTrigger:
     """
     Represents the reference trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggering/start_trigger.py.mako
+++ b/src/codegen/templates/_task_modules/triggering/start_trigger.py.mako
@@ -26,7 +26,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class StartTrigger(object):
+class StartTrigger:
     """
     Represents the start trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/_task_modules/triggers.py.mako
+++ b/src/codegen/templates/_task_modules/triggers.py.mako
@@ -32,7 +32,7 @@ from nidaqmx.constants import (
 %endif
 
 
-class Triggers(object):
+class Triggers:
     """
     Represents the trigger configurations for a DAQmx task.
     """

--- a/src/codegen/templates/property_getter_template.py.mako
+++ b/src/codegen/templates/property_getter_template.py.mako
@@ -12,7 +12,7 @@
 <%
         instantiation_line = None
         if not attribute.has_explicit_read_buffer_size:
-            instantiation_line = 'val = {0}()'.format(attribute.ctypes_data_type)
+            instantiation_line = 'val = {}()'.format(attribute.ctypes_data_type)
     %>\
     %if instantiation_line:
         ${instantiation_line}

--- a/src/codegen/templates/property_setter_template.py.mako
+++ b/src/codegen/templates/property_setter_template.py.mako
@@ -32,7 +32,7 @@
 
         if (attribute.is_list and attribute.ctypes_data_type != 'ctypes.c_char_p' and
                 attribute.bitfield_enum is None):
-            argtypes.append("wrapped_ndpointer(dtype={0}, flags=('C','W'))"
+            argtypes.append("wrapped_ndpointer(dtype={}, flags=('C','W'))"
                             .format(attribute.ctypes_data_type))
         elif attribute.ctypes_data_type == 'ctypes.c_char_p':
             argtypes.append('ctypes_byte_str')

--- a/src/codegen/templates/scale.py.mako
+++ b/src/codegen/templates/scale.py.mako
@@ -19,7 +19,7 @@ from nidaqmx.constants import (
 __all__ = ['Scale']
 
 
-class Scale(object):
+class Scale:
     """
     Represents a DAQmx scale.
     """
@@ -44,7 +44,7 @@ class Scale(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Scale(name={0})'.format(self._name)
+        return f'Scale(name={self._name})'
 
     @property
     def name(self):

--- a/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
+++ b/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
@@ -17,7 +17,7 @@ from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
 
 
-class ExpirationState(object):
+class ExpirationState:
     """
     Represents a DAQmx Watchdog expiration state.
     """

--- a/src/codegen/templates/system/device.py.mako
+++ b/src/codegen/templates/system/device.py.mako
@@ -32,7 +32,7 @@ from nidaqmx.constants import (
 __all__ = ['Device']
 
 
-class Device(object):
+class Device:
     """
     Represents a DAQmx device.
     """
@@ -57,7 +57,7 @@ class Device(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Device(name={0})'.format(self._name)
+        return f'Device(name={self._name})'
 
     @property
     def name(self):

--- a/src/codegen/templates/system/physical_channel.py.mako
+++ b/src/codegen/templates/system/physical_channel.py.mako
@@ -30,7 +30,7 @@ from nidaqmx.constants import (
 __all__ = ['PhysicalChannel']
 
 
-class PhysicalChannel(object):
+class PhysicalChannel:
     """
     Represents a DAQmx physical channel.
     """
@@ -55,7 +55,7 @@ class PhysicalChannel(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PhysicalChannel(name={0})'.format(self._name)
+        return f'PhysicalChannel(name={self._name})'
 
     @property
     def name(self):

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -32,7 +32,7 @@ from nidaqmx.types import (
 __all__ = ['System']
 
 
-class System(object):
+class System:
     """
     Represents a DAQmx system.
 

--- a/src/codegen/templates/system/watchdog.py.mako
+++ b/src/codegen/templates/system/watchdog.py.mako
@@ -30,7 +30,7 @@ from nidaqmx.types import (
 __all__ = ['WatchdogTask']
 
 
-class WatchdogTask(object):
+class WatchdogTask:
     """
     Represents the watchdog configurations for a DAQmx task.
     """
@@ -82,7 +82,7 @@ class WatchdogTask(object):
     def __del__(self):
         if self._handle is not None:
             warnings.warn(
-                'Task of name "{0}" was not explicitly closed before it was '
+                'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '
                 'reserved.'.format(self.name), DaqResourceWarning)
 
@@ -323,7 +323,7 @@ ${property_template.script_property(attribute)}\
         """
         if self._handle is None:
             warnings.warn(
-                'Attempted to close NI-DAQmx task of name "{0}" but task was '
+                'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
 

--- a/src/codegen/utilities/function_helpers.py
+++ b/src/codegen/utilities/function_helpers.py
@@ -113,9 +113,7 @@ def get_instantiation_lines(function_parameters):
                     )
         else:
             if not param.has_explicit_buffer_size:
-                instantiation_lines.append(
-                    f"{param.parameter_name} = {param.ctypes_data_type}()"
-                )
+                instantiation_lines.append(f"{param.parameter_name} = {param.ctypes_data_type}()")
     return instantiation_lines
 
 

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -2,7 +2,6 @@ from ctypes.util import find_library
 import ctypes
 from numpy.ctypeslib import ndpointer
 import platform
-import six
 import sys
 import threading
 
@@ -37,13 +36,13 @@ class c_bool32(ctypes.c_uint):
     del _getter, _setter
 
 
-class CtypesByteString(object):
+class CtypesByteString:
     """
     Custom argtype that automatically converts unicode strings to ASCII
     strings in Python 3.
     """
     def from_param(self, param):
-        if isinstance(param, six.text_type):
+        if isinstance(param, str):
             param = param.encode('ascii')
         return ctypes.c_char_p(param)
 
@@ -117,7 +116,7 @@ def enum_list_to_bitfield(enum_list, bitfield_enum_type):
     return bitfield_value
 
 
-class DaqFunctionImporter(object):
+class DaqFunctionImporter:
     """
     Wraps the function getter function of a ctypes library.
 
@@ -139,12 +138,12 @@ class DaqFunctionImporter(object):
             return cfunc
         except AttributeError:
             raise DaqFunctionNotSupportedError(
-                'The NI-DAQmx function "{0}" is not supported in this '
+                'The NI-DAQmx function "{}" is not supported in this '
                 'version of NI-DAQmx. Visit ni.com/downloads to upgrade your '
                 'version of NI-DAQmx.'.format(function))
 
 
-class DaqLibImporter(object):
+class DaqLibImporter:
     """
     Encapsulates NI-DAQmx library importing and handle type parsing logic.
     """
@@ -216,7 +215,7 @@ class DaqLibImporter(object):
                     'contact National Instruments for support.')
         else:
             raise DaqNotFoundError(
-                'NI-DAQmx Python is not supported on this platform: {0}. '
+                'NI-DAQmx Python is not supported on this platform: {}. '
                 'Please direct any questions or feedback to National '
                 'Instruments.'.format(sys.platform))
 

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -189,19 +189,12 @@ class DaqLibImporter:
         cdll = None
 
         if sys.platform.startswith('win') or sys.platform.startswith('cli'):
-            lib_name = "nicaiu"
-
-            # Converting to ASCII to workaround issue in Python 2.7.13:
-            # https://bugs.python.org/issue29082
-            if sys.version_info < (3,):
-                lib_name = lib_name.encode('ascii')
-
             if 'iron' in platform.python_implementation().lower():
                 windll = ctypes.windll.nicaiu
                 cdll = ctypes.cdll.nicaiu
             else:
-                windll = ctypes.windll.LoadLibrary(lib_name)
-                cdll = ctypes.cdll.LoadLibrary(lib_name)
+                windll = ctypes.windll.LoadLibrary('nicaiu')
+                cdll = ctypes.cdll.LoadLibrary('nicaiu')
 
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')

--- a/src/handwritten/_task_modules/channel_collection.py
+++ b/src/handwritten/_task_modules/channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -23,7 +22,7 @@ class ChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
         elif isinstance(item, Channel):
             items = item.channel_names
@@ -56,15 +55,15 @@ class ChannelCollection(Sequence):
             Indicates a channel object representing the subset of virtual
             channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             channel_names = self.channel_names[index]
         elif isinstance(index, slice):
             channel_names = flatten_channel_string(self.channel_names[index])
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             channel_names = index
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access channels.'
+                'Invalid index type "{}" used to access channels.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
         if channel_names:
@@ -72,7 +71,7 @@ class ChannelCollection(Sequence):
         else:
             raise DaqError(
                 'You cannot specify an empty index when indexing channels.\n'
-                'Index used: {0}'.format(index), DAQmxErrors.UNKNOWN)
+                'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
         return hash(self._handle.value)

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -153,20 +153,7 @@ class DaqWarning(Warning):
         return self._error_type
 
 
-class _ResourceWarning(Warning):
-    """
-    Resource warning raised by any NI-DAQmx method.
-
-    Used in place of built-in ResourceWarning to allow Python 2.7 support.
-    """
-    pass
-
-
-# If ResourceWarning is in exceptions, it is also in the built-in namespace.
-try:
-    DaqResourceWarning = ResourceWarning
-except NameError:
-    DaqResourceWarning = _ResourceWarning
+DaqResourceWarning = ResourceWarning
 
 warnings.filterwarnings("always", category=DaqWarning)
 warnings.filterwarnings("always", category=DaqResourceWarning)

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -24,9 +24,9 @@ class DaqError(Error):
             error_code (int): Specifies the NI-DAQmx error code.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqError, self).__init__(message)
+        super().__init__(message)
 
         self._error_code = int(error_code)
 
@@ -63,9 +63,9 @@ class DaqReadError(DaqError):
             error_code (int): Specifies the NI-DAQmx error code.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqReadError, self).__init__(message, error_code, task_name)
+        super().__init__(message, error_code, task_name)
 
         self._error_code = int(error_code)
         self._samps_per_chan_read = samps_per_chan_read
@@ -96,9 +96,9 @@ class DaqWriteError(DaqError):
             samps_per_chan_written (int): Specifies the number of samples written.
         """
         if task_name:
-            message = '{0}\n\nTask Name: {1}'.format(message, task_name)
+            message = f'{message}\n\nTask Name: {task_name}'
 
-        super(DaqWriteError, self).__init__(message, error_code, task_name)
+        super().__init__(message, error_code, task_name)
 
         self._error_code = int(error_code)
         self._samps_per_chan_written = samps_per_chan_written
@@ -127,8 +127,8 @@ class DaqWarning(Warning):
             message (string): Specifies the warning message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        super(DaqWarning, self).__init__(
-            '\nWarning {0} occurred.\n\n{1}'.format(error_code, message))
+        super().__init__(
+            f'\nWarning {error_code} occurred.\n\n{message}')
 
         self._error_code = int(error_code)
 

--- a/src/handwritten/stream_readers.py
+++ b/src/handwritten/stream_readers.py
@@ -21,7 +21,7 @@ __all__ = ['AnalogSingleChannelReader', 'AnalogMultiChannelReader',
            'PowerSingleChannelReader', 'PowerMultiChannelReader', 'PowerBinaryReader']
 
 
-class ChannelReaderBase(object):
+class ChannelReaderBase:
     """
     Defines base class for all NI-DAQmx stream readers.
     """
@@ -95,8 +95,8 @@ class ChannelReaderBase(object):
                 'NumPy array of the correct shape based on the number of '
                 'channels in task and the number of samples per channel '
                 'requested.\n\n'
-                'Shape of NumPy Array provided: {0}\n'
-                'Shape of NumPy Array required: {1}'
+                'Shape of NumPy Array provided: {}\n'
+                'Shape of NumPy Array required: {}'
                 .format(data.shape, array_shape),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 
@@ -139,8 +139,8 @@ class ChannelReaderBase(object):
                 'NumPy array of the correct shape based on the number of '
                 'channels in task and the number of digital lines per '
                 'channel.\n\n'
-                'Shape of NumPy Array provided: {0}\n'
-                'Shape of NumPy Array required: {1}'
+                'Shape of NumPy Array provided: {}\n'
+                'Shape of NumPy Array required: {}'
                 .format(data.shape, array_shape),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 

--- a/src/handwritten/stream_writers.py
+++ b/src/handwritten/stream_writers.py
@@ -14,7 +14,7 @@ __all__ = ['AnalogSingleChannelWriter', 'AnalogMultiChannelWriter',
            'DigitalSingleChannelWriter', 'DigitalMultiChannelWriter']
 
 
-class UnsetAutoStartSentinel(object):
+class UnsetAutoStartSentinel:
     pass
 
 
@@ -23,7 +23,7 @@ AUTO_START_UNSET = UnsetAutoStartSentinel()
 del UnsetAutoStartSentinel
 
 
-class ChannelWriterBase(object):
+class ChannelWriterBase:
     """
     Defines base class for all NI-DAQmx stream writers.
     """
@@ -180,8 +180,8 @@ class ChannelWriterBase(object):
                 'into this function is not shaped correctly. '
                 'You must pass in a NumPy array of the correct number of '
                 'dimensions based on the write method you use.\n\n'
-                'No. of dimensions of NumPy Array provided: {0}\n'
-                'No. of dimensions of NumPy Array required: {1}'
+                'No. of dimensions of NumPy Array provided: {}\n'
+                'No. of dimensions of NumPy Array required: {}'
                 .format(num_dimensions_in_data, num_dimensions_expected),
                 DAQmxErrors.UNKNOWN, task_name=self._task.name)
 

--- a/src/handwritten/system/_collections/device_collection.py
+++ b/src/handwritten/system/_collections/device_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class DeviceCollection(Sequence):
     def __contains__(self, item):
         device_names = self.device_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in device_names for i in items])
         elif isinstance(item, Device):
@@ -51,18 +50,18 @@ class DeviceCollection(Sequence):
             
             Indicates the subset of devices indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return Device(self.device_names[index])
         elif isinstance(index, slice):
             return [Device(name) for name in self.device_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             device_names = unflatten_channel_string(index)
             if len(device_names) == 1:
                 return Device(device_names[0])
             return [Device(name) for name in device_names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/src/handwritten/system/_collections/persisted_channel_collection.py
+++ b/src/handwritten/system/_collections/persisted_channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.global_channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in channel_names for i in items])
         elif isinstance(item, PersistedChannel):
@@ -52,19 +51,19 @@ class PersistedChannelCollection(Sequence):
             
             Indicates the of global channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedChannel(self.global_channel_names[index])
         elif isinstance(index, slice):
             return [PersistedChannel(name) for name in
                     self.global_channel_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedChannel(names[0])
             return [PersistedChannel(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/src/handwritten/system/_collections/persisted_scale_collection.py
+++ b/src/handwritten/system/_collections/persisted_scale_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedScaleCollection(Sequence):
     def __contains__(self, item):
         scale_names = self.scale_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in scale_names for i in items])
         elif isinstance(item, PersistedScale):
@@ -51,19 +50,19 @@ class PersistedScaleCollection(Sequence):
             
             Indicates the subset of custom scales indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedScale(self.scale_names[index])
         elif isinstance(index, slice):
             return [PersistedScale(name) for name in
                     self.scale_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedScale(names[0])
             return [PersistedScale(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/src/handwritten/system/_collections/persisted_task_collection.py
+++ b/src/handwritten/system/_collections/persisted_task_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -19,7 +18,7 @@ class PersistedTaskCollection(Sequence):
     def __contains__(self, item):
         task_names = self.task_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in task_names for i in items])
         elif isinstance(item, PersistedTask):
@@ -51,19 +50,19 @@ class PersistedTaskCollection(Sequence):
             
             Indicates the subset of saved tasks indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PersistedTask(self.task_names[index])
         elif isinstance(index, slice):
             return [PersistedTask(name) for name in
                     self.task_names[index]]
-        elif isinstance(index, six.string_types):
+        elif isinstance(index, str):
             names = unflatten_channel_string(index)
             if len(names) == 1:
                 return PersistedTask(names[0])
             return [PersistedTask(name) for name in names]
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/src/handwritten/system/_collections/physical_channel_collection.py
+++ b/src/handwritten/system/_collections/physical_channel_collection.py
@@ -1,5 +1,4 @@
 import ctypes
-import six
 from collections.abc import Sequence
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str
@@ -22,7 +21,7 @@ class PhysicalChannelCollection(Sequence):
     def __contains__(self, item):
         channel_names = self.channel_names
 
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             items = unflatten_channel_string(item)
             return all([i in channel_names for i in items])
         elif isinstance(item, PhysicalChannel):
@@ -57,15 +56,15 @@ class PhysicalChannelCollection(Sequence):
             
             Indicates the subset of physical channels indexed.
         """
-        if isinstance(index, six.integer_types):
+        if isinstance(index, int):
             return PhysicalChannel(self.channel_names[index])
         elif isinstance(index, slice):
             return PhysicalChannel(self.channel_names[index])
-        elif isinstance(index, six.string_types):
-            return PhysicalChannel('{0}/{1}'.format(self._name, index))
+        elif isinstance(index, str):
+            return PhysicalChannel(f'{self._name}/{index}')
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access collection.'
+                'Invalid index type "{}" used to access collection.'
                 .format(type(index)), DAQmxErrors.UNKNOWN)
 
     def __iter__(self):

--- a/src/handwritten/system/_watchdog_modules/expiration_states_collection.py
+++ b/src/handwritten/system/_watchdog_modules/expiration_states_collection.py
@@ -1,10 +1,8 @@
-import six
-
 from nidaqmx.errors import DaqError
 from nidaqmx.system._watchdog_modules.expiration_state import ExpirationState
 
 
-class ExpirationStatesCollection(object):
+class ExpirationStatesCollection:
     """
     Contains the collection of expiration states for a DAQmx Watchdog Task.
     
@@ -36,9 +34,9 @@ class ExpirationStatesCollection(object):
             
             The object representing the indexed expiration state.
         """
-        if isinstance(index, six.string_types):
+        if isinstance(index, str):
             return ExpirationState(self._handle, index)
         else:
             raise DaqError(
-                'Invalid index type "{0}" used to access expiration states.'
+                'Invalid index type "{}" used to access expiration states.'
                 .format(type(index)), -1)

--- a/src/handwritten/system/storage/persisted_channel.py
+++ b/src/handwritten/system/storage/persisted_channel.py
@@ -7,7 +7,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedChannel']
 
 
-class PersistedChannel(object):
+class PersistedChannel:
     """
     Represents a saved DAQmx global channel.
 
@@ -35,7 +35,7 @@ class PersistedChannel(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedChannel(name={0})'.format(self._name)
+        return f'PersistedChannel(name={self._name})'
 
     @property
     def author(self):

--- a/src/handwritten/system/storage/persisted_scale.py
+++ b/src/handwritten/system/storage/persisted_scale.py
@@ -8,7 +8,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedScale']
 
 
-class PersistedScale(object):
+class PersistedScale:
     """
     Represents a saved DAQmx custom scale.
 
@@ -36,7 +36,7 @@ class PersistedScale(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedScale(name={0})'.format(self._name)
+        return f'PersistedScale(name={self._name})'
 
     @property
     def author(self):

--- a/src/handwritten/system/storage/persisted_task.py
+++ b/src/handwritten/system/storage/persisted_task.py
@@ -7,7 +7,7 @@ from nidaqmx.errors import (
 __all__ = ['PersistedTask']
 
 
-class PersistedTask(object):
+class PersistedTask:
     """
     Represents a saved DAQmx task.
 
@@ -35,7 +35,7 @@ class PersistedTask(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'PersistedTask(name={0})'.format(self._name)
+        return f'PersistedTask(name={self._name})'
 
     @property
     def author(self):

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1,6 +1,5 @@
 import ctypes
 import numpy
-import six
 import warnings
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
@@ -43,11 +42,11 @@ from nidaqmx.utils import unflatten_channel_string, flatten_channel_string
 __all__ = ['Task']
 
 
-class UnsetNumSamplesSentinel(object):
+class UnsetNumSamplesSentinel:
     pass
 
 
-class UnsetAutoStartSentinel(object):
+class UnsetAutoStartSentinel:
     pass
 
 
@@ -58,7 +57,7 @@ del UnsetNumSamplesSentinel
 del UnsetAutoStartSentinel
 
 
-class Task(object):
+class Task:
     """
     Represents a DAQmx Task.
     """
@@ -96,7 +95,7 @@ class Task(object):
     def __del__(self):
         if self._handle:
             warnings.warn(
-                'Task of name "{0}" was not explicitly closed before it was '
+                'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '
                 'reserved.'.format(self._saved_name), DaqResourceWarning)
 
@@ -118,7 +117,7 @@ class Task(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Task(name={0})'.format(self.name)
+        return f'Task(name={self.name})'
 
     @property
     def name(self):
@@ -455,7 +454,7 @@ class Task(object):
         """
         if self._handle is None:
             warnings.warn(
-                'Attempted to close NI-DAQmx task of name "{0}" but task was '
+                'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
 
@@ -1122,8 +1121,8 @@ class Task(object):
             'If you are using boolean data, make sure the array dimension '
             'for lines in the data matches the number of lines in the '
             'channel.\n\n'
-            'Number of Lines Per Channel in Task: {0}\n'
-            'Number of Lines Per Channel in Data: {1}'
+            'Number of Lines Per Channel in Task: {}\n'
+            'Number of Lines Per Channel in Data: {}'
             .format(num_lines_expected, num_lines_in_data),
             DAQmxErrors.NUM_LINES_MISMATCH_IN_READ_OR_WRITE,
             task_name=self.name)
@@ -1137,8 +1136,8 @@ class Task(object):
             'When writing, supply data for all channels in the task. '
             'Alternatively, modify the task to contain the same number of '
             'channels as the data written.\n\n'
-            'Number of Channels in Task: {0}\n'
-            'Number of Channels in Data: {1}'
+            'Number of Channels in Task: {}\n'
+            'Number of Channels in Data: {}'
             .format(number_of_channels, number_of_channels_in_data),
             DAQmxErrors.WRITE_NUM_CHANS_MISMATCH, task_name=self.name)
 
@@ -1285,7 +1284,7 @@ class Task(object):
                         'Write failed, because this write method only accepts '
                         'boolean samples when there is one digital line per '
                         'channel in a task.\n\n'
-                        'Requested sample type: {0}'.format(type(element)),
+                        'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
 
                 data = numpy.asarray(data, dtype=bool)
@@ -1293,13 +1292,13 @@ class Task(object):
                     self._handle, data, number_of_samples_per_channel,
                     auto_start, timeout)
             else:
-                if (not isinstance(element, six.integer_types) and
+                if (not isinstance(element, int) and
                         not isinstance(element, numpy.uint32)):
                     raise DaqError(
                         'Write failed, because this write method only accepts '
                         'unsigned 32-bit integer samples when there are '
                         'multiple digital lines per channel in a task.\n\n'
-                        'Requested sample type: {0}'.format(type(element)),
+                        'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
 
                 data = numpy.asarray(data, dtype=numpy.uint32)

--- a/src/handwritten/utils.py
+++ b/src/handwritten/utils.py
@@ -110,10 +110,10 @@ def _channel_info_to_flattened_name(channel_info):
     if channel_info['start_index'] == -1:
         return channel_info['base_name']
     elif channel_info['start_index'] == channel_info['end_index']:
-        return '{0}{1}'.format(channel_info['base_name'],
+        return '{}{}'.format(channel_info['base_name'],
                                channel_info['start_index_str'])
     else:
-        return '{0}{1}:{2}'.format(channel_info['base_name'],
+        return '{}{}:{}'.format(channel_info['base_name'],
                                    channel_info['start_index_str'],
                                    channel_info['end_index_str'])
 

--- a/tests/legacy/test_channel_creation.py
+++ b/tests/legacy/test_channel_creation.py
@@ -23,7 +23,7 @@ from nidaqmx.constants import (
 from tests.helpers import generate_random_seed
 
 
-class TestAnalogCreateChannels(object):
+class TestAnalogCreateChannels:
     """Contains a collection of pytest tests.
 
     These validate the analog Create Channel functions in the NI-DAQmx Python API.

--- a/tests/legacy/test_channels.py
+++ b/tests/legacy/test_channels.py
@@ -6,7 +6,7 @@ import nidaqmx.system
 from nidaqmx.constants import TaskMode
 
 
-class TestChannels(object):
+class TestChannels:
     """Contains a collection of pytest tests.
 
     This validate the channel objects in the NI-DAQmx Python API.

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -8,7 +8,7 @@ from nidaqmx.utils import flatten_channel_string
 from tests.helpers import generate_random_seed
 
 
-class TestContainerOperations(object):
+class TestContainerOperations:
     """Contains a collection of pytest tests.
 
     This validate the container operations in the Python NI-DAQmx API.

--- a/tests/legacy/test_events.py
+++ b/tests/legacy/test_events.py
@@ -9,7 +9,7 @@ from nidaqmx.constants import AcquisitionType
 from tests.helpers import generate_random_seed
 
 
-class TestEvents(object):
+class TestEvents:
     """Contains a collection of pytest tests.
 
     This validate the NI-DAQmx events functionality in the Python NI-DAQmx API.

--- a/tests/legacy/test_invalid_writes.py
+++ b/tests/legacy/test_invalid_writes.py
@@ -10,7 +10,7 @@ from nidaqmx.utils import flatten_channel_string
 from tests.helpers import generate_random_seed
 
 
-class TestInvalidWrites(object):
+class TestInvalidWrites:
     """Contains a collection of pytest tests.
 
     These validate the write functionality with improper data.

--- a/tests/legacy/test_lib.py
+++ b/tests/legacy/test_lib.py
@@ -9,7 +9,7 @@ def _make_driver_version(*args):
     return System.DriverVersion._make(args)
 
 
-class TestLib(object):
+class TestLib:
     """Contains a collection of pytest tests.
 
     This validates the lib loading functionality in the NI-DAQmx Python API.

--- a/tests/legacy/test_multi_threading.py
+++ b/tests/legacy/test_multi_threading.py
@@ -105,6 +105,5 @@ class TestMultiThreadedReads:
                     actor_ref.stop(timeout=(number_of_samples / sample_rate) + 10)
                 except pykka.Timeout:
                     print(
-                        "Could not stop actor {} within the specified "
-                        "timeout.".format(actor_ref)
+                        "Could not stop actor {} within the specified " "timeout.".format(actor_ref)
                     )

--- a/tests/legacy/test_multi_threading.py
+++ b/tests/legacy/test_multi_threading.py
@@ -25,7 +25,7 @@ class DAQmxReaderActor(pykka.ThreadingActor):
 
     def __init__(self, task):
         """A proxy for reading samples."""
-        super(DAQmxReaderActor, self).__init__()
+        super().__init__()
         self.task = task
 
     def read(self, samples_per_read, number_of_reads, timeout=10):
@@ -34,7 +34,7 @@ class DAQmxReaderActor(pykka.ThreadingActor):
             self.task.read(number_of_samples_per_channel=samples_per_read, timeout=timeout)
 
 
-class TestMultiThreadedReads(object):
+class TestMultiThreadedReads:
     """Contains a collection of pytest tests.
 
     This validates multi-threaded reads using the NI-DAQmx Python API.
@@ -105,6 +105,6 @@ class TestMultiThreadedReads(object):
                     actor_ref.stop(timeout=(number_of_samples / sample_rate) + 10)
                 except pykka.Timeout:
                     print(
-                        "Could not stop actor {0} within the specified "
+                        "Could not stop actor {} within the specified "
                         "timeout.".format(actor_ref)
                     )

--- a/tests/legacy/test_power_up_states.py
+++ b/tests/legacy/test_power_up_states.py
@@ -5,7 +5,7 @@ from nidaqmx.constants import PowerUpStates
 from nidaqmx.system.system import DOPowerUpState
 
 
-class TestPowerUpStates(object):
+class TestPowerUpStates:
     """Contains a collection of pytest tests.
 
     This validate the power up states functions in the Python NI-DAQmx API.

--- a/tests/legacy/test_properties.py
+++ b/tests/legacy/test_properties.py
@@ -2,7 +2,6 @@
 import random
 
 import pytest
-import six
 
 import nidaqmx
 import nidaqmx.system
@@ -11,7 +10,7 @@ from nidaqmx.constants import AcquisitionType, UsageTypeAI
 from tests.helpers import generate_random_seed
 
 
-class TestPropertyBasicDataTypes(object):
+class TestPropertyBasicDataTypes:
     """Contains a collection of pytest tests.
 
     This validates the property getter,setter and deleter methods for different basic data types.
@@ -24,7 +23,7 @@ class TestPropertyBasicDataTypes(object):
 
             task.timing.cfg_samp_clk_timing(1000)
             task.triggers.start_trigger.cfg_dig_edge_start_trig(
-                "/{0}/Ctr0InternalOutput".format(any_x_series_device.name)
+                f"/{any_x_series_device.name}/Ctr0InternalOutput"
             )
 
             # Test property initial value.
@@ -146,7 +145,7 @@ class TestPropertyBasicDataTypes(object):
             assert task.timing.samp_clk_timebase_div == 100000
 
 
-class TestPropertyListDataTypes(object):
+class TestPropertyListDataTypes:
     """Contains a collection of pytest tests.
 
     This validates the property getter, setter, and deleter methods for list data types.
@@ -159,7 +158,7 @@ class TestPropertyListDataTypes(object):
         terminals = any_x_series_device.terminals
 
         assert isinstance(terminals, list)
-        assert isinstance(terminals[0], six.string_types)
+        assert isinstance(terminals[0], str)
 
     def test_list_of_enums_property(self, any_x_series_device):
         """Test for validating list of enums property."""

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -7,7 +7,7 @@ from nidaqmx.constants import AcquisitionType, BusType, Level, TaskMode
 from nidaqmx.error_codes import DAQmxErrors
 
 
-class TestReadExceptions(object):
+class TestReadExceptions:
     """Contains a collection of pytest tests.
 
     This validates the Read error behavior in the NI-DAQmx Python API.
@@ -32,14 +32,14 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate, idle_state=Level.LOW
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
             )
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
             )
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             read_task.ai_channels.add_ai_voltage_chan(
                 real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
@@ -88,14 +88,14 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate, idle_state=Level.LOW
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
             )
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
             )
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             read_task.ai_channels.add_ai_voltage_chan(
                 real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
@@ -149,14 +149,14 @@ class TestReadExceptions(object):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate, idle_state=Level.LOW
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
             )
             sample_clk_task.timing.cfg_implicit_timing(
                 samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
             )
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             read_task.ai_channels.add_ai_voltage_chan(
                 real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -33,7 +33,7 @@ class NoFixtureDetectedError(Error):
     pass
 
 
-class TestDAQmxIOBase(object):
+class TestDAQmxIOBase:
     """Contains a collection of methods that are used in read and write tests.
 
     Classes which validate the Task Read and Write functions in the NI-DAQmx Python API
@@ -60,7 +60,7 @@ class TestDAQmxIOBase(object):
 
             loopback_channel_pairs.append(
                 TestDAQmxIOBase.ChannelPair(
-                    ao_physical_chan.name, "{0}/_{1}_vs_aognd".format(device_name, ao_channel_name)
+                    ao_physical_chan.name, f"{device_name}/_{ao_channel_name}_vs_aognd"
                 )
             )
 
@@ -167,12 +167,12 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate, idle_state=Level.LOW
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
             )
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 loopback_channel_pair.output_channel, max_val=10, min_val=-10
@@ -227,12 +227,12 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate
             )
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
             sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 flatten_channel_string([c.output_channel for c in channels_to_test]),
@@ -430,7 +430,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
 
             ci_channel = read_task.ci_channels.add_ci_count_edges_chan(counters[1])
-            ci_channel.ci_count_edges_term = "/{0}InternalOutput".format(counters[0])
+            ci_channel.ci_count_edges_term = f"/{counters[0]}InternalOutput"
 
             read_task.start()
             write_task.start()
@@ -465,7 +465,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
             sample_clk_task.control(TaskMode.TASK_COMMIT)
-            samp_clk_terminal = "/{0}InternalOutput".format(counters[0])
+            samp_clk_terminal = f"/{counters[0]}InternalOutput"
 
             write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
             write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
@@ -474,7 +474,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
 
             read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
-            read_task.ci_channels.all.ci_count_edges_term = "/{0}InternalOutput".format(counters[1])
+            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
             read_task.timing.cfg_samp_clk_timing(
                 actual_frequency,
                 source=samp_clk_terminal,
@@ -513,7 +513,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=100, max_val=1000)
-            read_task.ci_channels.all.ci_pulse_freq_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
             read_task.ci_channels.all.ci_pulse_freq_starting_edge = starting_edge
 
             read_task.start()
@@ -545,7 +545,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.001, max_val=0.01)
-            read_task.ci_channels.all.ci_pulse_time_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
             read_task.ci_channels.all.ci_pulse_time_starting_edge = starting_edge
 
             read_task.start()
@@ -573,7 +573,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                "/{0}/100kHzTimebase".format(real_x_series_device.name),
+                f"/{real_x_series_device.name}/100kHzTimebase",
                 high_ticks=high_ticks,
                 low_ticks=low_ticks,
             )
@@ -581,11 +581,11 @@ class TestCounterReadWrite(TestDAQmxIOBase):
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1],
-                source_terminal="/{0}/100kHzTimebase".format(real_x_series_device.name),
+                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
                 min_val=100,
                 max_val=1000,
             )
-            read_task.ci_channels.all.ci_pulse_ticks_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
             read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
 
             read_task.start()

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -5,7 +5,7 @@ import nidaqmx
 from nidaqmx import DaqResourceWarning
 
 
-class TestResourceWarnings(object):
+class TestResourceWarnings:
     """Contains a collection of pytest tests.
 
     These validate the ResourceWarning behavior of the Python NI-DAQmx API.

--- a/tests/legacy/test_stream_analog_readers_writers.py
+++ b/tests/legacy/test_stream_analog_readers_writers.py
@@ -87,11 +87,11 @@ class TestAnalogSingleChannelReaderWriter(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate
             )
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 loopback_channel_pair.output_channel, max_val=10, min_val=-10
@@ -202,11 +202,11 @@ class TestAnalogMultiChannelReaderWriter(TestDAQmxIOBase):
             # Use a counter output pulse train task as the sample clock source
             # for both the AI and AO tasks.
             sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                "{0}/ctr0".format(real_x_series_device.name), freq=sample_rate
+                f"{real_x_series_device.name}/ctr0", freq=sample_rate
             )
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 flatten_channel_string([c.output_channel for c in channels_to_test]),

--- a/tests/legacy/test_stream_counter_readers_writers.py
+++ b/tests/legacy/test_stream_counter_readers_writers.py
@@ -37,7 +37,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
 
             read_task.ci_channels.add_ci_count_edges_chan(counters[1])
-            read_task.ci_channels.all.ci_count_edges_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[0]}InternalOutput"
 
             reader = CounterReader(read_task.in_stream)
 
@@ -67,7 +67,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             sample_clk_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
             actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
             sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            samp_clk_terminal = "/{0}InternalOutput".format(counters[0])
+            samp_clk_terminal = f"/{counters[0]}InternalOutput"
 
             write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
             write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
@@ -76,7 +76,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
 
             read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
-            read_task.ci_channels.all.ci_count_edges_term = "/{0}InternalOutput".format(counters[1])
+            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
             read_task.timing.cfg_samp_clk_timing(
                 actual_frequency,
                 source=samp_clk_terminal,
@@ -117,7 +117,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             actual_frequency = write_task.co_channels.all.co_pulse_freq
 
             read_task.ci_channels.add_ci_freq_chan(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_freq_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_freq_term = f"/{counters[0]}InternalOutput"
 
             reader = CounterReader(read_task.in_stream)
 
@@ -147,7 +147,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             read_task.ci_channels.add_ci_freq_chan(
                 counters[2], min_val=1000, max_val=10000, edge=Edge.RISING
             )
-            read_task.ci_channels.all.ci_freq_term = "/{0}InternalOutput".format(counters[1])
+            read_task.ci_channels.all.ci_freq_term = f"/{counters[1]}InternalOutput"
             read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
             read_task.start()
@@ -184,7 +184,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_pulse_freq_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
 
             read_task.start()
             write_task.start()
@@ -214,7 +214,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.control(TaskMode.TASK_COMMIT)
 
             read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_pulse_freq_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
             read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
             frequencies_to_test = numpy.array(
@@ -267,7 +267,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
             read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
-            read_task.ci_channels.all.ci_pulse_time_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
 
             read_task.start()
             write_task.start()
@@ -296,7 +296,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
             write_task.control(TaskMode.TASK_COMMIT)
 
             read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
-            read_task.ci_channels.all.ci_pulse_time_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
             read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
             high_times_to_test = numpy.array(
@@ -346,7 +346,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                "/{0}/100kHzTimebase".format(real_x_series_device.name),
+                f"/{real_x_series_device.name}/100kHzTimebase",
                 high_ticks=high_ticks,
                 low_ticks=low_ticks,
             )
@@ -354,11 +354,11 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1],
-                source_terminal="/{0}/100kHzTimebase".format(real_x_series_device.name),
+                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
                 min_val=100,
                 max_val=1000,
             )
-            read_task.ci_channels.all.ci_pulse_ticks_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
             read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
 
             read_task.start()
@@ -385,7 +385,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
             write_task.co_channels.add_co_pulse_chan_ticks(
                 counters[0],
-                "/{0}/100kHzTimebase".format(real_x_series_device.name),
+                f"/{real_x_series_device.name}/100kHzTimebase",
                 idle_state=Level.HIGH,
             )
             write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
@@ -393,11 +393,11 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
 
             read_task.ci_channels.add_ci_pulse_chan_ticks(
                 counters[1],
-                source_terminal="/{0}/100kHzTimebase".format(real_x_series_device.name),
+                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
                 min_val=100,
                 max_val=1000,
             )
-            read_task.ci_channels.all.ci_pulse_ticks_term = "/{0}InternalOutput".format(counters[0])
+            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
             read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
             high_ticks_to_test = numpy.array(

--- a/tests/legacy/test_system_collections.py
+++ b/tests/legacy/test_system_collections.py
@@ -1,8 +1,6 @@
 """Tests for validating systems collections."""
 import collections.abc
 
-import six
-
 import nidaqmx
 import nidaqmx.system
 from nidaqmx.system._collections.device_collection import DeviceCollection
@@ -12,7 +10,7 @@ from nidaqmx.system._collections.persisted_task_collection import PersistedTaskC
 from nidaqmx.system._collections.physical_channel_collection import PhysicalChannelCollection
 
 
-class TestSystemCollections(object):
+class TestSystemCollections:
     """Contains a collection of pytest tests.
 
     These validate the system collections functionality in the NI-DAQmx Python API.
@@ -41,7 +39,7 @@ class TestSystemCollections(object):
             assert isinstance(scales[0], nidaqmx.system.storage.PersistedScale)
 
             # Test specific property on object.
-            assert isinstance(scales[0].author, six.string_types)
+            assert isinstance(scales[0].author, str)
 
     def test_persisted_task_collection_property(self):
         """Test to validate persisted task collection property."""
@@ -55,7 +53,7 @@ class TestSystemCollections(object):
             assert isinstance(tasks[0], nidaqmx.system.storage.PersistedTask)
 
             # Test specific property on object.
-            assert isinstance(tasks[0].author, six.string_types)
+            assert isinstance(tasks[0].author, str)
 
     def test_persisted_channel_collection_property(self):
         """Test to validate persisted channel collection property."""
@@ -69,7 +67,7 @@ class TestSystemCollections(object):
             assert isinstance(global_channels[0], nidaqmx.system.storage.PersistedChannel)
 
             # Test specific property on object.
-            assert isinstance(global_channels[0].author, six.string_types)
+            assert isinstance(global_channels[0].author, str)
 
     def test_physical_channel_collection_property(self, any_x_series_device):
         """Test to validate physical channel collection property."""

--- a/tests/legacy/test_task.py
+++ b/tests/legacy/test_task.py
@@ -5,7 +5,7 @@ from nidaqmx import Task, DaqError
 from nidaqmx.error_codes import DAQmxErrors
 
 
-class TestTask(object):
+class TestTask:
     """Contains a collection of pytest tests.
 
     These validate duplicate and partially constructed tasks.

--- a/tests/legacy/test_teds.py
+++ b/tests/legacy/test_teds.py
@@ -8,7 +8,7 @@ from nidaqmx.constants import TEDSUnits, TerminalConfiguration
 from tests.helpers import generate_random_seed
 
 
-class TestTEDS(object):
+class TestTEDS:
     """Contains a collection of pytest tests.
 
     These validate the TEDS functionality in the NI-DAQmx Python API.

--- a/tests/legacy/test_utils.py
+++ b/tests/legacy/test_utils.py
@@ -3,7 +3,7 @@
 from nidaqmx.utils import flatten_channel_string, unflatten_channel_string
 
 
-class TestUtils(object):
+class TestUtils:
     """Contains a collection of pytest tests.
 
     These validate the utilities functionality in the NI-DAQmx Python API.

--- a/tests/legacy/test_watchdog.py
+++ b/tests/legacy/test_watchdog.py
@@ -11,7 +11,7 @@ from nidaqmx.system.watchdog import DOExpirationState
 from tests.helpers import generate_random_seed
 
 
-class TestWatchdog(object):
+class TestWatchdog:
     """Contains a collection of pytest tests.
 
     These validate the watchdog functionality in the NI-DAQmx Python API.

--- a/tests/legacy/test_write_exceptions.py
+++ b/tests/legacy/test_write_exceptions.py
@@ -7,7 +7,7 @@ from nidaqmx.constants import AcquisitionType, BusType, RegenerationMode
 from nidaqmx.error_codes import DAQmxErrors
 
 
-class TestWriteExceptions(object):
+class TestWriteExceptions:
     """Contains a collection of pytest tests.
 
     These validate the Write error behavior in the NI-DAQmx Python API.
@@ -30,7 +30,7 @@ class TestWriteExceptions(object):
         host_buffer_size = 1000
 
         with nidaqmx.Task() as write_task:
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10
@@ -84,7 +84,7 @@ class TestWriteExceptions(object):
         total_buffer_size = fifo_size + host_buffer_size
 
         with nidaqmx.Task() as write_task:
-            samp_clk_terminal = "/{0}/Ctr0InternalOutput".format(real_x_series_device.name)
+            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
             write_task.ao_channels.add_ao_voltage_chan(
                 real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10


### PR DESCRIPTION
### What does this Pull Request accomplish?

Run `pyupgrade --py37-plus`
- [pyupgrade](https://pypi.org/project/pyupgrade/) is intended to be run from a `pre-commit` hook, but I did a one-time run with PowerShell: `get-childitem -recurse "*.py" | foreach-object { poetry run pyupgrade --py37-plus $_ }`
- For `.py.mako` files, I ran `pyupgrade` on the output and then updated the templates accordingly.
- Here's what it did:
  - Remove refererences to `six.int_types`, etc. `int`/`long` and `str`/`unicode` have been unified in Python 3.x.
  - Remove explicit inheritance from `object`. Python 3.x does not support old-style classes, so explicitly inheriting from `object` is no longer necessary to opt-in to new-style classes.
  - Remove unnecessary parameter numbers from format strings. Parameter numbers like the `0` in `{0}` are only needed when repeating a format parameter.
  - Convert simple `.format` expressions to f-strings.
  - Simplify calls to `super()`

Remove other Python 2.7 workarounds:
- `_lib.py`: Don't encode lib name as ASCII
- `errors.py`: Remove `_ResourceWarning`

Remove dependency on `six` module.

### Why should this Pull Request be merged?

Clean up vestigial Python 2.7 support.

Remove a dependency (`six`).

### What testing has been done?

Ran `poetry run pytest` with Python 3.9.
Ran tests with Tox.