### PR TITLE
tests: Do not modify persisted scale properties

### DIFF
--- a/tests/component/test_persisted_scale_properties.py
+++ b/tests/component/test_persisted_scale_properties.py
@@ -3,12 +3,34 @@ import pytest
 
 
 @pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
-def test__persisted_scale__get_bool_property__returns_value(persisted_scale):
+def test__persisted_scale__get_bool_property__returns_persisted_value(persisted_scale):
     """Test for validating bool attributes in persisted scale."""
     assert persisted_scale.allow_interactive_editing
 
 
 @pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
-def test__persisted_scale__get_string_property__returns_value(persisted_scale):
+def test__persisted_scale__get_string_property__returns_persisted_value(persisted_scale):
     """Test for validating string attributes in persisted scale."""
     assert persisted_scale.author == "Test Author"
+
+
+@pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
+def test__persisted_scale__load_and_get_float64_property__returns_persisted_value(persisted_scale):
+    """Test for validating getter for float property."""
+    assert persisted_scale.load().lin_slope == 2.0
+
+
+@pytest.mark.parametrize("persisted_scale", ["polynomial_scale"], indirect=True)
+def test__persisted_scale__load_and_get_float64_list_property__returns_persisted_value(
+    persisted_scale,
+):
+    """Test for validating getter for float list property."""
+    assert persisted_scale.load().poly_forward_coeff == [0.0, 1.0]
+
+
+@pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
+def test__persisted_scale__load_and_get_string_property__returns_persisted_value(
+    persisted_scale,
+):
+    """Test for validating getter for string property."""
+    assert persisted_scale.load().description == "Twice the gain"

--- a/tests/component/test_scale_properties.py
+++ b/tests/component/test_scale_properties.py
@@ -1,43 +1,41 @@
 "Contains collection of pytest tests that validates the scale properties."
 
-import pytest
-
 from nidaqmx.constants import UnitsPreScaled
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.scale import Scale
 
+# Do not modify persisted scale properties in this test. Persisted scales are
+# cached for the lifetime of the process, so modifying persisted scale
+# properties will affect other tests that use the same scale.
 
-@pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
-def test__persisted_scale__get_float64_property__returns_persisted_value(persisted_scale):
+
+def test__scale__get_float64_property__returns_assigned_value():
     """Test for validating getter for float property."""
-    scale = persisted_scale.load()
+    scale = Scale.create_lin_scale("custom_linear_scale", 2)
 
     assert scale.lin_slope == 2.0
 
 
-@pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
-def test__persisted_scale__set_float64_property__returns_assigned_value(persisted_scale):
+def test__scale__set_float64_property__returns_assigned_value():
     """Test for validating setter for float property."""
-    scale = persisted_scale.load()
+    scale = Scale.create_lin_scale("custom_linear_scale", 2)
 
     scale.lin_slope = 5
 
-    assert scale.lin_slope == 5
+    assert scale.lin_slope == 5.0
 
 
-@pytest.mark.parametrize("persisted_scale", ["polynomial_scale"], indirect=True)
-def test__persisted_scale__get_float64_list_property__returns_persisted_value(persisted_scale):
+def test__scale__get_float64_list_property__returns_assigned_value():
     """Test for validating getter for float list property."""
-    scale = persisted_scale.load()
+    scale = Scale.create_polynomial_scale("custom_polynomial_scale", [0, 1], [0, 1])
 
     assert scale.poly_forward_coeff == [0.0, 1.0]
 
 
-@pytest.mark.parametrize("persisted_scale", ["polynomial_scale"], indirect=True)
-def test__persisted_scale__set_float64_list_property__returns_assigned_value(persisted_scale):
+def test__scale__set_float64_list_property__returns_assigned_value():
     """Test for validating setter for float list property."""
-    scale = persisted_scale.load()
+    scale = Scale.create_polynomial_scale("custom_polynomial_scale", [0, 1], [0, 1])
 
     coeff_list = [1.0, 2.0]
     scale.poly_forward_coeff = coeff_list
@@ -47,17 +45,17 @@ def test__persisted_scale__set_float64_list_property__returns_assigned_value(per
 
 def test__linear_scale__get_poly_scale_property__throws_daqerror():
     """Test for validating getter for polynomial scale float list property in linear scale."""
-    linear_scale = Scale.create_lin_scale("custom_linear_scale", 5)
+    linear_scale = Scale.create_lin_scale("custom_linear_scale", 1)
     try:
         _ = linear_scale.poly_forward_coeff
     except DaqError as e:
         assert e.error_type == DAQmxErrors.PROPERTY_NOT_SUPPORTED_FOR_SCALE_TYPE
 
 
-def test__scale__enum_property__returns_value():
+def test__scale__get_enum_property__returns_assigned_value():
     """Test for validating getter for enum property."""
     scale = Scale.create_lin_scale(
-        "custom_linear_scale", 5, y_intercept=1, pre_scaled_units=UnitsPreScaled.VOLTS
+        "custom_linear_scale", 1, y_intercept=1, pre_scaled_units=UnitsPreScaled.VOLTS
     )
 
     assert scale.pre_scaled_units == UnitsPreScaled.VOLTS
@@ -66,7 +64,7 @@ def test__scale__enum_property__returns_value():
 def test__scale__set_enum_property__returns_assigned_value():
     """Test for validating setter for enum property."""
     scale = Scale.create_lin_scale(
-        "custom_linear_scale", 5, y_intercept=1, pre_scaled_units=UnitsPreScaled.VOLTS
+        "custom_linear_scale", 1, y_intercept=1, pre_scaled_units=UnitsPreScaled.VOLTS
     )
 
     scale.pre_scaled_units = UnitsPreScaled.AMPS
@@ -74,25 +72,17 @@ def test__scale__set_enum_property__returns_assigned_value():
     assert scale.pre_scaled_units == UnitsPreScaled.AMPS
 
 
-def test__scale__string_property__returns_value():
+def test__scale__get_string_property__returns_assigned_value():
     """Test for validating getter for string property."""
-    scale = Scale.create_polynomial_scale(
-        "Custom_Polynominal_Scale",
-        [0, 1],
-        [0, 1],
-        pre_scaled_units=UnitsPreScaled.VOLTS,
-        scaled_units="AMPS",
-    )
+    scale = Scale.create_lin_scale("custom_linear_scale", 1, scaled_units="AMPS")
 
     assert scale.scaled_units == "AMPS"
 
 
-@pytest.mark.parametrize("persisted_scale", ["double_gain_scale"], indirect=True)
-def test__persisted_scale__set_string_property__returns_assigned_value(persisted_scale):
+def test__scale__set_string_property__returns_assigned_value():
     """Test for validating setter for string property."""
-    scale = persisted_scale.load()
+    scale = Scale.create_lin_scale("custom_linear_scale", 1, scaled_units="AMPS")
 
-    description = "Scale description."
-    scale.description = description
+    scale.scaled_units = "OHMS"
 
-    assert scale.description == description
+    assert scale.scaled_units == "OHMS"

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -42,6 +42,7 @@ ScaledUnits =
 ScaleType = Linear
 Author = Test Author
 AllowInteractiveEditing = True
+Descr = Twice the gain
 
 [DAQmxScale no_scaling_scale]
 Lin.Slope = 1


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Move test cases that load a persisted scale and validate the persisted value to `test_persisted_scale_properties.py`.
- Add a description to `double_gain_scale`
- Change `test_scale_properties.py` to avoid using persisted scales.

### Why should this Pull Request be merged?

`test_scale_properties.py` is causing other tests that use persisted scales to fail. 

### What testing has been done?

Ran `poetry run pytest` with Python 3.9.