### PR TITLE
codegen, tests: Roll back unnecessary deprecations and retrofit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 * ### Major Changes
     * Added a generator that produces the `nidaqmx` module code.
     * Some properties were renamed in an effort to improve the consistency of the `nidaqmx` module and to support maintainability of the generator. The previous names are still usable, but will emit a `DeprecationWarning` on usage. These deprecated properties may be removed in a future update.
+    * Unused enums have been removed. This affects enums that are solely used by DAQmx features that are not supported in the `nidaqmx` module, such as external calibration, the DAQmx switch API, and internal APIs.
     * Refactored the repository folder structure as follows:
         * `generated/nidaqmx/` - The output of the code generator and source for the build `nidaqmx` module. Do not directly modify any files in this folder.
         * `examples/` - Example programs demonstrating how to use the `nidaqmx` module.

--- a/generated/nidaqmx/_task_modules/channels/ai_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/ai_channel.py
@@ -3580,12 +3580,12 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ai_eddy_current_prox_probe_sensitivity(self):
+    def ai_eddy_current_prox_sensitivity(self):
         """
         float: Specifies the sensitivity of the eddy current proximity
             probe . This value is in the units you specify with
-            **ai_eddy_current_prox_probe_sensitivity_units**. Refer to
-            the sensor documentation to determine this value.
+            **ai_eddy_current_prox_sensitivity_units**. Refer to the
+            sensor documentation to determine this value.
         """
         val = ctypes.c_double()
 
@@ -3604,8 +3604,8 @@ class AIChannel(Channel):
 
         return val.value
 
-    @ai_eddy_current_prox_probe_sensitivity.setter
-    def ai_eddy_current_prox_probe_sensitivity(self, val):
+    @ai_eddy_current_prox_sensitivity.setter
+    def ai_eddy_current_prox_sensitivity(self, val):
         cfunc = (lib_importer.windll.
                  DAQmxSetAIEddyCurrentProxProbeSensitivity)
         if cfunc.argtypes is None:
@@ -3619,8 +3619,8 @@ class AIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ai_eddy_current_prox_probe_sensitivity.deleter
-    def ai_eddy_current_prox_probe_sensitivity(self):
+    @ai_eddy_current_prox_sensitivity.deleter
+    def ai_eddy_current_prox_sensitivity(self):
         cfunc = (lib_importer.windll.
                  DAQmxResetAIEddyCurrentProxProbeSensitivity)
         if cfunc.argtypes is None:
@@ -3634,11 +3634,10 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ai_eddy_current_prox_probe_sensitivity_units(self):
+    def ai_eddy_current_prox_sensitivity_units(self):
         """
         :class:`nidaqmx.constants.EddyCurrentProxProbeSensitivityUnits`:
-            Specifies the units of
-            **ai_eddy_current_prox_probe_sensitivity**.
+            Specifies the units of **ai_eddy_current_prox_sensitivity**.
         """
         val = ctypes.c_int()
 
@@ -3657,8 +3656,8 @@ class AIChannel(Channel):
 
         return EddyCurrentProxProbeSensitivityUnits(val.value)
 
-    @ai_eddy_current_prox_probe_sensitivity_units.setter
-    def ai_eddy_current_prox_probe_sensitivity_units(self, val):
+    @ai_eddy_current_prox_sensitivity_units.setter
+    def ai_eddy_current_prox_sensitivity_units(self, val):
         val = val.value
         cfunc = (lib_importer.windll.
                  DAQmxSetAIEddyCurrentProxProbeSensitivityUnits)
@@ -3673,8 +3672,8 @@ class AIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ai_eddy_current_prox_probe_sensitivity_units.deleter
-    def ai_eddy_current_prox_probe_sensitivity_units(self):
+    @ai_eddy_current_prox_sensitivity_units.deleter
+    def ai_eddy_current_prox_sensitivity_units(self):
         cfunc = (lib_importer.windll.
                  DAQmxResetAIEddyCurrentProxProbeSensitivityUnits)
         if cfunc.argtypes is None:
@@ -3688,7 +3687,7 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ai_eddy_current_prox_probe_units(self):
+    def ai_eddy_current_prox_units(self):
         """
         :class:`nidaqmx.constants.LengthUnits`: Specifies the units to
             use to return proximity measurements from the channel.
@@ -3709,8 +3708,8 @@ class AIChannel(Channel):
 
         return LengthUnits(val.value)
 
-    @ai_eddy_current_prox_probe_units.setter
-    def ai_eddy_current_prox_probe_units(self, val):
+    @ai_eddy_current_prox_units.setter
+    def ai_eddy_current_prox_units(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetAIEddyCurrentProxProbeUnits
         if cfunc.argtypes is None:
@@ -3724,8 +3723,8 @@ class AIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ai_eddy_current_prox_probe_units.deleter
-    def ai_eddy_current_prox_probe_units(self):
+    @ai_eddy_current_prox_units.deleter
+    def ai_eddy_current_prox_units(self):
         cfunc = lib_importer.windll.DAQmxResetAIEddyCurrentProxProbeUnits
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -5256,28 +5255,6 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ai_is_teds(self):
-        """
-        bool: Indicates if the virtual channel was initialized using a
-            TEDS bitstream from the corresponding physical channel.
-        """
-        val = c_bool32()
-
-        cfunc = lib_importer.windll.DAQmxGetAIIsTEDS
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(c_bool32)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @property
     def ai_lead_wire_resistance(self):
         """
         float: Specifies in ohms the resistance of the wires that lead
@@ -6757,7 +6734,7 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ai_rosette_strain_gage_orientation(self):
+    def ai_rosette_strain_gage_gage_orientation(self):
         """
         float: Specifies gage orientation in degrees with respect to the
             X axis.
@@ -6778,8 +6755,8 @@ class AIChannel(Channel):
 
         return val.value
 
-    @ai_rosette_strain_gage_orientation.setter
-    def ai_rosette_strain_gage_orientation(self, val):
+    @ai_rosette_strain_gage_gage_orientation.setter
+    def ai_rosette_strain_gage_gage_orientation(self, val):
         cfunc = lib_importer.windll.DAQmxSetAIRosetteStrainGageOrientation
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -6792,8 +6769,8 @@ class AIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ai_rosette_strain_gage_orientation.deleter
-    def ai_rosette_strain_gage_orientation(self):
+    @ai_rosette_strain_gage_gage_orientation.deleter
+    def ai_rosette_strain_gage_gage_orientation(self):
         cfunc = lib_importer.windll.DAQmxResetAIRosetteStrainGageOrientation
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -7676,6 +7653,55 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
+    def ai_strain_force_read_from_chan(self):
+        """
+        bool: Specifies whether the data is returned by DAQmx Read when
+            set on a raw strain channel that is part of a rosette
+            configuration.
+        """
+        val = c_bool32()
+
+        cfunc = lib_importer.windll.DAQmxGetAIStrainGageForceReadFromChan
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(c_bool32)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ai_strain_force_read_from_chan.setter
+    def ai_strain_force_read_from_chan(self, val):
+        cfunc = lib_importer.windll.DAQmxSetAIStrainGageForceReadFromChan
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ai_strain_force_read_from_chan.deleter
+    def ai_strain_force_read_from_chan(self):
+        cfunc = lib_importer.windll.DAQmxResetAIStrainGageForceReadFromChan
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
     def ai_strain_gage_cfg(self):
         """
         :class:`nidaqmx.constants.StrainGageBridgeType`: Specifies the
@@ -7715,55 +7741,6 @@ class AIChannel(Channel):
     @ai_strain_gage_cfg.deleter
     def ai_strain_gage_cfg(self):
         cfunc = lib_importer.windll.DAQmxResetAIStrainGageCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ai_strain_gage_force_read_from_chan(self):
-        """
-        bool: Specifies whether the data is returned by DAQmx Read when
-            set on a raw strain channel that is part of a rosette
-            configuration.
-        """
-        val = c_bool32()
-
-        cfunc = lib_importer.windll.DAQmxGetAIStrainGageForceReadFromChan
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(c_bool32)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ai_strain_gage_force_read_from_chan.setter
-    def ai_strain_gage_force_read_from_chan(self, val):
-        cfunc = lib_importer.windll.DAQmxSetAIStrainGageForceReadFromChan
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ai_strain_gage_force_read_from_chan.deleter
-    def ai_strain_gage_force_read_from_chan(self):
-        cfunc = lib_importer.windll.DAQmxResetAIStrainGageForceReadFromChan
         if cfunc.argtypes is None:
             with cfunc.arglock:
                 if cfunc.argtypes is None:
@@ -7923,6 +7900,28 @@ class AIChannel(Channel):
         error_code = cfunc(
             self._handle, self._name)
         check_for_error(error_code)
+
+    @property
+    def ai_teds_is_teds(self):
+        """
+        bool: Indicates if the virtual channel was initialized using a
+            TEDS bitstream from the corresponding physical channel.
+        """
+        val = c_bool32()
+
+        cfunc = lib_importer.windll.DAQmxGetAIIsTEDS
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(c_bool32)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
 
     @property
     def ai_teds_units(self):
@@ -9376,71 +9375,6 @@ class AIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity instead.")
-    def ai_eddy_current_prox_sensitivity(self):
-        return self.ai_eddy_current_prox_probe_sensitivity
-
-    @ai_eddy_current_prox_sensitivity.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity instead.")
-    def ai_eddy_current_prox_sensitivity(self, val):
-        self.ai_eddy_current_prox_probe_sensitivity = val
-
-    @ai_eddy_current_prox_sensitivity.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity instead.")
-    def ai_eddy_current_prox_sensitivity(self):
-        del self.ai_eddy_current_prox_probe_sensitivity
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity_units instead.")
-    def ai_eddy_current_prox_sensitivity_units(self):
-        return self.ai_eddy_current_prox_probe_sensitivity_units
-
-    @ai_eddy_current_prox_sensitivity_units.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity_units instead.")
-    def ai_eddy_current_prox_sensitivity_units(self, val):
-        self.ai_eddy_current_prox_probe_sensitivity_units = val
-
-    @ai_eddy_current_prox_sensitivity_units.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_sensitivity_units instead.")
-    def ai_eddy_current_prox_sensitivity_units(self):
-        del self.ai_eddy_current_prox_probe_sensitivity_units
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_units instead.")
-    def ai_eddy_current_prox_units(self):
-        return self.ai_eddy_current_prox_probe_units
-
-    @ai_eddy_current_prox_units.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_units instead.")
-    def ai_eddy_current_prox_units(self, val):
-        self.ai_eddy_current_prox_probe_units = val
-
-    @ai_eddy_current_prox_units.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_eddy_current_prox_probe_units instead.")
-    def ai_eddy_current_prox_units(self):
-        del self.ai_eddy_current_prox_probe_units
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_is_teds instead.")
-    def ai_teds_is_teds(self):
-        return self.ai_is_teds
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_rosette_strain_gage_orientation instead.")
-    def ai_rosette_strain_gage_gage_orientation(self):
-        return self.ai_rosette_strain_gage_orientation
-
-    @ai_rosette_strain_gage_gage_orientation.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_rosette_strain_gage_orientation instead.")
-    def ai_rosette_strain_gage_gage_orientation(self, val):
-        self.ai_rosette_strain_gage_orientation = val
-
-    @ai_rosette_strain_gage_gage_orientation.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_rosette_strain_gage_orientation instead.")
-    def ai_rosette_strain_gage_gage_orientation(self):
-        del self.ai_rosette_strain_gage_orientation
-
-    @property
     @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_rtd_r0 instead.")
     def ai_rtd_r_0(self):
         return self.ai_rtd_r0
@@ -9469,21 +9403,6 @@ class AIChannel(Channel):
     @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_sound_pressure_db_ref instead.")
     def ai_sound_pressured_b_ref(self):
         del self.ai_sound_pressure_db_ref
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_strain_gage_force_read_from_chan instead.")
-    def ai_strain_force_read_from_chan(self):
-        return self.ai_strain_gage_force_read_from_chan
-
-    @ai_strain_force_read_from_chan.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_strain_gage_force_read_from_chan instead.")
-    def ai_strain_force_read_from_chan(self, val):
-        self.ai_strain_gage_force_read_from_chan = val
-
-    @ai_strain_force_read_from_chan.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_strain_gage_force_read_from_chan instead.")
-    def ai_strain_force_read_from_chan(self):
-        del self.ai_strain_gage_force_read_from_chan
 
     @property
     @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_thrmstr_r1 instead.")

--- a/generated/nidaqmx/_task_modules/channels/ci_channel.py
+++ b/generated/nidaqmx/_task_modules/channels/ci_channel.py
@@ -2,7 +2,6 @@
 
 import ctypes
 import numpy
-import deprecation
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
 from nidaqmx.scale import Scale
@@ -1212,7 +1211,7 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ci_count_edges_count_reset_reset_count(self):
+    def ci_count_edges_count_reset_reset_cnt(self):
         """
         int: Specifies the value to reset the count to.
         """
@@ -1232,8 +1231,8 @@ class CIChannel(Channel):
 
         return val.value
 
-    @ci_count_edges_count_reset_reset_count.setter
-    def ci_count_edges_count_reset_reset_count(self, val):
+    @ci_count_edges_count_reset_reset_cnt.setter
+    def ci_count_edges_count_reset_reset_cnt(self, val):
         cfunc = lib_importer.windll.DAQmxSetCICountEdgesCountResetResetCount
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -1246,8 +1245,8 @@ class CIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ci_count_edges_count_reset_reset_count.deleter
-    def ci_count_edges_count_reset_reset_count(self):
+    @ci_count_edges_count_reset_reset_cnt.deleter
+    def ci_count_edges_count_reset_reset_cnt(self):
         cfunc = lib_importer.windll.DAQmxResetCICountEdgesCountResetResetCount
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -7759,7 +7758,7 @@ class CIChannel(Channel):
             terminal and when that signal has a higher frequency than
             the fastest onboard timebase. Setting this value disables
             duplicate count prevention unless you explicitly set
-            **ci_dup_count_prevent** to True.
+            **ci_dup_count_prevention** to True.
         """
         val = ctypes.c_uint()
 
@@ -8112,7 +8111,7 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ci_pulse_freq_start_edge(self):
+    def ci_pulse_freq_starting_edge(self):
         """
         :class:`nidaqmx.constants.Edge`: Specifies on which edge of the
             input signal to begin pulse measurement.
@@ -8133,8 +8132,8 @@ class CIChannel(Channel):
 
         return Edge(val.value)
 
-    @ci_pulse_freq_start_edge.setter
-    def ci_pulse_freq_start_edge(self, val):
+    @ci_pulse_freq_starting_edge.setter
+    def ci_pulse_freq_starting_edge(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetCIPulseFreqStartEdge
         if cfunc.argtypes is None:
@@ -8148,8 +8147,8 @@ class CIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ci_pulse_freq_start_edge.deleter
-    def ci_pulse_freq_start_edge(self):
+    @ci_pulse_freq_starting_edge.deleter
+    def ci_pulse_freq_starting_edge(self):
         cfunc = lib_importer.windll.DAQmxResetCIPulseFreqStartEdge
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -8629,7 +8628,7 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ci_pulse_ticks_start_edge(self):
+    def ci_pulse_ticks_starting_edge(self):
         """
         :class:`nidaqmx.constants.Edge`: Specifies on which edge of the
             input signal to begin pulse measurement.
@@ -8650,8 +8649,8 @@ class CIChannel(Channel):
 
         return Edge(val.value)
 
-    @ci_pulse_ticks_start_edge.setter
-    def ci_pulse_ticks_start_edge(self, val):
+    @ci_pulse_ticks_starting_edge.setter
+    def ci_pulse_ticks_starting_edge(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetCIPulseTicksStartEdge
         if cfunc.argtypes is None:
@@ -8665,8 +8664,8 @@ class CIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ci_pulse_ticks_start_edge.deleter
-    def ci_pulse_ticks_start_edge(self):
+    @ci_pulse_ticks_starting_edge.deleter
+    def ci_pulse_ticks_starting_edge(self):
         cfunc = lib_importer.windll.DAQmxResetCIPulseTicksStartEdge
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -9096,7 +9095,7 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
-    def ci_pulse_time_start_edge(self):
+    def ci_pulse_time_starting_edge(self):
         """
         :class:`nidaqmx.constants.Edge`: Specifies on which edge of the
             input signal to begin pulse measurement.
@@ -9117,8 +9116,8 @@ class CIChannel(Channel):
 
         return Edge(val.value)
 
-    @ci_pulse_time_start_edge.setter
-    def ci_pulse_time_start_edge(self, val):
+    @ci_pulse_time_starting_edge.setter
+    def ci_pulse_time_starting_edge(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetCIPulseTimeStartEdge
         if cfunc.argtypes is None:
@@ -9132,8 +9131,8 @@ class CIChannel(Channel):
             self._handle, self._name, val)
         check_for_error(error_code)
 
-    @ci_pulse_time_start_edge.deleter
-    def ci_pulse_time_start_edge(self):
+    @ci_pulse_time_starting_edge.deleter
+    def ci_pulse_time_starting_edge(self):
         cfunc = lib_importer.windll.DAQmxResetCIPulseTimeStartEdge
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -11725,6 +11724,389 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
+    def ci_velocity_a_input_dig_fltr_enable(self):
+        """
+        bool: Specifies whether to apply the pulse width filter to the
+            signal.
+        """
+        val = c_bool32()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderAInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(c_bool32)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_a_input_dig_fltr_enable.setter
+    def ci_velocity_a_input_dig_fltr_enable(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderAInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_dig_fltr_enable.deleter
+    def ci_velocity_a_input_dig_fltr_enable(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderAInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_dig_fltr_min_pulse_width(self):
+        """
+        float: Specifies in seconds the minimum pulse width the digital
+            filter recognizes.
+        """
+        val = ctypes.c_double()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderAInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_double)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_a_input_dig_fltr_min_pulse_width.setter
+    def ci_velocity_a_input_dig_fltr_min_pulse_width(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderAInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_double]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_dig_fltr_min_pulse_width.deleter
+    def ci_velocity_a_input_dig_fltr_min_pulse_width(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderAInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_dig_fltr_timebase_rate(self):
+        """
+        float: Specifies in hertz the rate of the pulse width filter
+            timebase. NI-DAQmx uses this value to compute settings for
+            the filter.
+        """
+        val = ctypes.c_double()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderAInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_double)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_a_input_dig_fltr_timebase_rate.setter
+    def ci_velocity_a_input_dig_fltr_timebase_rate(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderAInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_double]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_dig_fltr_timebase_rate.deleter
+    def ci_velocity_a_input_dig_fltr_timebase_rate(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderAInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_dig_fltr_timebase_src(self):
+        """
+        str: Specifies the input terminal of the signal to use as the
+            timebase of the pulse width filter.
+        """
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderAInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_char_p, ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = ctypes.create_string_buffer(temp_size)
+
+            size_or_code = cfunc(
+                self._handle, self._name, val, temp_size)
+
+            if is_string_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return val.value.decode('ascii')
+
+    @ci_velocity_a_input_dig_fltr_timebase_src.setter
+    def ci_velocity_a_input_dig_fltr_timebase_src(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderAInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_dig_fltr_timebase_src.deleter
+    def ci_velocity_a_input_dig_fltr_timebase_src(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderAInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_logic_lvl_behavior(self):
+        """
+        :class:`nidaqmx.constants.LogicLvlBehavior`: Specifies the logic
+            level behavior of the input terminal.
+        """
+        val = ctypes.c_int()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderAInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_int)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return LogicLvlBehavior(val.value)
+
+    @ci_velocity_a_input_logic_lvl_behavior.setter
+    def ci_velocity_a_input_logic_lvl_behavior(self, val):
+        val = val.value
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderAInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_int]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_logic_lvl_behavior.deleter
+    def ci_velocity_a_input_logic_lvl_behavior(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderAInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_term(self):
+        """
+        str: Specifies the terminal to which signal A is connected.
+        """
+        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderAInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_char_p, ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = ctypes.create_string_buffer(temp_size)
+
+            size_or_code = cfunc(
+                self._handle, self._name, val, temp_size)
+
+            if is_string_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return val.value.decode('ascii')
+
+    @ci_velocity_a_input_term.setter
+    def ci_velocity_a_input_term(self, val):
+        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderAInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_term.deleter
+    def ci_velocity_a_input_term(self):
+        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderAInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_a_input_term_cfg(self):
+        """
+        :class:`nidaqmx.constants.TerminalConfiguration`: Specifies the
+            input terminal configuration.
+        """
+        val = ctypes.c_int()
+
+        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderAInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_int)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return TerminalConfiguration(val.value)
+
+    @ci_velocity_a_input_term_cfg.setter
+    def ci_velocity_a_input_term_cfg(self, val):
+        val = val.value
+        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderAInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_int]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_a_input_term_cfg.deleter
+    def ci_velocity_a_input_term_cfg(self):
+        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderAInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
     def ci_velocity_ang_encoder_pulses_per_rev(self):
         """
         int: Specifies the number of pulses the encoder generates per
@@ -11827,6 +12209,389 @@ class CIChannel(Channel):
         check_for_error(error_code)
 
     @property
+    def ci_velocity_b_input_dig_fltr_enable(self):
+        """
+        bool: Specifies whether to apply the pulse width filter to the
+            signal.
+        """
+        val = c_bool32()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderBInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(c_bool32)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_b_input_dig_fltr_enable.setter
+    def ci_velocity_b_input_dig_fltr_enable(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderBInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_dig_fltr_enable.deleter
+    def ci_velocity_b_input_dig_fltr_enable(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderBInputDigFltrEnable)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_dig_fltr_min_pulse_width(self):
+        """
+        float: Specifies in seconds the minimum pulse width the digital
+            filter recognizes.
+        """
+        val = ctypes.c_double()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderBInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_double)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_b_input_dig_fltr_min_pulse_width.setter
+    def ci_velocity_b_input_dig_fltr_min_pulse_width(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderBInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_double]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_dig_fltr_min_pulse_width.deleter
+    def ci_velocity_b_input_dig_fltr_min_pulse_width(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderBInputDigFltrMinPulseWidth)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_dig_fltr_timebase_rate(self):
+        """
+        float: Specifies in hertz the rate of the pulse width filter
+            timebase. NI-DAQmx uses this value to compute settings for
+            the filter.
+        """
+        val = ctypes.c_double()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderBInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_double)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return val.value
+
+    @ci_velocity_b_input_dig_fltr_timebase_rate.setter
+    def ci_velocity_b_input_dig_fltr_timebase_rate(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderBInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_double]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_dig_fltr_timebase_rate.deleter
+    def ci_velocity_b_input_dig_fltr_timebase_rate(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderBInputDigFltrTimebaseRate)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_dig_fltr_timebase_src(self):
+        """
+        str: Specifies the input terminal of the signal to use as the
+            timebase of the pulse width filter.
+        """
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderBInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_char_p, ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = ctypes.create_string_buffer(temp_size)
+
+            size_or_code = cfunc(
+                self._handle, self._name, val, temp_size)
+
+            if is_string_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return val.value.decode('ascii')
+
+    @ci_velocity_b_input_dig_fltr_timebase_src.setter
+    def ci_velocity_b_input_dig_fltr_timebase_src(self, val):
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderBInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_dig_fltr_timebase_src.deleter
+    def ci_velocity_b_input_dig_fltr_timebase_src(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderBInputDigFltrTimebaseSrc)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_logic_lvl_behavior(self):
+        """
+        :class:`nidaqmx.constants.LogicLvlBehavior`: Specifies the logic
+            level behavior of the input terminal.
+        """
+        val = ctypes.c_int()
+
+        cfunc = (lib_importer.windll.
+                 DAQmxGetCIVelocityEncoderBInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_int)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return LogicLvlBehavior(val.value)
+
+    @ci_velocity_b_input_logic_lvl_behavior.setter
+    def ci_velocity_b_input_logic_lvl_behavior(self, val):
+        val = val.value
+        cfunc = (lib_importer.windll.
+                 DAQmxSetCIVelocityEncoderBInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_int]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_logic_lvl_behavior.deleter
+    def ci_velocity_b_input_logic_lvl_behavior(self):
+        cfunc = (lib_importer.windll.
+                 DAQmxResetCIVelocityEncoderBInputLogicLvlBehavior)
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_term(self):
+        """
+        str: Specifies the terminal to which signal B is connected.
+        """
+        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderBInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_char_p, ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = ctypes.create_string_buffer(temp_size)
+
+            size_or_code = cfunc(
+                self._handle, self._name, val, temp_size)
+
+            if is_string_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return val.value.decode('ascii')
+
+    @ci_velocity_b_input_term.setter
+    def ci_velocity_b_input_term(self, val):
+        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderBInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_term.deleter
+    def ci_velocity_b_input_term(self):
+        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderBInputTerm
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
+    def ci_velocity_b_input_term_cfg(self):
+        """
+        :class:`nidaqmx.constants.TerminalConfiguration`: Specifies the
+            input terminal configuration.
+        """
+        val = ctypes.c_int()
+
+        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderBInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.POINTER(ctypes.c_int)]
+
+        error_code = cfunc(
+            self._handle, self._name, ctypes.byref(val))
+        check_for_error(error_code)
+
+        return TerminalConfiguration(val.value)
+
+    @ci_velocity_b_input_term_cfg.setter
+    def ci_velocity_b_input_term_cfg(self, val):
+        val = val.value
+        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderBInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        ctypes.c_int]
+
+        error_code = cfunc(
+            self._handle, self._name, val)
+        check_for_error(error_code)
+
+    @ci_velocity_b_input_term_cfg.deleter
+    def ci_velocity_b_input_term_cfg(self):
+        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderBInputTermCfg
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str]
+
+        error_code = cfunc(
+            self._handle, self._name)
+        check_for_error(error_code)
+
+    @property
     def ci_velocity_div(self):
         """
         int: Specifies the value by which to divide the input signal.
@@ -11864,772 +12629,6 @@ class CIChannel(Channel):
     @ci_velocity_div.deleter
     def ci_velocity_div(self):
         cfunc = lib_importer.windll.DAQmxResetCIVelocityDiv
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_dig_fltr_enable(self):
-        """
-        bool: Specifies whether to apply the pulse width filter to the
-            signal.
-        """
-        val = c_bool32()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderAInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(c_bool32)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_a_input_dig_fltr_enable.setter
-    def ci_velocity_encoder_a_input_dig_fltr_enable(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderAInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_dig_fltr_enable.deleter
-    def ci_velocity_encoder_a_input_dig_fltr_enable(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderAInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_dig_fltr_min_pulse_width(self):
-        """
-        float: Specifies in seconds the minimum pulse width the digital
-            filter recognizes.
-        """
-        val = ctypes.c_double()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderAInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_double)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_a_input_dig_fltr_min_pulse_width.setter
-    def ci_velocity_encoder_a_input_dig_fltr_min_pulse_width(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderAInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_double]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_dig_fltr_min_pulse_width.deleter
-    def ci_velocity_encoder_a_input_dig_fltr_min_pulse_width(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderAInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_rate(self):
-        """
-        float: Specifies in hertz the rate of the pulse width filter
-            timebase. NI-DAQmx uses this value to compute settings for
-            the filter.
-        """
-        val = ctypes.c_double()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderAInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_double)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_a_input_dig_fltr_timebase_rate.setter
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_rate(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderAInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_double]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_dig_fltr_timebase_rate.deleter
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_rate(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderAInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_src(self):
-        """
-        str: Specifies the input terminal of the signal to use as the
-            timebase of the pulse width filter.
-        """
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderAInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_char_p, ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = ctypes.create_string_buffer(temp_size)
-
-            size_or_code = cfunc(
-                self._handle, self._name, val, temp_size)
-
-            if is_string_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return val.value.decode('ascii')
-
-    @ci_velocity_encoder_a_input_dig_fltr_timebase_src.setter
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_src(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderAInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_dig_fltr_timebase_src.deleter
-    def ci_velocity_encoder_a_input_dig_fltr_timebase_src(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderAInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_logic_lvl_behavior(self):
-        """
-        :class:`nidaqmx.constants.LogicLvlBehavior`: Specifies the logic
-            level behavior of the input terminal.
-        """
-        val = ctypes.c_int()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderAInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_int)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return LogicLvlBehavior(val.value)
-
-    @ci_velocity_encoder_a_input_logic_lvl_behavior.setter
-    def ci_velocity_encoder_a_input_logic_lvl_behavior(self, val):
-        val = val.value
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderAInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_int]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_logic_lvl_behavior.deleter
-    def ci_velocity_encoder_a_input_logic_lvl_behavior(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderAInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_term(self):
-        """
-        str: Specifies the terminal to which signal A is connected.
-        """
-        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderAInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_char_p, ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = ctypes.create_string_buffer(temp_size)
-
-            size_or_code = cfunc(
-                self._handle, self._name, val, temp_size)
-
-            if is_string_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return val.value.decode('ascii')
-
-    @ci_velocity_encoder_a_input_term.setter
-    def ci_velocity_encoder_a_input_term(self, val):
-        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderAInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_term.deleter
-    def ci_velocity_encoder_a_input_term(self):
-        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderAInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_a_input_term_cfg(self):
-        """
-        :class:`nidaqmx.constants.TerminalConfiguration`: Specifies the
-            input terminal configuration.
-        """
-        val = ctypes.c_int()
-
-        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderAInputTermCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_int)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return TerminalConfiguration(val.value)
-
-    @ci_velocity_encoder_a_input_term_cfg.setter
-    def ci_velocity_encoder_a_input_term_cfg(self, val):
-        val = val.value
-        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderAInputTermCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_int]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_a_input_term_cfg.deleter
-    def ci_velocity_encoder_a_input_term_cfg(self):
-        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderAInputTermCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_dig_fltr_enable(self):
-        """
-        bool: Specifies whether to apply the pulse width filter to the
-            signal.
-        """
-        val = c_bool32()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderBInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(c_bool32)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_b_input_dig_fltr_enable.setter
-    def ci_velocity_encoder_b_input_dig_fltr_enable(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderBInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str, c_bool32]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_dig_fltr_enable.deleter
-    def ci_velocity_encoder_b_input_dig_fltr_enable(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderBInputDigFltrEnable)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_dig_fltr_min_pulse_width(self):
-        """
-        float: Specifies in seconds the minimum pulse width the digital
-            filter recognizes.
-        """
-        val = ctypes.c_double()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderBInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_double)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_b_input_dig_fltr_min_pulse_width.setter
-    def ci_velocity_encoder_b_input_dig_fltr_min_pulse_width(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderBInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_double]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_dig_fltr_min_pulse_width.deleter
-    def ci_velocity_encoder_b_input_dig_fltr_min_pulse_width(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderBInputDigFltrMinPulseWidth)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_rate(self):
-        """
-        float: Specifies in hertz the rate of the pulse width filter
-            timebase. NI-DAQmx uses this value to compute settings for
-            the filter.
-        """
-        val = ctypes.c_double()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderBInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_double)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return val.value
-
-    @ci_velocity_encoder_b_input_dig_fltr_timebase_rate.setter
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_rate(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderBInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_double]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_dig_fltr_timebase_rate.deleter
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_rate(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderBInputDigFltrTimebaseRate)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_src(self):
-        """
-        str: Specifies the input terminal of the signal to use as the
-            timebase of the pulse width filter.
-        """
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderBInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_char_p, ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = ctypes.create_string_buffer(temp_size)
-
-            size_or_code = cfunc(
-                self._handle, self._name, val, temp_size)
-
-            if is_string_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return val.value.decode('ascii')
-
-    @ci_velocity_encoder_b_input_dig_fltr_timebase_src.setter
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_src(self, val):
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderBInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_dig_fltr_timebase_src.deleter
-    def ci_velocity_encoder_b_input_dig_fltr_timebase_src(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderBInputDigFltrTimebaseSrc)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_logic_lvl_behavior(self):
-        """
-        :class:`nidaqmx.constants.LogicLvlBehavior`: Specifies the logic
-            level behavior of the input terminal.
-        """
-        val = ctypes.c_int()
-
-        cfunc = (lib_importer.windll.
-                 DAQmxGetCIVelocityEncoderBInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_int)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return LogicLvlBehavior(val.value)
-
-    @ci_velocity_encoder_b_input_logic_lvl_behavior.setter
-    def ci_velocity_encoder_b_input_logic_lvl_behavior(self, val):
-        val = val.value
-        cfunc = (lib_importer.windll.
-                 DAQmxSetCIVelocityEncoderBInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_int]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_logic_lvl_behavior.deleter
-    def ci_velocity_encoder_b_input_logic_lvl_behavior(self):
-        cfunc = (lib_importer.windll.
-                 DAQmxResetCIVelocityEncoderBInputLogicLvlBehavior)
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_term(self):
-        """
-        str: Specifies the terminal to which signal B is connected.
-        """
-        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderBInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_char_p, ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = ctypes.create_string_buffer(temp_size)
-
-            size_or_code = cfunc(
-                self._handle, self._name, val, temp_size)
-
-            if is_string_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return val.value.decode('ascii')
-
-    @ci_velocity_encoder_b_input_term.setter
-    def ci_velocity_encoder_b_input_term(self, val):
-        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderBInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_term.deleter
-    def ci_velocity_encoder_b_input_term(self):
-        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderBInputTerm
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str]
-
-        error_code = cfunc(
-            self._handle, self._name)
-        check_for_error(error_code)
-
-    @property
-    def ci_velocity_encoder_b_input_term_cfg(self):
-        """
-        :class:`nidaqmx.constants.TerminalConfiguration`: Specifies the
-            input terminal configuration.
-        """
-        val = ctypes.c_int()
-
-        cfunc = lib_importer.windll.DAQmxGetCIVelocityEncoderBInputTermCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.POINTER(ctypes.c_int)]
-
-        error_code = cfunc(
-            self._handle, self._name, ctypes.byref(val))
-        check_for_error(error_code)
-
-        return TerminalConfiguration(val.value)
-
-    @ci_velocity_encoder_b_input_term_cfg.setter
-    def ci_velocity_encoder_b_input_term_cfg(self, val):
-        val = val.value
-        cfunc = lib_importer.windll.DAQmxSetCIVelocityEncoderBInputTermCfg
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        lib_importer.task_handle, ctypes_byte_str,
-                        ctypes.c_int]
-
-        error_code = cfunc(
-            self._handle, self._name, val)
-        check_for_error(error_code)
-
-    @ci_velocity_encoder_b_input_term_cfg.deleter
-    def ci_velocity_encoder_b_input_term_cfg(self):
-        cfunc = lib_importer.windll.DAQmxResetCIVelocityEncoderBInputTermCfg
         if cfunc.argtypes is None:
             with cfunc.arglock:
                 if cfunc.argtypes is None:
@@ -12842,169 +12841,4 @@ class CIChannel(Channel):
         error_code = cfunc(
             self._handle, self._name)
         check_for_error(error_code)
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_count_edges_count_reset_reset_count instead.")
-    def ci_count_edges_count_reset_reset_cnt(self):
-        return self.ci_count_edges_count_reset_reset_count
-
-    @ci_count_edges_count_reset_reset_cnt.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_count_edges_count_reset_reset_count instead.")
-    def ci_count_edges_count_reset_reset_cnt(self, val):
-        self.ci_count_edges_count_reset_reset_count = val
-
-    @ci_count_edges_count_reset_reset_cnt.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_count_edges_count_reset_reset_count instead.")
-    def ci_count_edges_count_reset_reset_cnt(self):
-        del self.ci_count_edges_count_reset_reset_count
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_freq_start_edge instead.")
-    def ci_pulse_freq_starting_edge(self):
-        return self.ci_pulse_freq_start_edge
-
-    @ci_pulse_freq_starting_edge.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_freq_start_edge instead.")
-    def ci_pulse_freq_starting_edge(self, val):
-        self.ci_pulse_freq_start_edge = val
-
-    @ci_pulse_freq_starting_edge.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_freq_start_edge instead.")
-    def ci_pulse_freq_starting_edge(self):
-        del self.ci_pulse_freq_start_edge
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_ticks_start_edge instead.")
-    def ci_pulse_ticks_starting_edge(self):
-        return self.ci_pulse_ticks_start_edge
-
-    @ci_pulse_ticks_starting_edge.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_ticks_start_edge instead.")
-    def ci_pulse_ticks_starting_edge(self, val):
-        self.ci_pulse_ticks_start_edge = val
-
-    @ci_pulse_ticks_starting_edge.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_ticks_start_edge instead.")
-    def ci_pulse_ticks_starting_edge(self):
-        del self.ci_pulse_ticks_start_edge
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_time_start_edge instead.")
-    def ci_pulse_time_starting_edge(self):
-        return self.ci_pulse_time_start_edge
-
-    @ci_pulse_time_starting_edge.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_time_start_edge instead.")
-    def ci_pulse_time_starting_edge(self, val):
-        self.ci_pulse_time_start_edge = val
-
-    @ci_pulse_time_starting_edge.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_pulse_time_start_edge instead.")
-    def ci_pulse_time_starting_edge(self):
-        del self.ci_pulse_time_start_edge
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_enable instead.")
-    def ci_velocity_a_input_dig_fltr_enable(self):
-        return self.ci_velocity_encoder_a_input_dig_fltr_enable
-
-    @ci_velocity_a_input_dig_fltr_enable.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_enable instead.")
-    def ci_velocity_a_input_dig_fltr_enable(self, val):
-        self.ci_velocity_encoder_a_input_dig_fltr_enable = val
-
-    @ci_velocity_a_input_dig_fltr_enable.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_enable instead.")
-    def ci_velocity_a_input_dig_fltr_enable(self):
-        del self.ci_velocity_encoder_a_input_dig_fltr_enable
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_min_pulse_width instead.")
-    def ci_velocity_a_input_dig_fltr_min_pulse_width(self):
-        return self.ci_velocity_encoder_a_input_dig_fltr_min_pulse_width
-
-    @ci_velocity_a_input_dig_fltr_min_pulse_width.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_min_pulse_width instead.")
-    def ci_velocity_a_input_dig_fltr_min_pulse_width(self, val):
-        self.ci_velocity_encoder_a_input_dig_fltr_min_pulse_width = val
-
-    @ci_velocity_a_input_dig_fltr_min_pulse_width.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_min_pulse_width instead.")
-    def ci_velocity_a_input_dig_fltr_min_pulse_width(self):
-        del self.ci_velocity_encoder_a_input_dig_fltr_min_pulse_width
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_rate instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_rate(self):
-        return self.ci_velocity_encoder_a_input_dig_fltr_timebase_rate
-
-    @ci_velocity_a_input_dig_fltr_timebase_rate.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_rate instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_rate(self, val):
-        self.ci_velocity_encoder_a_input_dig_fltr_timebase_rate = val
-
-    @ci_velocity_a_input_dig_fltr_timebase_rate.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_rate instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_rate(self):
-        del self.ci_velocity_encoder_a_input_dig_fltr_timebase_rate
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_src instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_src(self):
-        return self.ci_velocity_encoder_a_input_dig_fltr_timebase_src
-
-    @ci_velocity_a_input_dig_fltr_timebase_src.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_src instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_src(self, val):
-        self.ci_velocity_encoder_a_input_dig_fltr_timebase_src = val
-
-    @ci_velocity_a_input_dig_fltr_timebase_src.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_dig_fltr_timebase_src instead.")
-    def ci_velocity_a_input_dig_fltr_timebase_src(self):
-        del self.ci_velocity_encoder_a_input_dig_fltr_timebase_src
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_logic_lvl_behavior instead.")
-    def ci_velocity_a_input_logic_lvl_behavior(self):
-        return self.ci_velocity_encoder_a_input_logic_lvl_behavior
-
-    @ci_velocity_a_input_logic_lvl_behavior.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_logic_lvl_behavior instead.")
-    def ci_velocity_a_input_logic_lvl_behavior(self, val):
-        self.ci_velocity_encoder_a_input_logic_lvl_behavior = val
-
-    @ci_velocity_a_input_logic_lvl_behavior.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_logic_lvl_behavior instead.")
-    def ci_velocity_a_input_logic_lvl_behavior(self):
-        del self.ci_velocity_encoder_a_input_logic_lvl_behavior
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term instead.")
-    def ci_velocity_a_input_term(self):
-        return self.ci_velocity_encoder_a_input_term
-
-    @ci_velocity_a_input_term.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term instead.")
-    def ci_velocity_a_input_term(self, val):
-        self.ci_velocity_encoder_a_input_term = val
-
-    @ci_velocity_a_input_term.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term instead.")
-    def ci_velocity_a_input_term(self):
-        del self.ci_velocity_encoder_a_input_term
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term_cfg instead.")
-    def ci_velocity_a_input_term_cfg(self):
-        return self.ci_velocity_encoder_a_input_term_cfg
-
-    @ci_velocity_a_input_term_cfg.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term_cfg instead.")
-    def ci_velocity_a_input_term_cfg(self, val):
-        self.ci_velocity_encoder_a_input_term_cfg = val
-
-    @ci_velocity_a_input_term_cfg.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_velocity_encoder_a_input_term_cfg instead.")
-    def ci_velocity_a_input_term_cfg(self):
-        del self.ci_velocity_encoder_a_input_term_cfg
 

--- a/generated/nidaqmx/system/device.py
+++ b/generated/nidaqmx/system/device.py
@@ -716,6 +716,42 @@ class Device:
         return val.value
 
     @property
+    def ai_meas_types(self):
+        """
+        List[:class:`nidaqmx.constants.UsageTypeAI`]: Indicates the
+            measurement types supported by the physical channels of the
+            device. Refer to **ai_meas_types** for information on
+            specific channels.
+        """
+        cfunc = lib_importer.windll.DAQmxGetDevAISupportedMeasTypes
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
+                        flags=('C','W')), ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = numpy.zeros(temp_size, dtype=numpy.int32)
+
+            size_or_code = cfunc(
+                self._name, val, temp_size)
+
+            if is_array_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return [UsageTypeAI(e) for e in val]
+
+    @property
     def ai_min_rate(self):
         """
         float: Indicates the minimum rate for an analog input task on
@@ -871,42 +907,6 @@ class Device:
         check_for_error(error_code)
 
         return val.value
-
-    @property
-    def ai_supported_meas_types(self):
-        """
-        List[:class:`nidaqmx.constants.UsageTypeAI`]: Indicates the
-            measurement types supported by the physical channels of the
-            device. Refer to **ai_supported_meas_types** for information
-            on specific channels.
-        """
-        cfunc = lib_importer.windll.DAQmxGetDevAISupportedMeasTypes
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
-                        flags=('C','W')), ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = numpy.zeros(temp_size, dtype=numpy.int32)
-
-            size_or_code = cfunc(
-                self._name, val, temp_size)
-
-            if is_array_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return [UsageTypeAI(e) for e in val]
 
     @property
     def ai_trig_usage(self):
@@ -1217,6 +1217,42 @@ class Device:
         return val.value
 
     @property
+    def ao_output_types(self):
+        """
+        List[:class:`nidaqmx.constants.UsageTypeAO`]: Indicates the
+            generation types supported by the physical channels of the
+            device. Refer to **ao_output_types** for information on
+            specific channels.
+        """
+        cfunc = lib_importer.windll.DAQmxGetDevAOSupportedOutputTypes
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
+                        flags=('C','W')), ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = numpy.zeros(temp_size, dtype=numpy.int32)
+
+            size_or_code = cfunc(
+                self._name, val, temp_size)
+
+            if is_array_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return [UsageTypeAO(e) for e in val]
+
+    @property
     def ao_samp_clk_supported(self):
         """
         bool: Indicates if the device supports the sample clock timing
@@ -1271,42 +1307,6 @@ class Device:
         check_for_error(size_or_code)
 
         return [AcquisitionType(e) for e in val]
-
-    @property
-    def ao_supported_output_types(self):
-        """
-        List[:class:`nidaqmx.constants.UsageTypeAO`]: Indicates the
-            generation types supported by the physical channels of the
-            device. Refer to **ao_supported_output_types** for
-            information on specific channels.
-        """
-        cfunc = lib_importer.windll.DAQmxGetDevAOSupportedOutputTypes
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
-                        flags=('C','W')), ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = numpy.zeros(temp_size, dtype=numpy.int32)
-
-            size_or_code = cfunc(
-                self._name, val, temp_size)
-
-            if is_array_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return [UsageTypeAO(e) for e in val]
 
     @property
     def ao_trig_usage(self):
@@ -1484,6 +1484,42 @@ class Device:
         return val.value
 
     @property
+    def ci_meas_types(self):
+        """
+        List[:class:`nidaqmx.constants.UsageTypeCI`]: Indicates the
+            measurement types supported by the physical channels of the
+            device. Refer to **ci_meas_types** for information on
+            specific channels.
+        """
+        cfunc = lib_importer.windll.DAQmxGetDevCISupportedMeasTypes
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
+                        flags=('C','W')), ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = numpy.zeros(temp_size, dtype=numpy.int32)
+
+            size_or_code = cfunc(
+                self._name, val, temp_size)
+
+            if is_array_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return [UsageTypeCI(e) for e in val]
+
+    @property
     def ci_samp_clk_supported(self):
         """
         bool: Indicates if the device supports the sample clock timing
@@ -1538,42 +1574,6 @@ class Device:
         check_for_error(size_or_code)
 
         return [AcquisitionType(e) for e in val]
-
-    @property
-    def ci_supported_meas_types(self):
-        """
-        List[:class:`nidaqmx.constants.UsageTypeCI`]: Indicates the
-            measurement types supported by the physical channels of the
-            device. Refer to **ci_supported_meas_types** for information
-            on specific channels.
-        """
-        cfunc = lib_importer.windll.DAQmxGetDevCISupportedMeasTypes
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
-                        flags=('C','W')), ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = numpy.zeros(temp_size, dtype=numpy.int32)
-
-            size_or_code = cfunc(
-                self._name, val, temp_size)
-
-            if is_array_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return [UsageTypeCI(e) for e in val]
 
     @property
     def ci_trig_usage(self):
@@ -1639,6 +1639,42 @@ class Device:
         return val.value
 
     @property
+    def co_output_types(self):
+        """
+        List[:class:`nidaqmx.constants.UsageTypeCO`]: Indicates the
+            generation types supported by the physical channels of the
+            device. Refer to **co_output_types** for information on
+            specific channels.
+        """
+        cfunc = lib_importer.windll.DAQmxGetDevCOSupportedOutputTypes
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
+                        flags=('C','W')), ctypes.c_uint]
+
+        temp_size = 0
+        while True:
+            val = numpy.zeros(temp_size, dtype=numpy.int32)
+
+            size_or_code = cfunc(
+                self._name, val, temp_size)
+
+            if is_array_buffer_too_small(size_or_code):
+                # Buffer size must have changed between calls; check again.
+                temp_size = 0
+            elif size_or_code > 0 and temp_size == 0:
+                # Buffer size obtained, use to retrieve data.
+                temp_size = size_or_code
+            else:
+                break
+
+        check_for_error(size_or_code)
+
+        return [UsageTypeCO(e) for e in val]
+
+    @property
     def co_samp_clk_supported(self):
         """
         bool: Indicates if the device supports Sample Clock timing for
@@ -1693,42 +1729,6 @@ class Device:
         check_for_error(size_or_code)
 
         return [AcquisitionType(e) for e in val]
-
-    @property
-    def co_supported_output_types(self):
-        """
-        List[:class:`nidaqmx.constants.UsageTypeCO`]: Indicates the
-            generation types supported by the physical channels of the
-            device. Refer to **co_supported_output_types** for
-            information on specific channels.
-        """
-        cfunc = lib_importer.windll.DAQmxGetDevCOSupportedOutputTypes
-        if cfunc.argtypes is None:
-            with cfunc.arglock:
-                if cfunc.argtypes is None:
-                    cfunc.argtypes = [
-                        ctypes_byte_str, wrapped_ndpointer(dtype=numpy.int32,
-                        flags=('C','W')), ctypes.c_uint]
-
-        temp_size = 0
-        while True:
-            val = numpy.zeros(temp_size, dtype=numpy.int32)
-
-            size_or_code = cfunc(
-                self._name, val, temp_size)
-
-            if is_array_buffer_too_small(size_or_code):
-                # Buffer size must have changed between calls; check again.
-                temp_size = 0
-            elif size_or_code > 0 and temp_size == 0:
-                # Buffer size obtained, use to retrieve data.
-                temp_size = size_or_code
-            else:
-                break
-
-        check_for_error(size_or_code)
-
-        return [UsageTypeCO(e) for e in val]
 
     @property
     def co_trig_usage(self):
@@ -2504,26 +2504,6 @@ class Device:
         check_for_error(error_code)
 
         return val.value
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ai_supported_meas_types instead.")
-    def ai_meas_types(self):
-        return self.ai_supported_meas_types
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ao_supported_output_types instead.")
-    def ao_output_types(self):
-        return self.ao_supported_output_types
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use ci_supported_meas_types instead.")
-    def ci_meas_types(self):
-        return self.ci_supported_meas_types
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use co_supported_output_types instead.")
-    def co_output_types(self):
-        return self.co_supported_output_types
 
     @property
     @deprecation.deprecated(deprecated_in="0.7.0", details="Use is_simulated instead.")

--- a/generated/nidaqmx/system/watchdog.py
+++ b/generated/nidaqmx/system/watchdog.py
@@ -95,7 +95,7 @@ class WatchdogTask:
         return self._expiration_states
 
     @property
-    def expiration_trigger_dig_edge_edge(self):
+    def expir_trig_dig_edge_edge(self):
         """
         :class:`nidaqmx.constants.Edge`: Specifies on which edge of a
             digital signal to expire the watchdog task.
@@ -115,8 +115,8 @@ class WatchdogTask:
 
         return Edge(val.value)
 
-    @expiration_trigger_dig_edge_edge.setter
-    def expiration_trigger_dig_edge_edge(self, val):
+    @expir_trig_dig_edge_edge.setter
+    def expir_trig_dig_edge_edge(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetDigEdgeWatchdogExpirTrigEdge
         if cfunc.argtypes is None:
@@ -129,8 +129,8 @@ class WatchdogTask:
             self._handle, val)
         check_for_error(error_code)
 
-    @expiration_trigger_dig_edge_edge.deleter
-    def expiration_trigger_dig_edge_edge(self):
+    @expir_trig_dig_edge_edge.deleter
+    def expir_trig_dig_edge_edge(self):
         cfunc = lib_importer.windll.DAQmxResetDigEdgeWatchdogExpirTrigEdge
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -143,7 +143,7 @@ class WatchdogTask:
         check_for_error(error_code)
 
     @property
-    def expiration_trigger_dig_edge_src(self):
+    def expir_trig_dig_edge_src(self):
         """
         str: Specifies the name of a terminal where a digital signal
             exists to use as the source of the Expiration Trigger.
@@ -176,8 +176,8 @@ class WatchdogTask:
 
         return val.value.decode('ascii')
 
-    @expiration_trigger_dig_edge_src.setter
-    def expiration_trigger_dig_edge_src(self, val):
+    @expir_trig_dig_edge_src.setter
+    def expir_trig_dig_edge_src(self, val):
         cfunc = lib_importer.windll.DAQmxSetDigEdgeWatchdogExpirTrigSrc
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -189,8 +189,8 @@ class WatchdogTask:
             self._handle, val)
         check_for_error(error_code)
 
-    @expiration_trigger_dig_edge_src.deleter
-    def expiration_trigger_dig_edge_src(self):
+    @expir_trig_dig_edge_src.deleter
+    def expir_trig_dig_edge_src(self):
         cfunc = lib_importer.windll.DAQmxResetDigEdgeWatchdogExpirTrigSrc
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -203,7 +203,7 @@ class WatchdogTask:
         check_for_error(error_code)
 
     @property
-    def expiration_trigger_trig_on_network_conn_loss(self):
+    def expir_trig_trig_on_network_conn_loss(self):
         """
         bool: Specifies the watchdog timer behavior when the network
             connection is lost between the host and the chassis. If set
@@ -226,8 +226,8 @@ class WatchdogTask:
 
         return val.value
 
-    @expiration_trigger_trig_on_network_conn_loss.setter
-    def expiration_trigger_trig_on_network_conn_loss(self, val):
+    @expir_trig_trig_on_network_conn_loss.setter
+    def expir_trig_trig_on_network_conn_loss(self, val):
         cfunc = (lib_importer.windll.
                  DAQmxSetWatchdogExpirTrigTrigOnNetworkConnLoss)
         if cfunc.argtypes is None:
@@ -240,8 +240,8 @@ class WatchdogTask:
             self._handle, val)
         check_for_error(error_code)
 
-    @expiration_trigger_trig_on_network_conn_loss.deleter
-    def expiration_trigger_trig_on_network_conn_loss(self):
+    @expir_trig_trig_on_network_conn_loss.deleter
+    def expir_trig_trig_on_network_conn_loss(self):
         cfunc = (lib_importer.windll.
                  DAQmxResetWatchdogExpirTrigTrigOnNetworkConnLoss)
         if cfunc.argtypes is None:
@@ -255,7 +255,7 @@ class WatchdogTask:
         check_for_error(error_code)
 
     @property
-    def expiration_trigger_type(self):
+    def expir_trig_trig_type(self):
         """
         :class:`nidaqmx.constants.TriggerType`: Specifies the type of
             trigger to use to expire a watchdog task.
@@ -275,8 +275,8 @@ class WatchdogTask:
 
         return TriggerType(val.value)
 
-    @expiration_trigger_type.setter
-    def expiration_trigger_type(self, val):
+    @expir_trig_trig_type.setter
+    def expir_trig_trig_type(self, val):
         val = val.value
         cfunc = lib_importer.windll.DAQmxSetWatchdogExpirTrigType
         if cfunc.argtypes is None:
@@ -289,8 +289,8 @@ class WatchdogTask:
             self._handle, val)
         check_for_error(error_code)
 
-    @expiration_trigger_type.deleter
-    def expiration_trigger_type(self):
+    @expir_trig_trig_type.deleter
+    def expir_trig_trig_type(self):
         cfunc = lib_importer.windll.DAQmxResetWatchdogExpirTrigType
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -664,64 +664,4 @@ class WatchdogTask:
 
         error_code = cfunc(self._handle)
         check_for_error(error_code)
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_type instead.")
-    def expir_trig_trig_type(self):
-        return self.expiration_trigger_type
-
-    @expir_trig_trig_type.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_type instead.")
-    def expir_trig_trig_type(self, val):
-        self.expiration_trigger_type = val
-
-    @expir_trig_trig_type.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_type instead.")
-    def expir_trig_trig_type(self):
-        del self.expiration_trigger_type
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_edge instead.")
-    def expir_trig_dig_edge_edge(self):
-        return self.expiration_trigger_dig_edge_edge
-
-    @expir_trig_dig_edge_edge.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_edge instead.")
-    def expir_trig_dig_edge_edge(self, val):
-        self.expiration_trigger_dig_edge_edge = val
-
-    @expir_trig_dig_edge_edge.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_edge instead.")
-    def expir_trig_dig_edge_edge(self):
-        del self.expiration_trigger_dig_edge_edge
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_src instead.")
-    def expir_trig_dig_edge_src(self):
-        return self.expiration_trigger_dig_edge_src
-
-    @expir_trig_dig_edge_src.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_src instead.")
-    def expir_trig_dig_edge_src(self, val):
-        self.expiration_trigger_dig_edge_src = val
-
-    @expir_trig_dig_edge_src.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_dig_edge_src instead.")
-    def expir_trig_dig_edge_src(self):
-        del self.expiration_trigger_dig_edge_src
-
-    @property
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_trig_on_network_conn_loss instead.")
-    def expir_trig_trig_on_network_conn_loss(self):
-        return self.expiration_trigger_trig_on_network_conn_loss
-
-    @expir_trig_trig_on_network_conn_loss.setter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_trig_on_network_conn_loss instead.")
-    def expir_trig_trig_on_network_conn_loss(self, val):
-        self.expiration_trigger_trig_on_network_conn_loss = val
-
-    @expir_trig_trig_on_network_conn_loss.deleter
-    @deprecation.deprecated(deprecated_in="0.7.0", details="Use expiration_trigger_trig_on_network_conn_loss instead.")
-    def expir_trig_trig_on_network_conn_loss(self):
-        del self.expiration_trigger_trig_on_network_conn_loss
 

--- a/src/codegen/templates/_task_modules/channels/ci_channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/ci_channel.py.mako
@@ -9,7 +9,6 @@
 
 import ctypes
 import numpy
-import deprecation
 
 from nidaqmx._lib import lib_importer, ctypes_byte_str, c_bool32
 from nidaqmx.scale import Scale
@@ -33,5 +32,3 @@ class CIChannel(Channel):
 %for attribute in attributes:
 ${property_template.script_property(attribute)}\
 %endfor
-<%namespace name="deprecated_template" file="/property_deprecated_template.py.mako"/>\
-${deprecated_template.script_deprecated_property(attributes)}

--- a/src/codegen/templates/system/physical_channel.py.mako
+++ b/src/codegen/templates/system/physical_channel.py.mako
@@ -14,7 +14,6 @@
 
 import ctypes
 import numpy
-import deprecation
 
 from nidaqmx._lib import (
     lib_importer, wrapped_ndpointer, enum_bitfield_to_list, ctypes_byte_str,
@@ -69,8 +68,6 @@ class PhysicalChannel:
 ${property_template.script_property(attribute)}\
 %endfor
 \
-<%namespace name="deprecated_template" file="/property_deprecated_template.py.mako"/>\
-${deprecated_template.script_deprecated_property(attributes)}\
 <%namespace name="function_template" file="/function_template.py.mako"/>\
 %for function_object in functions:
 ${function_template.script_function(function_object)}

--- a/src/codegen/utilities/attribute_helpers.py
+++ b/src/codegen/utilities/attribute_helpers.py
@@ -49,29 +49,8 @@ EXCLUDED_ATTRIBUTES = [
 ]
 
 DEPRECATED_ATTRIBUTES = {
-    "ai_eddy_current_prox_sensitivity": {
-        "new_name": "ai_eddy_current_prox_probe_sensitivity",
-        "deprecated_in": "0.7.0",
-    },
-    "ai_eddy_current_prox_sensitivity_units": {
-        "new_name": "ai_eddy_current_prox_probe_sensitivity_units",
-        "deprecated_in": "0.7.0",
-    },
-    "ai_eddy_current_prox_units": {
-        "new_name": "ai_eddy_current_prox_probe_units",
-        "deprecated_in": "0.7.0",
-    },
-    "ai_teds_is_teds": {"new_name": "ai_is_teds", "deprecated_in": "0.7.0"},
-    "ai_rosette_strain_gage_gage_orientation": {
-        "new_name": "ai_rosette_strain_gage_orientation",
-        "deprecated_in": "0.7.0",
-    },
     "ai_rtd_r_0": {"new_name": "ai_rtd_r0", "deprecated_in": "0.7.0"},
     "ai_sound_pressured_b_ref": {"new_name": "ai_sound_pressure_db_ref", "deprecated_in": "0.7.0"},
-    "ai_strain_force_read_from_chan": {
-        "new_name": "ai_strain_gage_force_read_from_chan",
-        "deprecated_in": "0.7.0",
-    },
     "ai_thrmstr_r_1": {"new_name": "ai_thrmstr_r1", "deprecated_in": "0.7.0"},
     "ai_acceld_b_ref": {"new_name": "ai_accel_db_ref", "deprecated_in": "0.7.0"},
     "ai_voltaged_b_ref": {"new_name": "ai_voltage_db_ref", "deprecated_in": "0.7.0"},
@@ -79,67 +58,7 @@ DEPRECATED_ATTRIBUTES = {
         "new_name": "ai_velocity_iepe_sensor_db_ref",
         "deprecated_in": "0.7.0",
     },
-    "ci_count_edges_count_reset_reset_cnt": {
-        "new_name": "ci_count_edges_count_reset_reset_count",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_pulse_freq_starting_edge": {
-        "new_name": "ci_pulse_freq_start_edge",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_pulse_ticks_starting_edge": {
-        "new_name": "ci_pulse_ticks_start_edge",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_pulse_time_starting_edge": {
-        "new_name": "ci_pulse_time_start_edge",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_dig_fltr_enable": {
-        "new_name": "ci_velocity_encoder_a_input_dig_fltr_enable",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_dig_fltr_min_pulse_width": {
-        "new_name": "ci_velocity_encoder_a_input_dig_fltr_min_pulse_width",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_dig_fltr_timebase_rate": {
-        "new_name": "ci_velocity_encoder_a_input_dig_fltr_timebase_rate",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_dig_fltr_timebase_src": {
-        "new_name": "ci_velocity_encoder_a_input_dig_fltr_timebase_src",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_logic_lvl_behavior": {
-        "new_name": "ci_velocity_encoder_a_input_logic_lvl_behavior",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_term": {
-        "new_name": "ci_velocity_encoder_a_input_term",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_velocity_a_input_term_cfg": {
-        "new_name": "ci_velocity_encoder_a_input_term_cfg",
-        "deprecated_in": "0.7.0",
-    },
     "over_write": {"new_name": "overwrite", "deprecated_in": "0.7.0"},
-    "ai_meas_types": {
-        "new_name": "ai_supported_meas_types",
-        "deprecated_in": "0.7.0",
-    },
-    "ao_output_types": {
-        "new_name": "ao_supported_output_types",
-        "deprecated_in": "0.7.0",
-    },
-    "ci_meas_types": {
-        "new_name": "ci_supported_meas_types",
-        "deprecated_in": "0.7.0",
-    },
-    "co_output_types": {
-        "new_name": "co_supported_output_types",
-        "deprecated_in": "0.7.0",
-    },
     "dev_is_simulated": {
         "new_name": "is_simulated",
         "deprecated_in": "0.7.0",
@@ -156,19 +75,6 @@ DEPRECATED_ATTRIBUTES = {
     "expir_states_co_state": {"new_name": "co_state", "deprecated_in": "0.7.0"},
     "expir_states_do_state": {"new_name": "do_state", "deprecated_in": "0.7.0"},
     "expir_states_ao_state": {"new_name": "ao_state", "deprecated_in": "0.7.0"},
-    "expir_trig_trig_type": {"new_name": "expiration_trigger_type", "deprecated_in": "0.7.0"},
-    "expir_trig_dig_edge_edge": {
-        "new_name": "expiration_trigger_dig_edge_edge",
-        "deprecated_in": "0.7.0",
-    },
-    "expir_trig_dig_edge_src": {
-        "new_name": "expiration_trigger_dig_edge_src",
-        "deprecated_in": "0.7.0",
-    },
-    "expir_trig_trig_on_network_conn_loss": {
-        "new_name": "expiration_trigger_trig_on_network_conn_loss",
-        "deprecated_in": "0.7.0",
-    },
 }
 
 PYTHON_CLASS_ENUM_MERGE_SET = {
@@ -180,12 +86,37 @@ PYTHON_CLASS_ENUM_MERGE_SET = {
 }
 
 ATTRIBUTE_CHANGE_SET = {
-    "AIChannel": {"ai_custom_scale_name": "ai_custom_scale"},
+    "AIChannel": {
+        "ai_custom_scale_name": "ai_custom_scale",
+        "ai_strain_gage_force_read_from_chan": "ai_strain_force_read_from_chan",
+        "ai_eddy_current_prox_probe_sensitivity": "ai_eddy_current_prox_sensitivity",
+        "ai_eddy_current_prox_probe_sensitivity_units": "ai_eddy_current_prox_sensitivity_units",
+        "ai_eddy_current_prox_probe_units": "ai_eddy_current_prox_units",
+        "ai_is_teds": "ai_teds_is_teds",
+        "ai_rosette_strain_gage_orientation": "ai_rosette_strain_gage_gage_orientation",
+    },
     "AOChannel": {"ao_custom_scale_name": "ao_custom_scale"},
     "CIChannel": {
+        "ci_count_edges_count_reset_reset_count": "ci_count_edges_count_reset_reset_cnt",
         "ci_custom_scale_name": "ci_custom_scale",
         "ci_dup_count_prevent": "ci_dup_count_prevention",
-        "ci_dup_count_prevent": "ci_dup_count_prevention",
+        "ci_pulse_freq_start_edge": "ci_pulse_freq_starting_edge",
+        "ci_pulse_ticks_start_edge": "ci_pulse_ticks_starting_edge",
+        "ci_pulse_time_start_edge": "ci_pulse_time_starting_edge",
+        "ci_velocity_encoder_a_input_dig_fltr_enable": "ci_velocity_a_input_dig_fltr_enable",
+        "ci_velocity_encoder_a_input_dig_fltr_min_pulse_width": "ci_velocity_a_input_dig_fltr_min_pulse_width",
+        "ci_velocity_encoder_a_input_dig_fltr_timebase_rate": "ci_velocity_a_input_dig_fltr_timebase_rate",
+        "ci_velocity_encoder_a_input_dig_fltr_timebase_src": "ci_velocity_a_input_dig_fltr_timebase_src",
+        "ci_velocity_encoder_a_input_logic_lvl_behavior": "ci_velocity_a_input_logic_lvl_behavior",
+        "ci_velocity_encoder_a_input_term": "ci_velocity_a_input_term",
+        "ci_velocity_encoder_a_input_term_cfg": "ci_velocity_a_input_term_cfg",
+        "ci_velocity_encoder_b_input_dig_fltr_enable": "ci_velocity_b_input_dig_fltr_enable",
+        "ci_velocity_encoder_b_input_dig_fltr_min_pulse_width": "ci_velocity_b_input_dig_fltr_min_pulse_width",
+        "ci_velocity_encoder_b_input_dig_fltr_timebase_rate": "ci_velocity_b_input_dig_fltr_timebase_rate",
+        "ci_velocity_encoder_b_input_dig_fltr_timebase_src": "ci_velocity_b_input_dig_fltr_timebase_src",
+        "ci_velocity_encoder_b_input_logic_lvl_behavior": "ci_velocity_b_input_logic_lvl_behavior",
+        "ci_velocity_encoder_b_input_term": "ci_velocity_b_input_term",
+        "ci_velocity_encoder_b_input_term_cfg": "ci_velocity_b_input_term_cfg",
     },
     "Channel": {
         "chan_descr": "description",
@@ -221,9 +152,17 @@ ATTRIBUTE_CHANGE_SET = {
         "compact_rio_chassis_dev_name": "compact_rio_chassis_device",
         "field_daq_bank_dev_names": "field_daq_bank_devices",
         "field_daq_dev_name": "field_daq_device",
+        "ai_supported_meas_types": "ai_meas_types",
+        "ao_supported_output_types": "ao_output_types",
+        "ci_supported_meas_types": "ci_meas_types",
+        "co_supported_output_types": "co_output_types",
     },
     "PhysicalChannel": {
         "teds_template_i_ds": "teds_template_ids",
+        "ai_supported_meas_types": "ai_meas_types",
+        "ao_supported_output_types": "ao_output_types",
+        "ci_supported_meas_types": "ci_meas_types",
+        "co_supported_output_types": "co_output_types",
     },
     "ExpirationState": {
         "ao_expir_state": "ao_state",
@@ -231,11 +170,10 @@ ATTRIBUTE_CHANGE_SET = {
         "do_expir_state": "do_state",
     },
     "Watchdog": {
-        "expir_trig_type": "expiration_trigger_type",
+        "expir_trig_type": "expir_trig_trig_type",
         "has_expired": "expired",
-        "dig_edge_watchdog_expir_trig_edge": "expiration_trigger_dig_edge_edge",
-        "dig_edge_watchdog_expir_trig_src": "expiration_trigger_dig_edge_src",
-        "expir_trig_trig_on_network_conn_loss": "expiration_trigger_trig_on_network_conn_loss",
+        "dig_edge_watchdog_expir_trig_edge": "expir_trig_dig_edge_edge",
+        "dig_edge_watchdog_expir_trig_src": "expir_trig_dig_edge_src",
     },
     "Triggers": {"trigger_sync_type": "sync_type"},
 }
@@ -268,6 +206,13 @@ ATTR_NAME_CHANGE_IN_DESCRIPTION = {
     "physical_chan_ci_supported_meas_types": "ci_supported_meas_types",
     "physical_chan_co_supported_output_types": "co_supported_output_types",
     "physical_chan_teds_bit_stream": "teds_bit_stream",
+    "ai_eddy_current_prox_probe_sensitivity": "ai_eddy_current_prox_sensitivity",
+    "ai_eddy_current_prox_probe_sensitivity_units": "ai_eddy_current_prox_sensitivity_units",
+    "ci_dup_count_prevent": "ci_dup_count_prevention",
+    "ai_supported_meas_types": "ai_meas_types",
+    "ao_supported_output_types": "ao_output_types",
+    "ci_supported_meas_types": "ci_meas_types",
+    "co_supported_output_types": "co_output_types",
 }
 
 

--- a/tests/component/test_channel_properties.py
+++ b/tests/component/test_channel_properties.py
@@ -4,7 +4,7 @@ import pytest
 import nidaqmx
 from nidaqmx._task_modules.channels.ai_channel import AIChannel
 from nidaqmx._task_modules.channels.ci_channel import CIChannel
-from nidaqmx.constants import Edge, ExcitationSource, PowerIdleOutputBehavior, RTDType
+from nidaqmx.constants import ExcitationSource, PowerIdleOutputBehavior, RTDType
 
 
 @pytest.fixture(scope="function")

--- a/tests/component/test_channel_properties.py
+++ b/tests/component/test_channel_properties.py
@@ -1,11 +1,10 @@
 """Contains a collection of pytest tests that validates channel properties."""
-
 import pytest
 
 import nidaqmx
 from nidaqmx._task_modules.channels.ai_channel import AIChannel
 from nidaqmx._task_modules.channels.ci_channel import CIChannel
-from nidaqmx.constants import ExcitationSource, PowerIdleOutputBehavior, RTDType
+from nidaqmx.constants import Edge, ExcitationSource, PowerIdleOutputBehavior, RTDType
 
 
 @pytest.fixture(scope="function")
@@ -61,6 +60,16 @@ def ci_pulse_width_chan(any_x_series_device):
     """
     with nidaqmx.Task() as task:
         ci_channel = task.ci_channels.add_ci_pulse_width_chan(
+            any_x_series_device.ci_physical_chans[0].name,
+        )
+        yield ci_channel
+
+
+@pytest.fixture(scope="function")
+def ci_count_edges_chan(any_x_series_device):
+    """Creates CI Channel object to count edges."""
+    with nidaqmx.Task() as task:
+        ci_channel = task.ci_channels.add_ci_count_edges_chan(
             any_x_series_device.ci_physical_chans[0].name,
         )
         yield ci_channel
@@ -184,3 +193,21 @@ def test__channel__reset_uint32_property__returns_default_value(
     del ai_voltage_chan_with_excit.ai_lossy_lsb_removal_compressed_samp_size
 
     assert ai_voltage_chan_with_excit.ai_lossy_lsb_removal_compressed_samp_size == 16
+
+
+def test__channel__get_deprecated_properties__reports_warnings(ai_rtd_chan: AIChannel):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        assert ai_rtd_chan.ai_rtd_r0 == ai_rtd_chan.ai_rtd_r_0
+
+
+def test__channel__set_deprecated_properties__reports_warnings(ai_rtd_chan: AIChannel):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        ai_rtd_chan.ai_rtd_r_0 = 1000.0
+
+
+def test__channel__reset_deprecated_properties__reports_warnings(ai_rtd_chan: AIChannel):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        del ai_rtd_chan.ai_rtd_r_0

--- a/tests/component/test_device_properties.py
+++ b/tests/component/test_device_properties.py
@@ -2,6 +2,7 @@
 import pytest
 
 from nidaqmx.constants import BusType, TriggerUsage
+from nidaqmx.system import Device
 
 
 @pytest.mark.parametrize("device_by_name", ["bridgeTester"], indirect=True)
@@ -61,3 +62,14 @@ def test__device__list_of_uint_property__returns_value(device_by_name):
 
     assert isinstance(accessory_product_numbers, list)
     assert accessory_product_numbers == [0x7992]
+
+
+@pytest.mark.parametrize("device_by_name", ["bridgeTester"], indirect=True)
+def test__device__get_deprecated_properties__reports_warnings(device_by_name: Device):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        assert device_by_name.is_simulated == device_by_name.dev_is_simulated
+    with pytest.deprecated_call():
+        assert device_by_name.serial_num == device_by_name.dev_serial_num
+    with pytest.deprecated_call():
+        assert device_by_name.hwteds_supported == device_by_name.tedshwteds_supported

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -1,10 +1,9 @@
 """Tests for validating Read properties."""
-
 import pytest
 
 import nidaqmx
 import nidaqmx.system
-from nidaqmx.constants import ReadRelativeTo
+from nidaqmx.constants import OverwriteMode, ReadRelativeTo
 from nidaqmx.task import Task
 
 
@@ -162,3 +161,21 @@ def test__ai_task__reset_string_property__returns_default_value(ai_task: Task):
     del ai_task.in_stream.logging_file_path
 
     assert ai_task.in_stream.logging_file_path == ""
+
+
+def test__ai_task__get_deprecated_properties__reports_warnings(ai_task: Task):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        assert ai_task.in_stream.overwrite == ai_task.in_stream.over_write
+
+
+def test__ai_task__set_deprecated_properties__reports_warnings(ai_task: Task):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        ai_task.in_stream.over_write = OverwriteMode.DO_NOT_OVERWRITE_UNREAD_SAMPLES
+
+
+def test__ai_task__reset_deprecated_properties__reports_warnings(ai_task: Task):
+    """Test to validate deprecated properties."""
+    with pytest.deprecated_call():
+        del ai_task.in_stream.over_write

--- a/tests/component/test_watchdog_properties.py
+++ b/tests/component/test_watchdog_properties.py
@@ -1,10 +1,9 @@
 """Tests for validating watchdog properties."""
-
 import pytest
 
 import nidaqmx
 import nidaqmx.system
-from nidaqmx.constants import Level, Edge
+from nidaqmx.constants import Edge, Level
 from nidaqmx.errors import DaqError, DAQmxErrors
 from nidaqmx.system.watchdog import DOExpirationState
 
@@ -171,3 +170,45 @@ def test__watchdog_task__reset_string_property__returns_default_value(any_x_seri
         del task.expir_trig_dig_edge_src
 
         assert task.expir_trig_dig_edge_src == ""
+
+
+def test__watchdog_task__get_deprecated_properties__reports_warnings(any_x_series_device):
+    """Test to validate deprecated properties."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        with pytest.deprecated_call():
+            assert (
+                task.expiration_states[do_line.name].do_state
+                == task.expiration_states[do_line.name].expir_states_do_state
+            )
+
+
+def test__watchdog_task__set_deprecated_properties__reports_warnings(any_x_series_device):
+    """Test to validate deprecated properties."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        with pytest.deprecated_call():
+            task.expiration_states[do_line.name].expir_states_do_state = Level.HIGH
+
+
+def test__watchdog_task__reset_deprecated_properties__reports_warnings(any_x_series_device):
+    """Test to validate deprecated properties."""
+    do_line = any_x_series_device.do_lines[0]
+    with nidaqmx.system.WatchdogTask(any_x_series_device.name, timeout=0.5) as task:
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
+        task.cfg_watchdog_do_expir_states(expir_states)
+
+        with pytest.deprecated_call():
+            del task.expiration_states[do_line.name].expir_states_do_state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,8 @@ def _x_series_device(device_type):
     for device in system.devices:
         device_type_match = (
             device_type == DeviceType.ANY
-            or (device_type == DeviceType.REAL and not device.dev_is_simulated)
-            or (device_type == DeviceType.SIMULATED and device.dev_is_simulated)
+            or (device_type == DeviceType.REAL and not device.is_simulated)
+            or (device_type == DeviceType.SIMULATED and device.is_simulated)
         )
         if (
             device_type_match
@@ -85,10 +85,7 @@ def sim_ts_chassis():
         return system.devices["tsChassisTester"]
 
     for device in system.devices:
-        if (
-            device.dev_is_simulated
-            and device.product_category == ProductCategory.TEST_SCALE_CHASSIS
-        ):
+        if device.is_simulated and device.product_category == ProductCategory.TEST_SCALE_CHASSIS:
             return device
 
     pytest.skip(
@@ -104,7 +101,7 @@ def sim_ts_power_device(sim_ts_chassis):
     """Gets simulated power device information."""
     for device in sim_ts_chassis.chassis_module_devices:
         if (
-            device.dev_is_simulated
+            device.is_simulated
             and device.product_category == ProductCategory.TEST_SCALE_MODULE
             and UsageTypeAI.POWER in device.ai_meas_types
         ):
@@ -123,7 +120,7 @@ def sim_ts_voltage_device(sim_ts_chassis):
     """Gets simulated voltage device information."""
     for device in sim_ts_chassis.chassis_module_devices:
         if (
-            device.dev_is_simulated
+            device.is_simulated
             and device.product_category == ProductCategory.TEST_SCALE_MODULE
             and UsageTypeAI.VOLTAGE in device.ai_meas_types
         ):
@@ -143,7 +140,7 @@ def sim_ts_power_devices(sim_ts_chassis):
     devices = []
     for device in sim_ts_chassis.chassis_module_devices:
         if (
-            device.dev_is_simulated
+            device.is_simulated
             and device.product_category == ProductCategory.TEST_SCALE_MODULE
             and UsageTypeAI.POWER in device.ai_meas_types
         ):
@@ -167,7 +164,7 @@ def multi_threading_test_devices():
     devices = []
     for device in system.devices:
         if (
-            device.dev_is_simulated
+            device.is_simulated
             and device.product_category == ProductCategory.X_SERIES_DAQ
             and len(device.ai_physical_chans) >= 1
         ):

--- a/tests/legacy/test_channel_creation.py
+++ b/tests/legacy/test_channel_creation.py
@@ -139,7 +139,7 @@ class TestAnalogCreateChannels:
             assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.TWO_WIRE
             assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
             assert ai_channel.ai_excit_val == 0.0025
-            assert ai_channel.ai_rtd_r_0 == 100.0
+            assert ai_channel.ai_rtd_r0 == 100.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_create_ai_thrmstr_chan_iex(self, any_x_series_device, seed):
@@ -213,7 +213,7 @@ class TestAnalogCreateChannels:
             assert ai_channel.ai_thrmstr_a == 0.001295361
             assert ai_channel.ai_thrmstr_b == 0.0002343159
             assert ai_channel.ai_thrmstr_c == 0.0000001018703
-            assert ai_channel.ai_thrmstr_r_1 == 5000.0
+            assert ai_channel.ai_thrmstr_r1 == 5000.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_create_ai_resistance_chan(self, any_x_series_device, seed):

--- a/tests/legacy/test_system_collections.py
+++ b/tests/legacy/test_system_collections.py
@@ -25,7 +25,7 @@ class TestSystemCollections:
         assert isinstance(devices, collections.abc.Sequence)
 
         assert isinstance(devices[0], nidaqmx.system.Device)
-        assert isinstance(devices[0].dev_is_simulated, bool)
+        assert isinstance(devices[0].is_simulated, bool)
 
     def test_persisted_scale_collection_property(self):
         """Test to validate persisted scale property."""

--- a/tests/legacy/test_watchdog.py
+++ b/tests/legacy/test_watchdog.py
@@ -68,7 +68,7 @@ class TestWatchdog:
             task.cfg_watchdog_do_expir_states(expir_states)
 
             expir_state_obj = task.expiration_states[do_line.name]
-            assert expir_state_obj.expir_states_do_state == Level.TRISTATE
+            assert expir_state_obj.do_state == Level.TRISTATE
 
-            expir_state_obj.expir_states_do_state = Level.LOW
-            assert expir_state_obj.expir_states_do_state == Level.LOW
+            expir_state_obj.do_state = Level.LOW
+            assert expir_state_obj.do_state == Level.LOW


### PR DESCRIPTION
## What does this Pull Request accomplish?

### Roll back unnecessary deprecations

While retrofitting the tests to eliminate deprecation warnings, I began to question most of the deprecated properties. Many of the new names are different but not significantly better. I discussed it with @zhindes and we agreed to roll back most of the deprecations.

Keep only deprecations that do one of the following
- Fix obvious errors (like `ai_acceld_b_ref` -> `ai_accel_db_ref`)
- Make the API easier to use (like `device.dev_is_simulated` -> `device.is_simulated`)

For an overall codegen diff of the old generated code vs. the new generated code, see https://github.com/ni/nidaqmx-python/pull/266

### Retrofit tests to eliminate deprecation warnings

Change references to deprecated properties to use the new names.

### Add explicit test coverage for deprecated properties

Test that a subset of the deprecated properties generate deprecation warnings. Also assert that property getters return the same value for the old and new property names.

## Why should this Pull Request be merged?

Reduces the amount of retrofits for clients.

Fixes AB#2353456: nidaqmx-python tests and examples report many deprecation warnings
(It turned out that the examples did not use any deprecated properties.)

Adds test coverage for deprecated properties.

## What testing has been done?

Ran `poetry run pytest`.
Ran examples with `poetry run python -W default::DeprecationWarning`