### PR TITLE
Addition of Tests for Read properties

### DIFF
--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -9,156 +9,156 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def read_task(any_x_series_device):
+def ai_task(any_x_series_device):
     """Gets AI voltage task."""
     with nidaqmx.Task() as task:
         task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
         yield task
 
 
-def test__ai_task__get_int32_property__returns_default_value(read_task: Task):
+def test__ai_task__get_int32_property__returns_default_value(ai_task: Task):
     """Test to validate getter for int32 property."""
-    assert read_task.in_stream.offset == 0
+    assert ai_task.in_stream.offset == 0
 
 
-def test__ai_task__set_int32_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_int32_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for int32 property."""
-    read_task.in_stream.offset = 1
+    ai_task.in_stream.offset = 1
 
-    assert read_task.in_stream.offset == 1
+    assert ai_task.in_stream.offset == 1
 
 
-def test__ai_task__reset_int32_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_int32_property__returns_default_value(ai_task: Task):
     """Test to validate reset for int32 property."""
-    read_task.in_stream.offset = 2
+    ai_task.in_stream.offset = 2
 
-    del read_task.in_stream.offset
+    del ai_task.in_stream.offset
 
-    assert read_task.in_stream.offset == 0
+    assert ai_task.in_stream.offset == 0
 
 
-def test__ai_task__get_enum_property__returns_default_value(read_task: Task):
+def test__ai_task__get_enum_property__returns_default_value(ai_task: Task):
     """Test to validate getter for enum property."""
-    assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
+    assert ai_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__ai_task__set_enum_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_enum_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for enum property."""
-    read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
+    ai_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
-    assert read_task.in_stream.relative_to == ReadRelativeTo.FIRST_SAMPLE
+    assert ai_task.in_stream.relative_to == ReadRelativeTo.FIRST_SAMPLE
 
 
-def test__ai_task__reset_enum_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_enum_property__returns_default_value(ai_task: Task):
     """Test to validate reset for enum property."""
-    read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
+    ai_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
-    del read_task.in_stream.relative_to
+    del ai_task.in_stream.relative_to
 
-    assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
+    assert ai_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__ai_task__get_float_property__returns_default_value(read_task: Task):
+def test__ai_task__get_float_property__returns_default_value(ai_task: Task):
     """Test to validate getter for float property."""
-    assert read_task.in_stream.sleep_time == 0.001
+    assert ai_task.in_stream.sleep_time == 0.001
 
 
-def test__ai_task__set_float_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_float_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for float property."""
-    read_task.in_stream.sleep_time = 1.5
+    ai_task.in_stream.sleep_time = 1.5
 
-    assert read_task.in_stream.sleep_time == 1.5
+    assert ai_task.in_stream.sleep_time == 1.5
 
 
-def test__ai_task__reset_float_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_float_property__returns_default_value(ai_task: Task):
     """Test to validate reset for float property."""
-    read_task.in_stream.sleep_time = 3.5
+    ai_task.in_stream.sleep_time = 3.5
 
-    del read_task.in_stream.sleep_time
+    del ai_task.in_stream.sleep_time
 
-    assert read_task.in_stream.sleep_time == 0.001
+    assert ai_task.in_stream.sleep_time == 0.001
 
 
-def test__ai_task__get_uint32_property__returns_default_value(read_task: Task):
+def test__ai_task__get_uint32_property__returns_default_value(ai_task: Task):
     """Test to validate getter for uInt32 property."""
-    assert read_task.in_stream.num_chans == 1
+    assert ai_task.in_stream.num_chans == 1
 
 
-def test__ai_task__set_uint32_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_uint32_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for uInt32 property."""
-    read_task.in_stream.logging_file_write_size = 50000
+    ai_task.in_stream.logging_file_write_size = 50000
 
-    assert read_task.in_stream.logging_file_write_size == 50000
+    assert ai_task.in_stream.logging_file_write_size == 50000
 
 
-def test__ai_task__reset_uint32_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_uint32_property__returns_default_value(ai_task: Task):
     """Test to validate reset for uInt32 property."""
-    default_value = read_task.in_stream.logging_file_write_size
-    read_task.in_stream.logging_file_write_size = 30000
+    default_value = ai_task.in_stream.logging_file_write_size
+    ai_task.in_stream.logging_file_write_size = 30000
 
-    del read_task.in_stream.logging_file_write_size
+    del ai_task.in_stream.logging_file_write_size
 
-    assert read_task.in_stream.logging_file_write_size == default_value
+    assert ai_task.in_stream.logging_file_write_size == default_value
 
 
-def test__ai_task__get_uint64_property__returns_default_value(read_task: Task):
+def test__ai_task__get_uint64_property__returns_default_value(ai_task: Task):
     """Test to validate getter for uInt64 property."""
-    assert read_task.in_stream.logging_file_preallocation_size == 0
+    assert ai_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__ai_task__set_uint64_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_uint64_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for uInt64 property."""
-    read_task.in_stream.logging_file_preallocation_size = 100
+    ai_task.in_stream.logging_file_preallocation_size = 100
 
-    assert read_task.in_stream.logging_file_preallocation_size == 100
+    assert ai_task.in_stream.logging_file_preallocation_size == 100
 
 
-def test__ai_task__reset_uint64_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_uint64_property__returns_default_value(ai_task: Task):
     """Test to validate reset for uInt64 property."""
-    read_task.in_stream.logging_file_preallocation_size = 100
+    ai_task.in_stream.logging_file_preallocation_size = 100
 
-    del read_task.in_stream.logging_file_preallocation_size
+    del ai_task.in_stream.logging_file_preallocation_size
 
-    assert read_task.in_stream.logging_file_preallocation_size == 0
+    assert ai_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__ai_task__get_bool_property__returns_default_value(read_task: Task):
+def test__ai_task__get_bool_property__returns_default_value(ai_task: Task):
     """Test to validate getter for bool property."""
-    assert not read_task.in_stream.logging_pause
+    assert not ai_task.in_stream.logging_pause
 
 
-def test__ai_task__set_bool_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_bool_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for bool property."""
-    read_task.in_stream.logging_pause = True
+    ai_task.in_stream.logging_pause = True
 
-    assert read_task.in_stream.logging_pause
+    assert ai_task.in_stream.logging_pause
 
 
-def test__ai_task__reset_bool_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_bool_property__returns_default_value(ai_task: Task):
     """Test to validate reset for bool property."""
-    read_task.in_stream.logging_pause = True
+    ai_task.in_stream.logging_pause = True
 
-    del read_task.in_stream.logging_pause
+    del ai_task.in_stream.logging_pause
 
-    assert not read_task.in_stream.logging_pause
+    assert not ai_task.in_stream.logging_pause
 
 
-def test__ai_task__get_string_property__returns_default_value(read_task: Task):
+def test__ai_task__get_string_property__returns_default_value(ai_task: Task):
     """Test to validate getter for string property."""
-    assert read_task.in_stream.logging_file_path == ""
+    assert ai_task.in_stream.logging_file_path == ""
 
 
-def test__ai_task__set_string_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_string_property__returns_assigned_value(ai_task: Task):
     """Test to validate setter for string property."""
-    read_task.in_stream.logging_file_path = "TestData.tdms"
+    ai_task.in_stream.logging_file_path = "TestData.tdms"
 
-    assert read_task.in_stream.logging_file_path == "TestData.tdms"
+    assert ai_task.in_stream.logging_file_path == "TestData.tdms"
 
 
-def test__ai_task__reset_string_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_string_property__returns_default_value(ai_task: Task):
     """Test to validate reset for string property."""
-    read_task.in_stream.logging_file_path = "TestData.tdms"
+    ai_task.in_stream.logging_file_path = "TestData.tdms"
 
-    del read_task.in_stream.logging_file_path
+    del ai_task.in_stream.logging_file_path
 
-    assert read_task.in_stream.logging_file_path == ""
+    assert ai_task.in_stream.logging_file_path == ""

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -1,0 +1,162 @@
+"""Tests for validating Read properties."""
+
+import pytest
+import nidaqmx
+import nidaqmx.system
+from nidaqmx.constants import ReadRelativeTo
+from nidaqmx.task import Task
+
+
+@pytest.fixture(scope="module")
+def read_task(any_x_series_device):
+    """Gets AI voltage task."""
+    with nidaqmx.Task() as task:
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        yield task
+
+
+def test__write__get_int32_property__returns_value(read_task: Task):
+    """Test to validate getter for int32 property."""
+    assert read_task.in_stream.offset == 0
+
+
+def test__write__set_int32_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for int32 property."""
+    read_task.in_stream.offset = 1
+
+    assert read_task.in_stream.offset == 1
+
+
+def test__write__reset_int32_property__returns_default_value(read_task: Task):
+    """Test to validate reset for int32 property."""
+    read_task.in_stream.offset = 2
+
+    del read_task.in_stream.offset
+
+    assert read_task.in_stream.offset == 0
+
+
+def test__write__get_enum_property__returns_value(read_task: Task):
+    """Test to validate getter for enum property."""
+    assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
+
+
+def test__write__set_enum_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for enum property."""
+    read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
+
+    assert read_task.in_stream.relative_to == ReadRelativeTo.FIRST_SAMPLE
+
+
+def test__write__reset_enum_property__returns_default_value(read_task: Task):
+    """Test to validate reset for enum property."""
+    read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
+
+    del read_task.in_stream.relative_to
+
+    assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
+
+
+def test__write__get_float_property__returns_value(read_task: Task):
+    """Test to validate getter for float property."""
+    assert read_task.in_stream.sleep_time == 0.001
+
+
+def test__write__set_float_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for float property."""
+    read_task.in_stream.sleep_time = 1
+
+    assert read_task.in_stream.sleep_time == 1
+
+
+def test__write__reset_float_property__returns_default_value(read_task: Task):
+    """Test to validate reset for float property."""
+    read_task.in_stream.sleep_time = 3
+
+    del read_task.in_stream.sleep_time
+
+    assert read_task.in_stream.sleep_time == 0.001
+
+
+def test__write__get_uint32_property__returns_value(read_task: Task):
+    """Test to validate getter for uInt32 property."""
+    assert read_task.in_stream.num_chans == 1
+
+
+def test__write__set_uint32_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for uInt32 property."""
+    read_task.in_stream.logging_file_write_size = 50000
+
+    assert read_task.in_stream.logging_file_write_size == 50000
+
+
+def test__write__reset_uint32_property__returns_default_value(read_task: Task):
+    """Test to validate reset for uInt32 property."""
+    read_task.in_stream.logging_file_write_size = 30000
+
+    del read_task.in_stream.logging_file_write_size
+
+    assert read_task.in_stream.logging_file_write_size == 4294967295
+
+
+def test__write__get_uint64_property__returns_value(read_task: Task):
+    """Test to validate getter for uInt64 property."""
+    assert read_task.in_stream.logging_file_preallocation_size == 0
+
+
+def test__write__set_uint64_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for uInt64 property."""
+    read_task.in_stream.logging_file_preallocation_size = 100
+
+    assert read_task.in_stream.logging_file_preallocation_size == 100
+
+
+def test__write__reset_uint64_property__returns_default_value(read_task: Task):
+    """Test to validate reset for uInt64 property."""
+    read_task.in_stream.logging_file_preallocation_size = 100
+
+    del read_task.in_stream.logging_file_preallocation_size
+
+    assert read_task.in_stream.logging_file_preallocation_size == 0
+
+
+def test__write__get_bool_property__returns_value(read_task: Task):
+    """Test to validate getter for bool property."""
+    assert not read_task.in_stream.logging_pause
+
+
+def test__write__set_bool_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for bool property."""
+    read_task.in_stream.logging_pause = True
+
+    assert read_task.in_stream.logging_pause
+
+
+def test__write__reset_bool_property__returns_default_value(read_task: Task):
+    """Test to validate reset for bool property."""
+    read_task.in_stream.logging_pause = True
+
+    del read_task.in_stream.logging_pause
+
+    assert not read_task.in_stream.logging_pause
+
+
+def test__write__get_string_property__returns_value(read_task: Task):
+    """Test to validate getter for string property."""
+    assert read_task.in_stream.logging_file_path == ""
+
+
+def test__write__set_string_property__returns_assigned_value(read_task: Task):
+    """Test to validate setter for string property."""
+    read_task.in_stream.logging_file_path = ".\\TestPath"
+
+    assert read_task.in_stream.logging_file_path == ".\\TestPath"
+
+
+def test__write__reset_string_property__returns_default_value(read_task: Task):
+    """Test to validate reset for string property."""
+    read_task.in_stream.logging_file_path = ".\\TestPath"
+
+    del read_task.in_stream.logging_file_path
+
+    assert read_task.in_stream.logging_file_path == ""

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -8,7 +8,7 @@ from nidaqmx.constants import ReadRelativeTo
 from nidaqmx.task import Task
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def read_task(any_x_series_device):
     """Gets AI voltage task."""
     with nidaqmx.Task() as task:
@@ -16,19 +16,19 @@ def read_task(any_x_series_device):
         yield task
 
 
-def test__read__get_int32_property__returns_value(read_task: Task):
+def test__ai_task__get_int32_property__returns_default_value(read_task: Task):
     """Test to validate getter for int32 property."""
     assert read_task.in_stream.offset == 0
 
 
-def test__read__set_int32_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_int32_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for int32 property."""
     read_task.in_stream.offset = 1
 
     assert read_task.in_stream.offset == 1
 
 
-def test__read__reset_int32_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_int32_property__returns_default_value(read_task: Task):
     """Test to validate reset for int32 property."""
     read_task.in_stream.offset = 2
 
@@ -37,19 +37,19 @@ def test__read__reset_int32_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.offset == 0
 
 
-def test__read__get_enum_property__returns_value(read_task: Task):
+def test__ai_task__get_enum_property__returns_default_value(read_task: Task):
     """Test to validate getter for enum property."""
     assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__read__set_enum_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_enum_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for enum property."""
     read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
     assert read_task.in_stream.relative_to == ReadRelativeTo.FIRST_SAMPLE
 
 
-def test__read__reset_enum_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_enum_property__returns_default_value(read_task: Task):
     """Test to validate reset for enum property."""
     read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
@@ -58,19 +58,19 @@ def test__read__reset_enum_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__read__get_float_property__returns_value(read_task: Task):
+def test__ai_task__get_float_property__returns_default_value(read_task: Task):
     """Test to validate getter for float property."""
     assert read_task.in_stream.sleep_time == 0.001
 
 
-def test__read__set_float_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_float_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for float property."""
     read_task.in_stream.sleep_time = 1.5
 
     assert read_task.in_stream.sleep_time == 1.5
 
 
-def test__read__reset_float_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_float_property__returns_default_value(read_task: Task):
     """Test to validate reset for float property."""
     read_task.in_stream.sleep_time = 3.5
 
@@ -79,40 +79,41 @@ def test__read__reset_float_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.sleep_time == 0.001
 
 
-def test__read__get_uint32_property__returns_value(read_task: Task):
+def test__ai_task__get_uint32_property__returns_default_value(read_task: Task):
     """Test to validate getter for uInt32 property."""
     assert read_task.in_stream.num_chans == 1
 
 
-def test__read__set_uint32_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_uint32_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for uInt32 property."""
     read_task.in_stream.logging_file_write_size = 50000
 
     assert read_task.in_stream.logging_file_write_size == 50000
 
 
-def test__read__reset_uint32_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_uint32_property__returns_default_value(read_task: Task):
     """Test to validate reset for uInt32 property."""
+    default_value = read_task.in_stream.logging_file_write_size
     read_task.in_stream.logging_file_write_size = 30000
 
     del read_task.in_stream.logging_file_write_size
 
-    assert read_task.in_stream.logging_file_write_size == 4294967295
+    assert read_task.in_stream.logging_file_write_size == default_value
 
 
-def test__read__get_uint64_property__returns_value(read_task: Task):
+def test__ai_task__get_uint64_property__returns_default_value(read_task: Task):
     """Test to validate getter for uInt64 property."""
     assert read_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__read__set_uint64_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_uint64_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for uInt64 property."""
     read_task.in_stream.logging_file_preallocation_size = 100
 
     assert read_task.in_stream.logging_file_preallocation_size == 100
 
 
-def test__read__reset_uint64_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_uint64_property__returns_default_value(read_task: Task):
     """Test to validate reset for uInt64 property."""
     read_task.in_stream.logging_file_preallocation_size = 100
 
@@ -121,19 +122,19 @@ def test__read__reset_uint64_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__read__get_bool_property__returns_value(read_task: Task):
+def test__ai_task__get_bool_property__returns_default_value(read_task: Task):
     """Test to validate getter for bool property."""
     assert not read_task.in_stream.logging_pause
 
 
-def test__read__set_bool_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_bool_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for bool property."""
     read_task.in_stream.logging_pause = True
 
     assert read_task.in_stream.logging_pause
 
 
-def test__read__reset_bool_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_bool_property__returns_default_value(read_task: Task):
     """Test to validate reset for bool property."""
     read_task.in_stream.logging_pause = True
 
@@ -142,21 +143,21 @@ def test__read__reset_bool_property__returns_default_value(read_task: Task):
     assert not read_task.in_stream.logging_pause
 
 
-def test__read__get_string_property__returns_value(read_task: Task):
+def test__ai_task__get_string_property__returns_default_value(read_task: Task):
     """Test to validate getter for string property."""
     assert read_task.in_stream.logging_file_path == ""
 
 
-def test__read__set_string_property__returns_assigned_value(read_task: Task):
+def test__ai_task__set_string_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for string property."""
-    read_task.in_stream.logging_file_path = ".\\TestPath"
+    read_task.in_stream.logging_file_path = "TestData.tdms"
 
-    assert read_task.in_stream.logging_file_path == ".\\TestPath"
+    assert read_task.in_stream.logging_file_path == "TestData.tdms"
 
 
-def test__read__reset_string_property__returns_default_value(read_task: Task):
+def test__ai_task__reset_string_property__returns_default_value(read_task: Task):
     """Test to validate reset for string property."""
-    read_task.in_stream.logging_file_path = ".\\TestPath"
+    read_task.in_stream.logging_file_path = "TestData.tdms"
 
     del read_task.in_stream.logging_file_path
 

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -8,7 +8,7 @@ from nidaqmx.constants import ReadRelativeTo
 from nidaqmx.task import Task
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def read_task(any_x_series_device):
     """Gets AI voltage task."""
     with nidaqmx.Task() as task:

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -16,19 +16,19 @@ def read_task(any_x_series_device):
         yield task
 
 
-def test__write__get_int32_property__returns_value(read_task: Task):
+def test__read__get_int32_property__returns_value(read_task: Task):
     """Test to validate getter for int32 property."""
     assert read_task.in_stream.offset == 0
 
 
-def test__write__set_int32_property__returns_assigned_value(read_task: Task):
+def test__read__set_int32_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for int32 property."""
     read_task.in_stream.offset = 1
 
     assert read_task.in_stream.offset == 1
 
 
-def test__write__reset_int32_property__returns_default_value(read_task: Task):
+def test__read__reset_int32_property__returns_default_value(read_task: Task):
     """Test to validate reset for int32 property."""
     read_task.in_stream.offset = 2
 
@@ -37,19 +37,19 @@ def test__write__reset_int32_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.offset == 0
 
 
-def test__write__get_enum_property__returns_value(read_task: Task):
+def test__read__get_enum_property__returns_value(read_task: Task):
     """Test to validate getter for enum property."""
     assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__write__set_enum_property__returns_assigned_value(read_task: Task):
+def test__read__set_enum_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for enum property."""
     read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
     assert read_task.in_stream.relative_to == ReadRelativeTo.FIRST_SAMPLE
 
 
-def test__write__reset_enum_property__returns_default_value(read_task: Task):
+def test__read__reset_enum_property__returns_default_value(read_task: Task):
     """Test to validate reset for enum property."""
     read_task.in_stream.relative_to = ReadRelativeTo.FIRST_SAMPLE
 
@@ -58,40 +58,40 @@ def test__write__reset_enum_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.relative_to == ReadRelativeTo.CURRENT_READ_POSITION
 
 
-def test__write__get_float_property__returns_value(read_task: Task):
+def test__read__get_float_property__returns_value(read_task: Task):
     """Test to validate getter for float property."""
     assert read_task.in_stream.sleep_time == 0.001
 
 
-def test__write__set_float_property__returns_assigned_value(read_task: Task):
+def test__read__set_float_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for float property."""
-    read_task.in_stream.sleep_time = 1
+    read_task.in_stream.sleep_time = 1.5
 
-    assert read_task.in_stream.sleep_time == 1
+    assert read_task.in_stream.sleep_time == 1.5
 
 
-def test__write__reset_float_property__returns_default_value(read_task: Task):
+def test__read__reset_float_property__returns_default_value(read_task: Task):
     """Test to validate reset for float property."""
-    read_task.in_stream.sleep_time = 3
+    read_task.in_stream.sleep_time = 3.5
 
     del read_task.in_stream.sleep_time
 
     assert read_task.in_stream.sleep_time == 0.001
 
 
-def test__write__get_uint32_property__returns_value(read_task: Task):
+def test__read__get_uint32_property__returns_value(read_task: Task):
     """Test to validate getter for uInt32 property."""
     assert read_task.in_stream.num_chans == 1
 
 
-def test__write__set_uint32_property__returns_assigned_value(read_task: Task):
+def test__read__set_uint32_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for uInt32 property."""
     read_task.in_stream.logging_file_write_size = 50000
 
     assert read_task.in_stream.logging_file_write_size == 50000
 
 
-def test__write__reset_uint32_property__returns_default_value(read_task: Task):
+def test__read__reset_uint32_property__returns_default_value(read_task: Task):
     """Test to validate reset for uInt32 property."""
     read_task.in_stream.logging_file_write_size = 30000
 
@@ -100,19 +100,19 @@ def test__write__reset_uint32_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.logging_file_write_size == 4294967295
 
 
-def test__write__get_uint64_property__returns_value(read_task: Task):
+def test__read__get_uint64_property__returns_value(read_task: Task):
     """Test to validate getter for uInt64 property."""
     assert read_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__write__set_uint64_property__returns_assigned_value(read_task: Task):
+def test__read__set_uint64_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for uInt64 property."""
     read_task.in_stream.logging_file_preallocation_size = 100
 
     assert read_task.in_stream.logging_file_preallocation_size == 100
 
 
-def test__write__reset_uint64_property__returns_default_value(read_task: Task):
+def test__read__reset_uint64_property__returns_default_value(read_task: Task):
     """Test to validate reset for uInt64 property."""
     read_task.in_stream.logging_file_preallocation_size = 100
 
@@ -121,19 +121,19 @@ def test__write__reset_uint64_property__returns_default_value(read_task: Task):
     assert read_task.in_stream.logging_file_preallocation_size == 0
 
 
-def test__write__get_bool_property__returns_value(read_task: Task):
+def test__read__get_bool_property__returns_value(read_task: Task):
     """Test to validate getter for bool property."""
     assert not read_task.in_stream.logging_pause
 
 
-def test__write__set_bool_property__returns_assigned_value(read_task: Task):
+def test__read__set_bool_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for bool property."""
     read_task.in_stream.logging_pause = True
 
     assert read_task.in_stream.logging_pause
 
 
-def test__write__reset_bool_property__returns_default_value(read_task: Task):
+def test__read__reset_bool_property__returns_default_value(read_task: Task):
     """Test to validate reset for bool property."""
     read_task.in_stream.logging_pause = True
 
@@ -142,19 +142,19 @@ def test__write__reset_bool_property__returns_default_value(read_task: Task):
     assert not read_task.in_stream.logging_pause
 
 
-def test__write__get_string_property__returns_value(read_task: Task):
+def test__read__get_string_property__returns_value(read_task: Task):
     """Test to validate getter for string property."""
     assert read_task.in_stream.logging_file_path == ""
 
 
-def test__write__set_string_property__returns_assigned_value(read_task: Task):
+def test__read__set_string_property__returns_assigned_value(read_task: Task):
     """Test to validate setter for string property."""
     read_task.in_stream.logging_file_path = ".\\TestPath"
 
     assert read_task.in_stream.logging_file_path == ".\\TestPath"
 
 
-def test__write__reset_string_property__returns_default_value(read_task: Task):
+def test__read__reset_string_property__returns_default_value(read_task: Task):
     """Test to validate reset for string property."""
     read_task.in_stream.logging_file_path = ".\\TestPath"
 

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -1,6 +1,7 @@
 """Tests for validating Read properties."""
 
 import pytest
+
 import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import ReadRelativeTo


### PR DESCRIPTION
**What does this Pull Request accomplish?**

- Adds Tests for testing the different datatypes of Read properties.
- The following file changes were made in the PR,
     - Added a new test file `test_read_properties.py` which contains the tests.

     - Datatypes covered (`boolean`, `enum`, `int32`, `float64`, `string`, `uInt32`, `uInt64`)
     
**Why should this Pull Request be merged?**
[Task 2330447](https://dev.azure.com/ni/DevCentral/_workitems/edit/2330447): Add or verify tests for Read Data property and related data types