### PR TITLE
Fix event callback pointer's CFUNCTYPE() for signal event functions

### DIFF
--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -4429,7 +4429,8 @@ class LibraryInterpreter(BaseInterpreter):
             self, task, options, callback_function, callback_data):
 
         DAQmxDoneEventCallbackPtr = ctypes.CFUNCTYPE(
-            lib_importer.task_handle, ctypes.c_int)        
+            ctypes.c_int32, lib_importer.task_handle, ctypes.c_int,
+            ctypes.c_void_p)        
         
         cfunc = lib_importer.windll.DAQmxRegisterDoneEvent
         
@@ -4457,7 +4458,8 @@ class LibraryInterpreter(BaseInterpreter):
             callback_function, callback_data):
 
         DAQmxEveryNSamplesEventCallbackPtr = ctypes.CFUNCTYPE(
-            lib_importer.task_handle, ctypes.c_int, ctypes.c_uint)        
+            ctypes.c_int32, lib_importer.task_handle, ctypes.c_int,
+            ctypes.c_uint, ctypes.c_void_p)        
         
         cfunc = lib_importer.windll.DAQmxRegisterEveryNSamplesEvent
         
@@ -4486,7 +4488,8 @@ class LibraryInterpreter(BaseInterpreter):
             self, task, signal_id, options, callback_function, callback_data):
 
         DAQmxSignalEventCallbackPtr = ctypes.CFUNCTYPE(
-            lib_importer.task_handle, ctypes.c_int)        
+            ctypes.c_int32, lib_importer.task_handle, ctypes.c_int,
+            ctypes.c_void_p)        
         
         cfunc = lib_importer.windll.DAQmxRegisterSignalEvent
         

--- a/src/codegen/templates/library_interpreter/event_function_call.py.mako
+++ b/src/codegen/templates/library_interpreter/event_function_call.py.mako
@@ -8,11 +8,12 @@
 <% 
 callback_func_param = ""
 function_callback = f'{re.sub("register", "", function.function_name)}_callbacks'
+callback_param_types = get_callback_param_data_types(function.base_parameters)
 %>\
 %for parameter in function.base_parameters:
     %if parameter.parameter_name == "callback_function":
         ${parameter.type} = ctypes.CFUNCTYPE(
-            ${', '.join(get_callback_param_data_types(parameter.callback_params)) | wrap(12)})        
+            ${', '.join(callback_param_types) | wrap(12)})        
         <% 
             callback_func_param = parameter.type
         %>

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -329,9 +329,12 @@ def get_callback_param_data_types(func_params):
     callback_param_types = []
     # callback_param_types = [result_type, [**ctypes_data_type** of callback_params], **ctypes_data_type** of callback_data_param]
     callback_param_types.append("ctypes.c_int32")
-    callback_param_types.extend([p["ctypes_data_type"] for p in callback_func_param.callback_params])
+    callback_param_types.extend(
+        [p["ctypes_data_type"] for p in callback_func_param.callback_params]
+    )
     callback_param_types.append(callback_data_param.ctypes_data_type)
     return callback_param_types
+
 
 def get_compound_parameter(params):
     """Returns the compound parameter associated with the given function."""

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -327,7 +327,8 @@ def get_callback_param_data_types(func_params):
     callback_func_param = next(p for p in func_params if p.parameter_name == "callback_function")
     callback_data_param = next(p for p in func_params if p.parameter_name == "callback_data")
     callback_param_types = []
-    # callback_param_types = [result_type, [**ctypes_data_type** of callback_params], **ctypes_data_type** of callback_data_param]
+    # callback_param_types = [result_type, [**ctypes_data_type** of callback_params],
+    # **ctypes_data_type** of callback_data_param]
     callback_param_types.append("ctypes.c_int32")
     callback_param_types.extend(
         [p["ctypes_data_type"] for p in callback_func_param.callback_params]

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -326,15 +326,13 @@ def get_callback_param_data_types(func_params):
     """Gets the data types for call back function parameters."""
     callback_func_param = next(p for p in func_params if p.parameter_name == "callback_function")
     callback_data_param = next(p for p in func_params if p.parameter_name == "callback_data")
-    callback_param_types = []
-    # callback_param_types = [result_type, [**ctypes_data_type** of callback_params],
+    # callback_param_types: [result_type, [**ctypes_data_type** of callback_params],
     # **ctypes_data_type** of callback_data_param]
-    callback_param_types.append("ctypes.c_int32")
-    callback_param_types.extend(
-        [p["ctypes_data_type"] for p in callback_func_param.callback_params]
+    return (
+        ["ctypes.c_int32"]
+        + [p["ctypes_data_type"] for p in callback_func_param.callback_params]
+        + [callback_data_param.ctypes_data_type]
     )
-    callback_param_types.append(callback_data_param.ctypes_data_type)
-    return callback_param_types
 
 
 def get_compound_parameter(params):

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -322,10 +322,16 @@ def get_c_function_call_template(func):
     return "/default_c_function_call.py.mako"
 
 
-def get_callback_param_data_types(params):
+def get_callback_param_data_types(func_params):
     """Gets the data types for call back function parameters."""
-    return [p["ctypes_data_type"] for p in params]
-
+    callback_func_param = next(p for p in func_params if p.parameter_name == "callback_function")
+    callback_data_param = next(p for p in func_params if p.parameter_name == "callback_data")
+    callback_param_types = []
+    # callback_param_types = [result_type, [**ctypes_data_type** of callback_params], **ctypes_data_type** of callback_data_param]
+    callback_param_types.append("ctypes.c_int32")
+    callback_param_types.extend([p["ctypes_data_type"] for p in callback_func_param.callback_params])
+    callback_param_types.append(callback_data_param.ctypes_data_type)
+    return callback_param_types
 
 def get_compound_parameter(params):
     """Returns the compound parameter associated with the given function."""


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR fixes callback pointer's return type and argument types for signal event functions.
- Update `ctypes.CFUNCTYPE()` for `EventCallbackPtr` functions
  - Add `CFUNCTYPE()`'s result type as `ctypes.c_int32` for all `EventCallbackPtr` functions.
  - Add `callbackData` type as `ctypes.c_void_p` in `ctypes.CFUNCTYPE()` for all `EventCallbackPtr` functions.

### Why should this Pull Request be merged?

Fixes [Task 2380284](https://dev.azure.com/ni/DevCentral/_workitems/edit/2380284): Add missing parameters for `DAQmxSignalEventCallbackPtr` signal event calls

### What testing has been done?

Manually generated the out files and verified.