### PR TITLE
Update assert in test_task_double_close test case

### DIFF
--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -13,9 +13,10 @@ class TestResourceWarnings:
 
     def test_task_double_close(self):
         """Test to validate double closure of tasks."""
-        with pytest.warns(DaqResourceWarning):
-            with nidaqmx.Task() as task:
-                task.close()
+        with nidaqmx.Task() as task:
+            task.close()
+            assert not task._handle
+            assert not task._close_on_exit
 
     def test_unclosed_task(self):
         """Test to validate unclosed tasks."""


### PR DESCRIPTION
- Since `_close_on_exit` has been introduced in clause of `__exit__()` in `task.py`, there won't be any `DaqResourceWarning` thrown unless `_close_on_exit` remains `True` on double closure of task.
- So, Updated the test case `test_task_double_close` to validate `_close_on_exit` to `False` and `_handle` to `None`.