### PR TITLE
fix coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = clean, py37, py38, py39, py310, py311, report
 whitelist_externals = poetry
 commands =
    poetry install -v
-   poetry run pytest --quiet --cov=nidaqmx --cov-append --cov-report= --junitxml=pytests-{envname}.xml tests/ {posargs}
+   poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=pytests-{envname}.xml tests/ {posargs}
 
 [testenv:clean]
 skip_install = true


### PR DESCRIPTION
# Why should this Pull Request be merged?

This fixes coverage reports on my system. The documentation says cov is a path of a module name, but for whatever reason only the path seems to work for me.

# Testing

Ran all of tox, and poked around the coverage report. It all looks good.

```
  clean: commands succeeded
  py37: commands succeeded
  py38: commands succeeded
  py39: commands succeeded
  py310: commands succeeded
  py311: commands succeeded
  report: commands succeeded
  congratulations :)
```