### PR TITLE
fix test_examples type annotations for python <3.9

### DIFF
--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -1,4 +1,5 @@
 """Acceptance tests for shipping examples."""
+from __future__ import annotations
 
 import contextlib
 import re


### PR DESCRIPTION
# What does this Pull Request accomplish?

Makes `test_examples.py` usable in Python 3.7/3.8. Type hinting generics wasn't available until [PEP 585](https://peps.python.org/pep-0585/) without a `__future__` import.

# What testing has been done?

```
C:\dev\nidaqmx-python>poetry run pytest
================================================ test session starts =================================================
platform win32 -- Python 3.7.9, pytest-7.2.2, pluggy-1.0.0
...
========================================== 296 passed, 10 skipped in 50.03s ==========================================
```