### PR TITLE
Update "value" parameter's argtype in get_physical_chan_attribute_bytes() by updating latest scrapigen metadata 

### DIFF
--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -2941,12 +2941,12 @@ class LibraryInterpreter(BaseInterpreter):
         with cfunc.arglock:
             cfunc.argtypes = [
                 ctypes_byte_str, ctypes_byte_str, ctypes.c_int32,
-                wrapped_ndpointer(dtype=numpy.generic, flags=('C','W')),
+                wrapped_ndpointer(dtype=numpy.uint8, flags=('C','W')),
                 ctypes.c_uint]
 
         temp_size = 0
         while True:
-            value = numpy.zeros(temp_size, dtype=numpy.generic)
+            value = numpy.zeros(temp_size, dtype=numpy.uint8)
             size_or_code = cfunc(
                 physical_channel, attribute, value, temp_size)
             if is_array_buffer_too_small(size_or_code):

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -14523,7 +14523,7 @@ functions = {
                 'type': 'int32'
             },
             {
-                'ctypes_data_type': 'numpy.generic',
+                'ctypes_data_type': 'numpy.uint8',
                 'direction': 'out',
                 'is_list': True,
                 'name': 'value',

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -14527,7 +14527,7 @@ functions = {
                 'direction': 'out',
                 'is_list': True,
                 'name': 'value',
-                'python_data_type': 'object',
+                'python_data_type': 'int',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'size'


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR updates value parameter's argtype to `numpy.uint8` in `LibraryInterpreter`.
The functions.py scrapigen metadata is updated from https://github.com/ni/grpc-device-scrapigen/pull/165

### Why should this Pull Request be merged?

Fixes [Task 2377912](https://dev.azure.com/ni/DevCentral/_workitems/edit/2377912): Fix get_physical_chan_attribute_bytes() out parameter type (numpy.generic -> numpy.uint8)

### What testing has been done?

Manually generated the out files and tested.