### PR TITLE
Test Updates | Update the task related tests to use the task fixture

### DIFF
--- a/tests/component/test_buffer_property.py
+++ b/tests/component/test_buffer_property.py
@@ -1,43 +1,40 @@
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import SampleTimingType
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 
 
-def test___ai_task___set_int32_property___value_is_set(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
+def test___ai_task___set_int32_property___value_is_set(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
 
-        # Setting a valid input buffer size of type int32
-        task.in_stream.input_buf_size = 2000000000
+    # Setting a valid input buffer size of type int32
+    task.in_stream.input_buf_size = 2000000000
 
-        assert task.in_stream.input_buf_size == 2000000000
+    assert task.in_stream.input_buf_size == 2000000000
 
 
 def test___ai_task___set_valid_value_to_unsupported_property___unsupported_error_raised(
+    task,
     any_x_series_device,
 ):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
+    """Test for validating unsupported attribute in buffer."""
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
 
-        with pytest.raises(DaqError) as exc_info:
-            task.out_stream.output_buf_size = 2000
+    with pytest.raises(DaqError) as exc_info:
+        task.out_stream.output_buf_size = 2000
 
-        assert exc_info.value.error_code == DAQmxErrors.ATTRIBUTE_NOT_SUPPORTED_IN_TASK_CONTEXT
+    assert exc_info.value.error_code == DAQmxErrors.ATTRIBUTE_NOT_SUPPORTED_IN_TASK_CONTEXT
 
+def test___ai_task___reset_int32_property___value_is_set_to_default(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
+    default_buffer_size = task.in_stream.input_buf_size
+    task.in_stream.input_buf_size = 2000000000
 
-def test___ai_task___reset_int32_property___value_is_set_to_default(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
-        default_buffer_size = task.in_stream.input_buf_size
-        task.in_stream.input_buf_size = 2000000000
+    # Resetting input buffer size
+    del task.in_stream.input_buf_size
 
-        # Resetting input buffer size
-        del task.in_stream.input_buf_size
-
-        assert task.in_stream.input_buf_size == default_buffer_size
+    assert task.in_stream.input_buf_size == default_buffer_size

--- a/tests/component/test_buffer_property.py
+++ b/tests/component/test_buffer_property.py
@@ -19,7 +19,6 @@ def test___ai_task___set_valid_value_to_unsupported_property___unsupported_error
     task,
     any_x_series_device,
 ):
-    """Test for validating unsupported attribute in buffer."""
     task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
 

--- a/tests/component/test_buffer_property.py
+++ b/tests/component/test_buffer_property.py
@@ -28,6 +28,7 @@ def test___ai_task___set_valid_value_to_unsupported_property___unsupported_error
 
     assert exc_info.value.error_code == DAQmxErrors.ATTRIBUTE_NOT_SUPPORTED_IN_TASK_CONTEXT
 
+
 def test___ai_task___reset_int32_property___value_is_set_to_default(task, any_x_series_device):
     task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK

--- a/tests/component/test_channel_properties.py
+++ b/tests/component/test_channel_properties.py
@@ -1,6 +1,5 @@
 import pytest
 
-import nidaqmx
 from nidaqmx._task_modules.channels.ai_channel import AIChannel
 from nidaqmx._task_modules.channels.ci_channel import CIChannel
 from nidaqmx.constants import ExcitationSource, PowerIdleOutputBehavior, RTDType

--- a/tests/component/test_channel_properties.py
+++ b/tests/component/test_channel_properties.py
@@ -7,59 +7,54 @@ from nidaqmx.constants import ExcitationSource, PowerIdleOutputBehavior, RTDType
 
 
 @pytest.fixture(scope="function")
-def ai_voltage_chan_with_excit(any_x_series_device):
+def ai_voltage_chan_with_excit(task, any_x_series_device):
     """Creates AI Channel object to measure voltage."""
-    with nidaqmx.Task() as task:
-        ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
-            any_x_series_device.ai_physical_chans[0].name,
-            voltage_excit_source=ExcitationSource.EXTERNAL,
-            voltage_excit_val=0.1,
-        )
-        yield ai_channel
+    ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
+        any_x_series_device.ai_physical_chans[0].name,
+        voltage_excit_source=ExcitationSource.EXTERNAL,
+        voltage_excit_val=0.1,
+    )
+    yield ai_channel
 
 
 @pytest.fixture(scope="function")
-def ai_power_chan(sim_ts_power_device):
+def ai_power_chan(task, sim_ts_power_device):
     """Creates AI Channel object to measure power."""
-    with nidaqmx.Task() as task:
-        ai_pwr_channel = task.ai_channels.add_ai_power_chan(
-            f"{sim_ts_power_device.name}/power",
-            voltage_setpoint=6.0,
-            current_setpoint=3.0,
-            output_enable=True,
-        )
-        yield ai_pwr_channel
+    ai_pwr_channel = task.ai_channels.add_ai_power_chan(
+        f"{sim_ts_power_device.name}/power",
+        voltage_setpoint=6.0,
+        current_setpoint=3.0,
+        output_enable=True,
+    )
+    yield ai_pwr_channel
 
 
 @pytest.fixture(scope="function")
-def ai_rtd_chan(any_x_series_device):
+def ai_rtd_chan(task, any_x_series_device):
     """Creates AI Channel object that use an RTD to measure temperature."""
-    with nidaqmx.Task() as task:
-        ai_channel = task.ai_channels.add_ai_rtd_chan(
-            any_x_series_device.ai_physical_chans[0].name,
-            rtd_type=RTDType.PT_3750,
-        )
-        yield ai_channel
+    ai_channel = task.ai_channels.add_ai_rtd_chan(
+        any_x_series_device.ai_physical_chans[0].name,
+        rtd_type=RTDType.PT_3750,
+    )
+    yield ai_channel
 
 
 @pytest.fixture(scope="function")
-def ci_pulse_width_chan(any_x_series_device):
+def ci_pulse_width_chan(task, any_x_series_device):
     """Creates CI Channel object to measure the width of a digital pulse."""
-    with nidaqmx.Task() as task:
-        ci_channel = task.ci_channels.add_ci_pulse_width_chan(
-            any_x_series_device.ci_physical_chans[0].name,
-        )
-        yield ci_channel
+    ci_channel = task.ci_channels.add_ci_pulse_width_chan(
+        any_x_series_device.ci_physical_chans[0].name,
+    )
+    yield ci_channel
 
 
 @pytest.fixture(scope="function")
-def ci_count_edges_chan(any_x_series_device):
+def ci_count_edges_chan(task, any_x_series_device):
     """Creates CI Channel object to count edges."""
-    with nidaqmx.Task() as task:
-        ci_channel = task.ci_channels.add_ci_count_edges_chan(
-            any_x_series_device.ci_physical_chans[0].name,
-        )
-        yield ci_channel
+    ci_channel = task.ci_channels.add_ci_count_edges_chan(
+        any_x_series_device.ci_physical_chans[0].name,
+    )
+    yield ci_channel
 
 
 def test___channel___get_boolean_property___returns_default_value(

--- a/tests/component/test_export_signal_properties.py
+++ b/tests/component/test_export_signal_properties.py
@@ -1,6 +1,5 @@
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import ExportAction, TaskMode
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
@@ -8,19 +7,17 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_task(any_x_series_device):
+def ai_voltage_task(task, any_x_series_device):
     """Gets AI voltage task."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        yield task
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    yield task
 
 
 @pytest.fixture()
-def ao_voltage_task(any_x_series_device):
+def ao_voltage_task(task, any_x_series_device):
     """Gets AO voltage task."""
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        yield task
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    yield task
 
 
 def test___ai_task___get_enum_property___returns_default_value(ai_voltage_task: Task):

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -1,17 +1,14 @@
 import pytest
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx.constants import OverwriteMode, ReadRelativeTo
 from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_task(any_x_series_device):
+def ai_task(task, any_x_series_device):
     """Gets AI voltage task."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        yield task
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    yield task
 
 
 def test___ai_task___get_int32_property___returns_default_value(ai_task: Task):

--- a/tests/component/test_timing_properties.py
+++ b/tests/component/test_timing_properties.py
@@ -1,202 +1,182 @@
 import pytest
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx import DaqError
 from nidaqmx.constants import AcquisitionType, SampleTimingType
 from nidaqmx.error_codes import DAQmxErrors
 
 
-def test___timing___get_boolean_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
+def test___timing___get_boolean_property___returns_value(task, any_x_series_device):
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
 
-        assert not task.timing.simultaneous_ao_enable
+    assert not task.timing.simultaneous_ao_enable
 
 
-def test___timing___set_boolean_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
+def test___timing___set_boolean_property___returns_assigned_value(task, any_x_series_device):
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
 
-        task.timing.simultaneous_ao_enable = True
+    task.timing.simultaneous_ao_enable = True
 
-        assert task.timing.simultaneous_ao_enable
+    assert task.timing.simultaneous_ao_enable
 
 
-def test___timing___reset_boolean_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
-        task.timing.simultaneous_ao_enable = True
+def test___timing___reset_boolean_property___returns_default_value(task, any_x_series_device):
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
+    task.timing.simultaneous_ao_enable = True
 
-        del task.timing.simultaneous_ao_enable
+    del task.timing.simultaneous_ao_enable
 
-        assert not task.timing.simultaneous_ao_enable
+    assert not task.timing.simultaneous_ao_enable
 
 
-def test___timing___get_string_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___get_string_property___returns_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
+    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
 
 
-def test___timing___set_string_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___set_string_property___returns_assigned_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        task.timing.samp_clk_src = "PFI0"
+    task.timing.samp_clk_src = "PFI0"
 
-        assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/PFI0"
+    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/PFI0"
 
 
-def test___timing___reset_string_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000, source="PFI0")
+def test___timing___reset_string_property___returns_default_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000, source="PFI0")
 
-        del task.timing.samp_clk_src
+    del task.timing.samp_clk_src
 
-        assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
+    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
 
 
-def test___timing___set_invalid_source_terminal_name___throws_daqerror(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_invalid_source_terminal_name___throws_daqerror(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-        task.timing.cfg_samp_clk_timing(1000, source="Test_Invalid_Device_Source")
+    task.timing.cfg_samp_clk_timing(1000, source="Test_Invalid_Device_Source")
 
-        with pytest.raises(DaqError) as e:
-            _ = task.timing.samp_clk_src
-        assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_SOURCE_TERMINAL_NAME_ROUTING
+    with pytest.raises(DaqError) as e:
+        _ = task.timing.samp_clk_src
+    assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_SOURCE_TERMINAL_NAME_ROUTING
 
 
-def test___timing___get_enum_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
+def test___timing___get_enum_property___returns_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
-        assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
+    assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
 
-def test___timing___set_enum_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
+def test___timing___set_enum_property___returns_assigned_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
-        task.timing.samp_quant_samp_mode = AcquisitionType.FINITE
+    task.timing.samp_quant_samp_mode = AcquisitionType.FINITE
 
-        assert task.timing.samp_quant_samp_mode == AcquisitionType.FINITE
+    assert task.timing.samp_quant_samp_mode == AcquisitionType.FINITE
 
 
-def test___timing___reset_enum_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.FINITE)
+def test___timing___reset_enum_property___returns_default_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.FINITE)
 
-        del task.timing.samp_quant_samp_mode
+    del task.timing.samp_quant_samp_mode
 
-        assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
+    assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
 
-def test___timing___get_float64_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___get_float64_property___returns_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        assert task.timing.samp_clk_rate == 1000
+    assert task.timing.samp_clk_rate == 1000
 
 
-def test___timing___set_float64_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___set_float64_property___returns_assigned_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        task.timing.samp_clk_rate = 2000
+    task.timing.samp_clk_rate = 2000
 
-        assert task.timing.samp_clk_rate == 2000
+    assert task.timing.samp_clk_rate == 2000
 
 
-def test___timing___reset_float64_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        default_value = task.timing.samp_clk_rate
-        task.timing.cfg_samp_clk_timing(10000)
+def test___timing___reset_float64_property___returns_default_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    default_value = task.timing.samp_clk_rate
+    task.timing.cfg_samp_clk_timing(10000)
 
-        del task.timing.samp_clk_rate
+    del task.timing.samp_clk_rate
 
-        assert task.timing.samp_clk_rate == default_value
+    assert task.timing.samp_clk_rate == default_value
 
 
-def test___timing___get_uint32_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___get_uint32_property___returns_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        assert task.timing.samp_clk_timebase_div == 100000
+    assert task.timing.samp_clk_timebase_div == 100000
 
 
-def test___timing___set_uint32_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
+def test___timing___set_uint32_property___returns_assigned_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
 
-        task.timing.samp_clk_timebase_div = 500
+    task.timing.samp_clk_timebase_div = 500
 
-        assert task.timing.samp_clk_timebase_div == 500
+    assert task.timing.samp_clk_timebase_div == 500
 
 
-def test___timing___reset_uint32_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000)
-        default_value = task.timing.samp_clk_timebase_div
-        task.timing.samp_clk_timebase_div = 200000
-        assert task.timing.samp_clk_rate == 500
+def test___timing___reset_uint32_property___returns_default_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000)
+    default_value = task.timing.samp_clk_timebase_div
+    task.timing.samp_clk_timebase_div = 200000
+    assert task.timing.samp_clk_rate == 500
 
-        del task.timing.samp_clk_timebase_div
+    del task.timing.samp_clk_timebase_div
 
-        assert task.timing.samp_clk_timebase_div == default_value
+    assert task.timing.samp_clk_timebase_div == default_value
 
 
-def test___timing___get_uint64_property___returns_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        task.timing.cfg_samp_clk_timing(1000, samps_per_chan=100)
+def test___timing___get_uint64_property___returns_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.timing.cfg_samp_clk_timing(1000, samps_per_chan=100)
 
-        assert task.timing.samp_quant_samp_per_chan == 100
+    assert task.timing.samp_quant_samp_per_chan == 100
 
 
-def test___timing___set_uint64_property___returns_assigned_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_uint64_property___returns_assigned_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-        task.timing.samp_quant_samp_per_chan = 10000
+    task.timing.samp_quant_samp_per_chan = 10000
 
-        assert task.timing.samp_quant_samp_per_chan == 10000
+    assert task.timing.samp_quant_samp_per_chan == 10000
 
 
-def test___timing___reset_uint64_property___returns_default_value(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        default_value = task.timing.samp_quant_samp_per_chan
-        task.timing.cfg_samp_clk_timing(1000, samps_per_chan=10000)
+def test___timing___reset_uint64_property___returns_default_value(task, any_x_series_device):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    default_value = task.timing.samp_quant_samp_per_chan
+    task.timing.cfg_samp_clk_timing(1000, samps_per_chan=10000)
 
-        del task.timing.samp_quant_samp_per_chan
+    del task.timing.samp_quant_samp_per_chan
 
-        assert task.timing.samp_quant_samp_per_chan == default_value
+    assert task.timing.samp_quant_samp_per_chan == default_value
 
 
-def test___timing___set_unint64_property_out_of_range_value___throws_daqerror(any_x_series_device):
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_unint64_property_out_of_range_value___throws_daqerror(
+    task, any_x_series_device
+):
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-        task.timing.cfg_samp_clk_timing(1000, samps_per_chan=1)
+    task.timing.cfg_samp_clk_timing(1000, samps_per_chan=1)
 
-        with pytest.raises(DaqError) as e:
-            _ = task.timing.samp_quant_samp_per_chan
-        assert e.value.error_type == DAQmxErrors.INVALID_ATTRIBUTE_VALUE
+    with pytest.raises(DaqError) as e:
+        _ = task.timing.samp_quant_samp_per_chan
+    assert e.value.error_type == DAQmxErrors.INVALID_ATTRIBUTE_VALUE

--- a/tests/component/test_trigger_properties.py
+++ b/tests/component/test_trigger_properties.py
@@ -1,6 +1,5 @@
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import TaskMode, TriggerType
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
@@ -8,11 +7,10 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_task(any_x_series_device):
+def ai_voltage_task(task, any_x_series_device):
     """Gets AI voltage task."""
-    with nidaqmx.Task() as task:
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-        yield task
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    yield task
 
 
 def test___ai_task___get_float_property___returns_default_value(ai_voltage_task: Task):

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -8,11 +8,10 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ao_task(any_x_series_device):
+def ao_task(task, any_x_series_device):
     """Gets AO voltage task."""
-    with nidaqmx.Task() as task:
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-        yield task
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    yield task
 
 
 def test___ao_task___get_int32_property___returns_default_value(ao_task: Task):

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -1,7 +1,5 @@
 import pytest
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx.constants import WriteRelativeTo
 from nidaqmx.errors import DaqError, DAQmxErrors
 from nidaqmx.task import Task
@@ -79,31 +77,28 @@ def test___ao_task___get_uint64_property___returns_default_value(ao_task: Task):
 
 
 @pytest.mark.parametrize("device_by_name", ["aoTester"], indirect=True)
-def test___ao_current_task___get_bool_property___returns_default_value(device_by_name):
-    with nidaqmx.Task() as ao_current_task:
-        ao_current_task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
-        ao_current_task.start()
+def test___ao_current_task___get_bool_property___returns_default_value(task, device_by_name):
+    task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
+    task.start()
 
-        assert not ao_current_task.out_stream.open_current_loop_chans_exist
-
-
-@pytest.mark.parametrize("device_by_name", ["aoTester"], indirect=True)
-def test___ao_current_task___get_string_list_property___returns_default_value(device_by_name):
-    with nidaqmx.Task() as ao_current_task:
-        ao_current_task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
-        ao_current_task.start()
-        _ = ao_current_task.out_stream.open_current_loop_chans_exist
-
-        assert ao_current_task.out_stream.open_current_loop_chans == []
+    assert not task.out_stream.open_current_loop_chans_exist
 
 
 @pytest.mark.parametrize("device_by_name", ["aoTester"], indirect=True)
-def test___ao_current_task__read_property___out_of_order___throws_daqerror(device_by_name):
-    with nidaqmx.Task() as ao_current_task:
-        ao_current_task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
-        ao_current_task.start()
+def test___ao_current_task___get_string_list_property___returns_default_value(task, device_by_name):
+    task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
+    task.start()
+    _ = task.out_stream.open_current_loop_chans_exist
 
-        with pytest.raises(DaqError) as exc_info:
-            _ = ao_current_task.out_stream.open_current_loop_chans
+    assert task.out_stream.open_current_loop_chans == []
 
-        assert exc_info.value.error_type == DAQmxErrors.TWO_PART_ATTRIBUTE_CALLED_OUT_OF_ORDER
+
+@pytest.mark.parametrize("device_by_name", ["aoTester"], indirect=True)
+def test___ao_current_task__read_property___out_of_order___throws_daqerror(task, device_by_name):
+    task.ao_channels.add_ao_current_chan(device_by_name.ao_physical_chans[0].name)
+    task.start()
+
+    with pytest.raises(DaqError) as exc_info:
+        _ = task.out_stream.open_current_loop_chans
+
+    assert exc_info.value.error_type == DAQmxErrors.TWO_PART_ATTRIBUTE_CALLED_OUT_OF_ORDER

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -292,7 +292,6 @@ def task(request, generate_task):
     may get double-close warnings.
     """
     new_task_name = _get_marker_value(request, "new_task_name", "")
-    new_task_name = "" if new_task_name is None else new_task_name
     return generate_task(task_name=new_task_name)
 
 

--- a/tests/legacy/test_channel_creation.py
+++ b/tests/legacy/test_channel_creation.py
@@ -4,7 +4,6 @@ import random
 import numpy
 import pytest
 
-import nidaqmx
 from nidaqmx import constants
 from nidaqmx.constants import (
     TerminalConfiguration,
@@ -33,294 +32,285 @@ class TestAnalogCreateChannels:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_voltage_chan(self, any_x_series_device, seed):
+    def test_create_ai_voltage_chan(self, task, any_x_series_device, seed):
         """Test for creating AI voltage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_voltage_chan(
-                ai_phys_chan,
-                name_to_assign_to_channel="VoltageChannel",
-                terminal_config=TerminalConfiguration.NRSE,
-                min_val=-20.0,
-                max_val=20.0,
-                units=VoltageUnits.FROM_CUSTOM_SCALE,
-                custom_scale_name="double_gain_scale",
-            )
+        ai_channel = task.ai_channels.add_ai_voltage_chan(
+            ai_phys_chan,
+            name_to_assign_to_channel="VoltageChannel",
+            terminal_config=TerminalConfiguration.NRSE,
+            min_val=-20.0,
+            max_val=20.0,
+            units=VoltageUnits.FROM_CUSTOM_SCALE,
+            custom_scale_name="double_gain_scale",
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "VoltageChannel"
-            assert ai_channel.ai_term_cfg == TerminalConfiguration.NRSE
-            assert ai_channel.ai_min == -20.0
-            assert ai_channel.ai_max == 20.0
-            assert ai_channel.ai_voltage_units == VoltageUnits.FROM_CUSTOM_SCALE
-            assert ai_channel.ai_custom_scale.name == "double_gain_scale"
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "VoltageChannel"
+        assert ai_channel.ai_term_cfg == TerminalConfiguration.NRSE
+        assert ai_channel.ai_min == -20.0
+        assert ai_channel.ai_max == 20.0
+        assert ai_channel.ai_voltage_units == VoltageUnits.FROM_CUSTOM_SCALE
+        assert ai_channel.ai_custom_scale.name == "double_gain_scale"
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_current_chan(self, any_x_series_device, seed):
+    def test_create_ai_current_chan(self, task, any_x_series_device, seed):
         """Test for creating AI current channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_current_chan(
-                ai_phys_chan,
-                name_to_assign_to_channel="CurrentChannel",
-                terminal_config=TerminalConfiguration.RSE,
-                min_val=-0.01,
-                max_val=0.01,
-                units=CurrentUnits.AMPS,
-                shunt_resistor_loc=CurrentShuntResistorLocation.EXTERNAL,
-                ext_shunt_resistor_val=100.0,
-            )
+        ai_channel = task.ai_channels.add_ai_current_chan(
+            ai_phys_chan,
+            name_to_assign_to_channel="CurrentChannel",
+            terminal_config=TerminalConfiguration.RSE,
+            min_val=-0.01,
+            max_val=0.01,
+            units=CurrentUnits.AMPS,
+            shunt_resistor_loc=CurrentShuntResistorLocation.EXTERNAL,
+            ext_shunt_resistor_val=100.0,
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "CurrentChannel"
-            assert ai_channel.ai_term_cfg == TerminalConfiguration.RSE
-            assert ai_channel.ai_min == -0.01
-            assert ai_channel.ai_max == 0.01
-            assert ai_channel.ai_current_units == CurrentUnits.AMPS
-            assert ai_channel.ai_current_shunt_loc == CurrentShuntResistorLocation.EXTERNAL
-            assert ai_channel.ai_current_shunt_resistance == 100.0
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "CurrentChannel"
+        assert ai_channel.ai_term_cfg == TerminalConfiguration.RSE
+        assert ai_channel.ai_min == -0.01
+        assert ai_channel.ai_max == 0.01
+        assert ai_channel.ai_current_units == CurrentUnits.AMPS
+        assert ai_channel.ai_current_shunt_loc == CurrentShuntResistorLocation.EXTERNAL
+        assert ai_channel.ai_current_shunt_resistance == 100.0
 
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_create_ai_voltage_rms_chan(self, any_x_series_device, seed):
+    # def test_create_ai_voltage_rms_chan(self, task, any_x_series_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
     #     ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
     #
-    #     with nidaqmx.Task() as task:
-    #         ai_channel = task.ai_channels.add_ai_voltage_rms_chan(
-    #             ai_phys_chan, name_to_assign_to_channel="VoltageRMSChannel",
-    #             terminal_config=TerminalConfiguration.bal_diff, min_val=-1.0,
-    #             max_val=1.0, units=VoltageUnits.volts, custom_scale_name="")
+    #     ai_channel = task.ai_channels.add_ai_voltage_rms_chan(
+    #         ai_phys_chan, name_to_assign_to_channel="VoltageRMSChannel",
+    #         terminal_config=TerminalConfiguration.bal_diff, min_val=-1.0,
+    #         max_val=1.0, units=VoltageUnits.volts, custom_scale_name="")
     #
-    #         assert ai_channel.name == "VoltageRMSChannel"
-    #         assert ai_channel.ai_term_cfg == TerminalConfiguration.bal_diff
-    #         assert ai_channel.ai_min == -1.0
-    #         assert ai_channel.ai_max == 1.0
-    #         assert ai_channel.ai_voltage_units == VoltageUnits.volts
-    #         assert ai_channel.ai_custom_scale.name == ""
+    #     assert ai_channel.name == "VoltageRMSChannel"
+    #     assert ai_channel.ai_term_cfg == TerminalConfiguration.bal_diff
+    #     assert ai_channel.ai_min == -1.0
+    #     assert ai_channel.ai_max == 1.0
+    #     assert ai_channel.ai_voltage_units == VoltageUnits.volts
+    #     assert ai_channel.ai_custom_scale.name == ""
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_rtd_chan(self, any_x_series_device, seed):
+    def test_create_ai_rtd_chan(self, task, any_x_series_device, seed):
         """Test for creating AI RTD channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_rtd_chan(
-                ai_phys_chan,
-                name_to_assign_to_channel="RTDChannel",
-                min_val=28.0,
-                max_val=120.0,
-                units=TemperatureUnits.K,
-                rtd_type=RTDType.PT_3750,
-                resistance_config=ResistanceConfiguration.TWO_WIRE,
-                current_excit_source=ExcitationSource.EXTERNAL,
-                current_excit_val=0.0025,
-                r_0=100.0,
-            )
+        ai_channel = task.ai_channels.add_ai_rtd_chan(
+            ai_phys_chan,
+            name_to_assign_to_channel="RTDChannel",
+            min_val=28.0,
+            max_val=120.0,
+            units=TemperatureUnits.K,
+            rtd_type=RTDType.PT_3750,
+            resistance_config=ResistanceConfiguration.TWO_WIRE,
+            current_excit_source=ExcitationSource.EXTERNAL,
+            current_excit_val=0.0025,
+            r_0=100.0,
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "RTDChannel"
-            assert numpy.isclose(ai_channel.ai_min, 28.0, atol=1)
-            assert numpy.isclose(ai_channel.ai_max, 221.0, atol=1)
-            assert ai_channel.ai_temp_units == TemperatureUnits.K
-            assert ai_channel.ai_rtd_type == RTDType.PT_3750
-            assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.TWO_WIRE
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 0.0025
-            assert ai_channel.ai_rtd_r0 == 100.0
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "RTDChannel"
+        assert numpy.isclose(ai_channel.ai_min, 28.0, atol=1)
+        assert numpy.isclose(ai_channel.ai_max, 221.0, atol=1)
+        assert ai_channel.ai_temp_units == TemperatureUnits.K
+        assert ai_channel.ai_rtd_type == RTDType.PT_3750
+        assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.TWO_WIRE
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 0.0025
+        assert ai_channel.ai_rtd_r0 == 100.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_iex(self, any_x_series_device, seed):
+    def test_create_ai_thrmstr_chan_iex(self, task, any_x_series_device, seed):
         """Test for creating AI thermistor channel with current excitation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_thrmstr_chan_iex(
-                ai_phys_chan,
-                name_to_assign_to_channel="ThermistorIexChannel",
-                min_val=-30.0,
-                max_val=300.0,
-                units=TemperatureUnits.DEG_C,
-                resistance_config=ResistanceConfiguration.FOUR_WIRE,
-                current_excit_source=ExcitationSource.EXTERNAL,
-                current_excit_val=0.0001,
-                a=0.0013,
-                b=0.00023,
-                c=0.000000102,
-            )
+        ai_channel = task.ai_channels.add_ai_thrmstr_chan_iex(
+            ai_phys_chan,
+            name_to_assign_to_channel="ThermistorIexChannel",
+            min_val=-30.0,
+            max_val=300.0,
+            units=TemperatureUnits.DEG_C,
+            resistance_config=ResistanceConfiguration.FOUR_WIRE,
+            current_excit_source=ExcitationSource.EXTERNAL,
+            current_excit_val=0.0001,
+            a=0.0013,
+            b=0.00023,
+            c=0.000000102,
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "ThermistorIexChannel"
-            assert numpy.isclose(ai_channel.ai_min, -30.0, atol=1)
-            assert numpy.isclose(ai_channel.ai_max, 300.0, atol=1)
-            assert ai_channel.ai_temp_units == TemperatureUnits.DEG_C
-            assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.FOUR_WIRE
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 0.0001
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "ThermistorIexChannel"
+        assert numpy.isclose(ai_channel.ai_min, -30.0, atol=1)
+        assert numpy.isclose(ai_channel.ai_max, 300.0, atol=1)
+        assert ai_channel.ai_temp_units == TemperatureUnits.DEG_C
+        assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.FOUR_WIRE
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 0.0001
 
-            assert ai_channel.ai_thrmstr_a == 0.0013
-            assert ai_channel.ai_thrmstr_b == 0.00023
-            assert ai_channel.ai_thrmstr_c == 0.000000102
+        assert ai_channel.ai_thrmstr_a == 0.0013
+        assert ai_channel.ai_thrmstr_b == 0.00023
+        assert ai_channel.ai_thrmstr_c == 0.000000102
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_vex(self, any_x_series_device, seed):
+    def test_create_ai_thrmstr_chan_vex(self, task, any_x_series_device, seed):
         """Test for creating AI thermistor channel with voltage excitation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_thrmstr_chan_vex(
-                ai_phys_chan,
-                name_to_assign_to_channel="ThermistorVexChannel",
-                min_val=-50.0,
-                max_val=300.0,
-                units=TemperatureUnits.DEG_C,
-                resistance_config=ResistanceConfiguration.FOUR_WIRE,
-                voltage_excit_source=ExcitationSource.EXTERNAL,
-                voltage_excit_val=2.5,
-                a=0.001295361,
-                b=0.0002343159,
-                c=0.0000001018703,
-                r_1=5000.0,
-            )
+        ai_channel = task.ai_channels.add_ai_thrmstr_chan_vex(
+            ai_phys_chan,
+            name_to_assign_to_channel="ThermistorVexChannel",
+            min_val=-50.0,
+            max_val=300.0,
+            units=TemperatureUnits.DEG_C,
+            resistance_config=ResistanceConfiguration.FOUR_WIRE,
+            voltage_excit_source=ExcitationSource.EXTERNAL,
+            voltage_excit_val=2.5,
+            a=0.001295361,
+            b=0.0002343159,
+            c=0.0000001018703,
+            r_1=5000.0,
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "ThermistorVexChannel"
-            assert numpy.isclose(ai_channel.ai_min, -50.0, atol=1)
-            assert numpy.isclose(ai_channel.ai_max, 300.0, atol=1)
-            assert ai_channel.ai_temp_units == TemperatureUnits.DEG_C
-            assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.FOUR_WIRE
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 2.5
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "ThermistorVexChannel"
+        assert numpy.isclose(ai_channel.ai_min, -50.0, atol=1)
+        assert numpy.isclose(ai_channel.ai_max, 300.0, atol=1)
+        assert ai_channel.ai_temp_units == TemperatureUnits.DEG_C
+        assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.FOUR_WIRE
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 2.5
 
-            assert ai_channel.ai_thrmstr_a == 0.001295361
-            assert ai_channel.ai_thrmstr_b == 0.0002343159
-            assert ai_channel.ai_thrmstr_c == 0.0000001018703
-            assert ai_channel.ai_thrmstr_r1 == 5000.0
+        assert ai_channel.ai_thrmstr_a == 0.001295361
+        assert ai_channel.ai_thrmstr_b == 0.0002343159
+        assert ai_channel.ai_thrmstr_c == 0.0000001018703
+        assert ai_channel.ai_thrmstr_r1 == 5000.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_resistance_chan(self, any_x_series_device, seed):
+    def test_create_ai_resistance_chan(self, task, any_x_series_device, seed):
         """Test for creating AI resistance channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            # Note: 1000 ohms @ 5 mA = 5V range, which exists on most X Series devices.
-            ai_channel = task.ai_channels.add_ai_resistance_chan(
-                ai_phys_chan,
-                name_to_assign_to_channel="ResistanceChannel",
-                min_val=-1000.0,
-                max_val=1000.0,
-                units=ResistanceUnits.OHMS,
-                resistance_config=ResistanceConfiguration.TWO_WIRE,
-                current_excit_source=ExcitationSource.EXTERNAL,
-                current_excit_val=0.005,
-                custom_scale_name="",
-            )
+        # Note: 1000 ohms @ 5 mA = 5V range, which exists on most X Series devices.
+        ai_channel = task.ai_channels.add_ai_resistance_chan(
+            ai_phys_chan,
+            name_to_assign_to_channel="ResistanceChannel",
+            min_val=-1000.0,
+            max_val=1000.0,
+            units=ResistanceUnits.OHMS,
+            resistance_config=ResistanceConfiguration.TWO_WIRE,
+            current_excit_source=ExcitationSource.EXTERNAL,
+            current_excit_val=0.005,
+            custom_scale_name="",
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "ResistanceChannel"
-            assert numpy.isclose(ai_channel.ai_min, -1000.0, atol=1)
-            assert numpy.isclose(ai_channel.ai_max, 1000.0, atol=1)
-            assert ai_channel.ai_resistance_units == ResistanceUnits.OHMS
-            assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.TWO_WIRE
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 0.005
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "ResistanceChannel"
+        assert numpy.isclose(ai_channel.ai_min, -1000.0, atol=1)
+        assert numpy.isclose(ai_channel.ai_max, 1000.0, atol=1)
+        assert ai_channel.ai_resistance_units == ResistanceUnits.OHMS
+        assert ai_channel.ai_resistance_cfg == ResistanceConfiguration.TWO_WIRE
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 0.005
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_ai_strain_gage_chan(self, any_x_series_device, seed):
+    def test_ai_strain_gage_chan(self, task, any_x_series_device, seed):
         """Test for creating AI strain gage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_strain_gage_chan(
-                ai_phys_chan,
-                name_to_assign_to_channel="StrainGageChannel",
-                min_val=-0.05,
-                max_val=0.05,
-                units=StrainUnits.STRAIN,
-                strain_config=StrainGageBridgeType.FULL_BRIDGE_I,
-                voltage_excit_source=ExcitationSource.EXTERNAL,
-                voltage_excit_val=1.0,
-                gage_factor=4.0,
-                initial_bridge_voltage=0.0,
-                nominal_gage_resistance=350.0,
-                poisson_ratio=0.30,
-                lead_wire_resistance=0.1,
-                custom_scale_name="",
-            )
+        ai_channel = task.ai_channels.add_ai_strain_gage_chan(
+            ai_phys_chan,
+            name_to_assign_to_channel="StrainGageChannel",
+            min_val=-0.05,
+            max_val=0.05,
+            units=StrainUnits.STRAIN,
+            strain_config=StrainGageBridgeType.FULL_BRIDGE_I,
+            voltage_excit_source=ExcitationSource.EXTERNAL,
+            voltage_excit_val=1.0,
+            gage_factor=4.0,
+            initial_bridge_voltage=0.0,
+            nominal_gage_resistance=350.0,
+            poisson_ratio=0.30,
+            lead_wire_resistance=0.1,
+            custom_scale_name="",
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "StrainGageChannel"
-            assert numpy.isclose(ai_channel.ai_min, -0.05)
-            assert numpy.isclose(ai_channel.ai_max, 0.05)
-            assert ai_channel.ai_strain_units == StrainUnits.STRAIN
-            assert ai_channel.ai_strain_gage_cfg == StrainGageBridgeType.FULL_BRIDGE_I
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 1.0
-            assert ai_channel.ai_strain_gage_gage_factor == 4.0
-            assert ai_channel.ai_bridge_initial_voltage == 0.0
-            assert ai_channel.ai_strain_gage_poisson_ratio == 0.30
-            assert ai_channel.ai_lead_wire_resistance == 0.1
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "StrainGageChannel"
+        assert numpy.isclose(ai_channel.ai_min, -0.05)
+        assert numpy.isclose(ai_channel.ai_max, 0.05)
+        assert ai_channel.ai_strain_units == StrainUnits.STRAIN
+        assert ai_channel.ai_strain_gage_cfg == StrainGageBridgeType.FULL_BRIDGE_I
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 1.0
+        assert ai_channel.ai_strain_gage_gage_factor == 4.0
+        assert ai_channel.ai_bridge_initial_voltage == 0.0
+        assert ai_channel.ai_strain_gage_poisson_ratio == 0.30
+        assert ai_channel.ai_lead_wire_resistance == 0.1
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_voltage_chan_with_excit(self, any_x_series_device, seed):
+    def test_create_ai_voltage_chan_with_excit(self, task, any_x_series_device, seed):
         """Test for creating AI voltage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
-                ai_phys_chan,
-                name_to_assign_to_channel="VoltageExcitChannel",
-                terminal_config=TerminalConfiguration.NRSE,
-                min_val=-10.0,
-                max_val=10.0,
-                units=VoltageUnits.VOLTS,
-                bridge_config=BridgeConfiguration.NO_BRIDGE,
-                voltage_excit_source=ExcitationSource.EXTERNAL,
-                voltage_excit_val=0.1,
-                use_excit_for_scaling=False,
-                custom_scale_name="",
-            )
+        ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
+            ai_phys_chan,
+            name_to_assign_to_channel="VoltageExcitChannel",
+            terminal_config=TerminalConfiguration.NRSE,
+            min_val=-10.0,
+            max_val=10.0,
+            units=VoltageUnits.VOLTS,
+            bridge_config=BridgeConfiguration.NO_BRIDGE,
+            voltage_excit_source=ExcitationSource.EXTERNAL,
+            voltage_excit_val=0.1,
+            use_excit_for_scaling=False,
+            custom_scale_name="",
+        )
 
-            assert ai_channel.physical_channel.name == ai_phys_chan
-            assert ai_channel.name == "VoltageExcitChannel"
-            assert ai_channel.ai_term_cfg == TerminalConfiguration.NRSE
-            assert numpy.isclose(ai_channel.ai_min, -10.0)
-            assert numpy.isclose(ai_channel.ai_max, 10.0)
-            assert ai_channel.ai_voltage_units == VoltageUnits.VOLTS
-            assert ai_channel.ai_bridge_cfg == BridgeConfiguration.NO_BRIDGE
-            assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
-            assert ai_channel.ai_excit_val == 0.1
-            assert not ai_channel.ai_excit_use_for_scaling
+        assert ai_channel.physical_channel.name == ai_phys_chan
+        assert ai_channel.name == "VoltageExcitChannel"
+        assert ai_channel.ai_term_cfg == TerminalConfiguration.NRSE
+        assert numpy.isclose(ai_channel.ai_min, -10.0)
+        assert numpy.isclose(ai_channel.ai_max, 10.0)
+        assert ai_channel.ai_voltage_units == VoltageUnits.VOLTS
+        assert ai_channel.ai_bridge_cfg == BridgeConfiguration.NO_BRIDGE
+        assert ai_channel.ai_excit_src == ExcitationSource.EXTERNAL
+        assert ai_channel.ai_excit_val == 0.1
+        assert not ai_channel.ai_excit_use_for_scaling
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_power_chan(self, sim_ts_power_device, seed):
+    def test_create_ai_power_chan(self, task, sim_ts_power_device, seed):
         """Test for creating AI power channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -332,25 +322,24 @@ class TestAnalogCreateChannels:
         # CPLD is fixed-point, so values are coerced to something close.
         setpoint_tolerance = 1e-03
 
-        with nidaqmx.Task() as task:
-            pwr_channel = task.ai_channels.add_ai_power_chan(
-                pwr_phys_chan,
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
-                name_to_assign_to_channel="PowerChannel",
-            )
+        pwr_channel = task.ai_channels.add_ai_power_chan(
+            pwr_phys_chan,
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+            name_to_assign_to_channel="PowerChannel",
+        )
 
-            assert pwr_channel.physical_channel.name == pwr_phys_chan
-            assert pwr_channel.name == "PowerChannel"
-            assert numpy.isclose(
-                pwr_channel.pwr_voltage_setpoint, voltage_setpoint, atol=setpoint_tolerance
-            )
-            assert numpy.isclose(
-                pwr_channel.pwr_current_setpoint, current_setpoint, atol=setpoint_tolerance
-            )
-            assert pwr_channel.pwr_output_enable == output_enable
-            assert (
-                pwr_channel.pwr_idle_output_behavior
-                == constants.PowerIdleOutputBehavior.MAINTAIN_EXISTING_VALUE
-            )
+        assert pwr_channel.physical_channel.name == pwr_phys_chan
+        assert pwr_channel.name == "PowerChannel"
+        assert numpy.isclose(
+            pwr_channel.pwr_voltage_setpoint, voltage_setpoint, atol=setpoint_tolerance
+        )
+        assert numpy.isclose(
+            pwr_channel.pwr_current_setpoint, current_setpoint, atol=setpoint_tolerance
+        )
+        assert pwr_channel.pwr_output_enable == output_enable
+        assert (
+            pwr_channel.pwr_idle_output_behavior
+            == constants.PowerIdleOutputBehavior.MAINTAIN_EXISTING_VALUE
+        )

--- a/tests/legacy/test_channels.py
+++ b/tests/legacy/test_channels.py
@@ -1,8 +1,6 @@
 """Tests for validating the channel objects."""
 import numpy
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx.constants import TaskMode
 
 
@@ -12,58 +10,52 @@ class TestChannels:
     This validate the channel objects in the NI-DAQmx Python API.
     """
 
-    def test_ai_channel(self, any_x_series_device):
+    def test_ai_channel(self, task, any_x_series_device):
         """Tests for creating ai channel."""
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_voltage_chan(
-                any_x_series_device.ai_physical_chans[0].name, max_val=10
-            )
+        ai_channel = task.ai_channels.add_ai_voltage_chan(
+            any_x_series_device.ai_physical_chans[0].name, max_val=10
+        )
 
-            # Test property default value.
-            assert ai_channel.ai_max == 10
+        # Test property default value.
+        assert ai_channel.ai_max == 10
 
-    def test_ao_channel(self, any_x_series_device):
+    def test_ao_channel(self, task, any_x_series_device):
         """Tests for creating ao channel."""
-        with nidaqmx.Task() as task:
-            ao_channel = task.ao_channels.add_ao_voltage_chan(
-                any_x_series_device.ao_physical_chans[0].name, max_val=5
-            )
+        ao_channel = task.ao_channels.add_ao_voltage_chan(
+            any_x_series_device.ao_physical_chans[0].name, max_val=5
+        )
 
-            # Test property default value.
-            assert ao_channel.ao_max == 5
+        # Test property default value.
+        assert ao_channel.ao_max == 5
 
-    def test_ci_channel(self, real_x_series_device):
+    def test_ci_channel(self, task, real_x_series_device):
         """Tests for creating ci channel."""
-        with nidaqmx.Task() as task:
-            ci_channel = task.ci_channels.add_ci_count_edges_chan(
-                real_x_series_device.ci_physical_chans[0].name, initial_count=10
-            )
+        ci_channel = task.ci_channels.add_ci_count_edges_chan(
+            real_x_series_device.ci_physical_chans[0].name, initial_count=10
+        )
 
-            task.control(TaskMode.TASK_COMMIT)
+        task.control(TaskMode.TASK_COMMIT)
 
-            assert ci_channel.ci_count == 10
+        assert ci_channel.ci_count == 10
 
-    def test_co_channel(self, any_x_series_device):
+    def test_co_channel(self, task, any_x_series_device):
         """Tests for creating co channel."""
-        with nidaqmx.Task() as task:
-            co_channel = task.co_channels.add_co_pulse_chan_freq(
-                any_x_series_device.co_physical_chans[0].name, freq=5000
-            )
+        co_channel = task.co_channels.add_co_pulse_chan_freq(
+            any_x_series_device.co_physical_chans[0].name, freq=5000
+        )
 
-            task.control(TaskMode.TASK_COMMIT)
+        task.control(TaskMode.TASK_COMMIT)
 
-            numpy.testing.assert_allclose([co_channel.co_pulse_freq], [5000], rtol=0.05)
+        numpy.testing.assert_allclose([co_channel.co_pulse_freq], [5000], rtol=0.05)
 
-    def test_di_channel(self, any_x_series_device):
+    def test_di_channel(self, task, any_x_series_device):
         """Tests for creating di channel."""
-        with nidaqmx.Task() as task:
-            di_channel = task.di_channels.add_di_chan(any_x_series_device.di_lines[0].name)
+        di_channel = task.di_channels.add_di_chan(any_x_series_device.di_lines[0].name)
 
-            assert di_channel.di_num_lines == 1
+        assert di_channel.di_num_lines == 1
 
-    def test_do_channel(self, any_x_series_device):
+    def test_do_channel(self, task, any_x_series_device):
         """Tests for creating do channel."""
-        with nidaqmx.Task() as task:
-            do_channel = task.do_channels.add_do_chan(any_x_series_device.do_lines[0].name)
+        do_channel = task.do_channels.add_do_chan(any_x_series_device.do_lines[0].name)
 
-            assert do_channel.do_num_lines == 1
+        assert do_channel.do_num_lines == 1

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -3,7 +3,6 @@ import random
 
 import pytest
 
-import nidaqmx
 from nidaqmx.utils import flatten_channel_string
 from tests.helpers import generate_random_seed
 
@@ -82,35 +81,32 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_hash_operations(self, any_x_series_device, seed):
+    def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        # Reset the pseudorandom number generator with seed.
-        random.seed(seed)
-
         ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 3)
+        task_1 = generate_task()
+        task_2 = generate_task()
+        ai_channel_1 = task_1.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[0].name,
+            name_to_assign_to_channel="VoltageChannel",
+            max_val=5,
+            min_val=-5,
+        )
+        ai_channel_2 = task_1.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[1].name, max_val=5, min_val=-5
+        )
 
-        with nidaqmx.Task() as task_1, nidaqmx.Task() as task_2:
-            ai_channel_1 = task_1.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[0].name,
-                name_to_assign_to_channel="VoltageChannel",
-                max_val=5,
-                min_val=-5,
-            )
-            ai_channel_2 = task_1.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[1].name, max_val=5, min_val=-5
-            )
+        ai_channel_3 = task_2.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[2].name,
+            name_to_assign_to_channel="VoltageChannel",
+            max_val=5,
+            min_val=-5,
+        )
 
-            ai_channel_3 = task_2.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[2].name,
-                name_to_assign_to_channel="VoltageChannel",
-                max_val=5,
-                min_val=-5,
-            )
-
-            assert hash(ai_channel_1) == hash(task_1.ai_channels[0])
-            assert hash(ai_channel_1) != hash(ai_channel_2)
-            assert hash(task_1.ai_channels) != hash(task_2.ai_channels)
-            assert hash(ai_channel_1) != hash(ai_channel_3)
+        assert hash(ai_channel_1) == hash(task_1.ai_channels[0])
+        assert hash(ai_channel_1) != hash(ai_channel_2)
+        assert hash(task_1.ai_channels) != hash(task_2.ai_channels)
+        assert hash(ai_channel_1) != hash(ai_channel_3)

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -15,73 +15,71 @@ class TestContainerOperations:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_concatenate_operations(self, any_x_series_device, seed):
+    def test_concatenate_operations(self, task, any_x_series_device, seed):
         """Test for concatenate operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
 
-        with nidaqmx.Task() as task:
-            ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[0].name, max_val=5, min_val=-5
-            )
+        ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[0].name, max_val=5, min_val=-5
+        )
 
-            ai_channel_2 = task.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[1].name, max_val=5, min_val=-5
-            )
+        ai_channel_2 = task.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[1].name, max_val=5, min_val=-5
+        )
 
-            # Concatenate two channels.
-            ai_channel = ai_channel_1 + ai_channel_2
+        # Concatenate two channels.
+        ai_channel = ai_channel_1 + ai_channel_2
 
-            # Test that concatenated channel name has flattened value of the
-            # individual channel names.
-            assert ai_channel.name == flatten_channel_string(
-                [ai_phys_chans[0].name, ai_phys_chans[1].name]
-            )
+        # Test that concatenated channel name has flattened value of the
+        # individual channel names.
+        assert ai_channel.name == flatten_channel_string(
+            [ai_phys_chans[0].name, ai_phys_chans[1].name]
+        )
 
-            # Test that setting property on concatenated channel changes the
-            # property values of the individual channels.
-            ai_channel.ai_max = 10
-            assert ai_channel_1.ai_max == 10
-            assert ai_channel_2.ai_max == 10
+        # Test that setting property on concatenated channel changes the
+        # property values of the individual channels.
+        ai_channel.ai_max = 10
+        assert ai_channel_1.ai_max == 10
+        assert ai_channel_2.ai_max == 10
 
-            # Concatenate two channels.
-            ai_channel_1 += ai_channel_2
+        # Concatenate two channels.
+        ai_channel_1 += ai_channel_2
 
-            # Test that concatenated channel name has flattened value of the
-            # individual channel names.
-            assert ai_channel_1.name == flatten_channel_string(
-                [ai_phys_chans[0].name, ai_phys_chans[1].name]
-            )
+        # Test that concatenated channel name has flattened value of the
+        # individual channel names.
+        assert ai_channel_1.name == flatten_channel_string(
+            [ai_phys_chans[0].name, ai_phys_chans[1].name]
+        )
 
-            # Test that setting property on concatenated channel changes the
-            # property values of the individual channels.
-            # Note: 0.2V range exists on most X Series devices.
-            ai_channel_1.ai_max = 0.2
-            ai_channel_1.ai_min = -0.2
-            assert ai_channel_2.ai_max == 0.2
-            assert ai_channel_2.ai_min == -0.2
+        # Test that setting property on concatenated channel changes the
+        # property values of the individual channels.
+        # Note: 0.2V range exists on most X Series devices.
+        ai_channel_1.ai_max = 0.2
+        ai_channel_1.ai_min = -0.2
+        assert ai_channel_2.ai_max == 0.2
+        assert ai_channel_2.ai_min == -0.2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_equality_operations(self, any_x_series_device, seed):
+    def test_equality_operations(self, task, any_x_series_device, seed):
         """Test for equality operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
 
-        with nidaqmx.Task() as task:
-            ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[0].name, max_val=5, min_val=-5
-            )
-            ai_channel_2 = task.ai_channels.add_ai_voltage_chan(
-                ai_phys_chans[1].name, max_val=5, min_val=-5
-            )
+        ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[0].name, max_val=5, min_val=-5
+        )
+        ai_channel_2 = task.ai_channels.add_ai_voltage_chan(
+            ai_phys_chans[1].name, max_val=5, min_val=-5
+        )
 
-            assert ai_channel_1 == task.ai_channels[0]
-            assert ai_channel_1 == task.ai_channels[ai_phys_chans[0].name]
-            assert ai_channel_1 != ai_channel_2
+        assert ai_channel_1 == task.ai_channels[0]
+        assert ai_channel_1 == task.ai_channels[ai_phys_chans[0].name]
+        assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_hash_operations(self, any_x_series_device, seed):

--- a/tests/legacy/test_events.py
+++ b/tests/legacy/test_events.py
@@ -4,7 +4,6 @@ import time
 
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import AcquisitionType
 from tests.helpers import generate_random_seed
 
@@ -16,7 +15,7 @@ class TestEvents:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_every_n_samples_event(self, any_x_series_device, seed):
+    def test_every_n_samples_event(self, task, any_x_series_device, seed):
         """Test for validating every n samples event."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -24,52 +23,51 @@ class TestEvents:
         samples_chunk = 100
         sample_rate = 5000
 
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-            samples_multiple = random.randint(2, 5)
-            num_samples = samples_chunk * samples_multiple
+        samples_multiple = random.randint(2, 5)
+        num_samples = samples_chunk * samples_multiple
 
-            task.timing.cfg_samp_clk_timing(
-                sample_rate, sample_mode=AcquisitionType.FINITE, samps_per_chan=num_samples
-            )
+        task.timing.cfg_samp_clk_timing(
+            sample_rate, sample_mode=AcquisitionType.FINITE, samps_per_chan=num_samples
+        )
 
-            # Python 2.X does not have nonlocal keyword.
-            non_local_var = {"samples_read": 0}
+        # Python 2.X does not have nonlocal keyword.
+        non_local_var = {"samples_read": 0}
 
-            def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
-                samples = task.read(number_of_samples_per_channel=samples_chunk, timeout=2.0)
-                non_local_var["samples_read"] += len(samples)
-                return 0
+        def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
+            samples = task.read(number_of_samples_per_channel=samples_chunk, timeout=2.0)
+            non_local_var["samples_read"] += len(samples)
+            return 0
 
-            task.register_every_n_samples_acquired_into_buffer_event(samples_chunk, callback)
+        task.register_every_n_samples_acquired_into_buffer_event(samples_chunk, callback)
 
-            task.start()
-            task.wait_until_done(timeout=2)
+        task.start()
+        task.wait_until_done(timeout=2)
 
-            # Wait until done doesn't wait for all callbacks to be processed.
-            time.sleep(1)
-            task.stop()
+        # Wait until done doesn't wait for all callbacks to be processed.
+        time.sleep(1)
+        task.stop()
 
-            assert non_local_var["samples_read"] == num_samples
+        assert non_local_var["samples_read"] == num_samples
 
-            samples_multiple = random.randint(2, 5)
-            num_samples = samples_chunk * samples_multiple
+        samples_multiple = random.randint(2, 5)
+        num_samples = samples_chunk * samples_multiple
 
-            task.timing.cfg_samp_clk_timing(
-                sample_rate, sample_mode=AcquisitionType.FINITE, samps_per_chan=num_samples
-            )
+        task.timing.cfg_samp_clk_timing(
+            sample_rate, sample_mode=AcquisitionType.FINITE, samps_per_chan=num_samples
+        )
 
-            non_local_var = {"samples_read": 0}
+        non_local_var = {"samples_read": 0}
 
-            # Unregister event callback function by passing None.
-            task.register_every_n_samples_acquired_into_buffer_event(samples_chunk, None)
+        # Unregister event callback function by passing None.
+        task.register_every_n_samples_acquired_into_buffer_event(samples_chunk, None)
 
-            task.start()
-            task.wait_until_done(timeout=2)
+        task.start()
+        task.wait_until_done(timeout=2)
 
-            # Wait until done doesn't wait for all callbacks to be processed.
-            time.sleep(1)
-            task.stop()
+        # Wait until done doesn't wait for all callbacks to be processed.
+        time.sleep(1)
+        task.stop()
 
-            assert non_local_var["samples_read"] == 0
+        assert non_local_var["samples_read"] == 0

--- a/tests/legacy/test_export_signals.py
+++ b/tests/legacy/test_export_signals.py
@@ -18,7 +18,7 @@ class TestExportSignals(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_export_signals(self, any_x_series_device, seed):
+    def test_export_signals(self, task, any_x_series_device, seed):
         """Test for validating export signals."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -26,10 +26,9 @@ class TestExportSignals(TestDAQmxIOBase):
         ai_chan = random.choice(any_x_series_device.ai_physical_chans)
         pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(ai_chan.name)
-            task.timing.cfg_samp_clk_timing(1000)
+        task.ai_channels.add_ai_voltage_chan(ai_chan.name)
+        task.timing.cfg_samp_clk_timing(1000)
 
-            task.export_signals.export_signal(Signal.SAMPLE_CLOCK, pfi_line)
+        task.export_signals.export_signal(Signal.SAMPLE_CLOCK, pfi_line)
 
-            assert task.export_signals.samp_clk_output_term == pfi_line
+        assert task.export_signals.samp_clk_output_term == pfi_line

--- a/tests/legacy/test_export_signals.py
+++ b/tests/legacy/test_export_signals.py
@@ -3,7 +3,6 @@ import random
 
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import Signal
 from tests.helpers import generate_random_seed
 from tests.legacy.test_read_write import TestDAQmxIOBase

--- a/tests/legacy/test_invalid_reads.py
+++ b/tests/legacy/test_invalid_reads.py
@@ -14,7 +14,7 @@
 # class TestInvalidReads(TestReadWriteBase):
 
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_one_chan_read_for_n_chan_task(self, any_x_series_device, seed):
+# def test_one_chan_read_for_n_chan_task(self, task, any_x_series_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
@@ -24,31 +24,29 @@
 #     ai_channels = random.sample(
 #         any_x_series_device.ai_physical_chans, number_of_channels)
 #
-#     with nidaqmx.Task() as task:
-#         task.ai_channels.add_ai_voltage_chan(
-#             flatten_channel_string([c.name for c in ai_channels]),
-#             max_val=10, min_val=-10)
+#     task.ai_channels.add_ai_voltage_chan(
+#         flatten_channel_string([c.name for c in ai_channels]),
+#         max_val=10, min_val=-10)
 #
-#         with pytest.raises(DaqError) as e:
-#             task.read_one_chan()
-#         assert e.value.error_code == -200523
+#     with pytest.raises(DaqError) as e:
+#         task.read_one_chan()
+#     assert e.value.error_code == -200523
 
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_numpy_read_for_counter_pulse_task(self, any_x_series_device, seed):
+# def test_numpy_read_for_counter_pulse_task(self, task, any_x_series_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
 #     counter = random.choice(self._get_device_counters(any_x_series_device))
 #
-#     with nidaqmx.Task() as task:
-#         task.ci_channels.add_ci_pulse_chan_freq(counter)
+#     task.ci_channels.add_ci_pulse_chan_freq(counter)
 #
-#         with pytest.raises(DaqError) as e:
-#             task.read_numpy()
-#         assert e.value.error_code == -1
+#     with pytest.raises(DaqError) as e:
+#         task.read_numpy()
+#     assert e.value.error_code == -1
 #
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_numpy_read_incorrectly_shaped_data(self, any_x_series_device, seed):
+# def test_numpy_read_incorrectly_shaped_data(self, task, any_x_series_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
@@ -59,23 +57,22 @@
 #         any_x_series_device.ai_physical_chans, number_of_channels)
 #     number_of_samples = random.randint(50, 100)
 #
-#     with nidaqmx.Task() as task:
-#         task.ai_channels.add_ai_voltage_chan(
-#             flatten_channel_string([c.name for c in channels_to_test]),
-#             max_val=10, min_val=-10)
-#         task.timing.cfg_samp_clk_timing(
-#             1000, samps_per_chan=number_of_samples)
+#     task.ai_channels.add_ai_voltage_chan(
+#         flatten_channel_string([c.name for c in channels_to_test]),
+#         max_val=10, min_val=-10)
+#     task.timing.cfg_samp_clk_timing(
+#         1000, samps_per_chan=number_of_samples)
 #
-#         # Allocate numpy array but swap the rows and columns so the numpy
-#         # array is shaped incorrectly, but the amount of samples is still
-#         # the same.
-#         numpy_array = numpy.zeros(
-#             (number_of_samples, number_of_channels), dtype=numpy.float64)
+#     # Allocate numpy array but swap the rows and columns so the numpy
+#     # array is shaped incorrectly, but the amount of samples is still
+#     # the same.
+#     numpy_array = numpy.zeros(
+#         (number_of_samples, number_of_channels), dtype=numpy.float64)
 #
-#         with pytest.raises(DaqError) as e:
-#             task.read_numpy(
-#                 numpy_array=numpy_array,
-#                 number_of_samples_per_channel=number_of_samples,
-#                 timeout=2)
+#     with pytest.raises(DaqError) as e:
+#         task.read_numpy(
+#             numpy_array=numpy_array,
+#             number_of_samples_per_channel=number_of_samples,
+#             timeout=2)
 #
-#         assert e.value.error_code == -1
+#     assert e.value.error_code == -1

--- a/tests/legacy/test_invalid_writes.py
+++ b/tests/legacy/test_invalid_writes.py
@@ -4,7 +4,6 @@ import random
 import numpy
 import pytest
 
-import nidaqmx
 from nidaqmx.errors import DaqError
 from nidaqmx.utils import flatten_channel_string
 from tests.helpers import generate_random_seed
@@ -17,7 +16,7 @@ class TestInvalidWrites:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_insufficient_write_data(self, any_x_series_device, seed):
+    def test_insufficient_write_data(self, task, any_x_series_device, seed):
         """Test for validating write functionality with insufficient data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -26,24 +25,23 @@ class TestInvalidWrites:
         number_of_channels = random.randint(2, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
 
-        with nidaqmx.Task() as task:
-            task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
+        )
 
-            with pytest.raises(DaqError) as e:
-                task.write(random.uniform(-10, 10))
-            assert e.value.error_code == -200524
+        with pytest.raises(DaqError) as e:
+            task.write(random.uniform(-10, 10))
+        assert e.value.error_code == -200524
 
-            number_of_samples = random.randint(1, number_of_channels - 1)
-            values_to_test = [random.uniform(-10, 10) for _ in range(number_of_samples)]
+        number_of_samples = random.randint(1, number_of_channels - 1)
+        values_to_test = [random.uniform(-10, 10) for _ in range(number_of_samples)]
 
-            with pytest.raises(DaqError) as e:
-                task.write(values_to_test, auto_start=True)
-            assert e.value.error_code == -200524
+        with pytest.raises(DaqError) as e:
+            task.write(values_to_test, auto_start=True)
+        assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_insufficient_numpy_write_data(self, any_x_series_device, seed):
+    def test_insufficient_numpy_write_data(self, task, any_x_series_device, seed):
         """Test for validating write functionality with insufficient data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -52,22 +50,19 @@ class TestInvalidWrites:
         number_of_channels = random.randint(2, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
 
-        with nidaqmx.Task() as task:
-            task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
+        )
 
-            number_of_samples = random.randint(1, number_of_channels - 1)
-            values_to_test = numpy.float64(
-                [random.uniform(-10, 10) for _ in range(number_of_samples)]
-            )
+        number_of_samples = random.randint(1, number_of_channels - 1)
+        values_to_test = numpy.float64([random.uniform(-10, 10) for _ in range(number_of_samples)])
 
-            with pytest.raises(DaqError) as e:
-                task.write(values_to_test, auto_start=True)
-            assert e.value.error_code == -200524
+        with pytest.raises(DaqError) as e:
+            task.write(values_to_test, auto_start=True)
+        assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_extraneous_write_data(self, any_x_series_device, seed):
+    def test_extraneous_write_data(self, task, any_x_series_device, seed):
         """Test for validating write functionality with extraneous data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -76,24 +71,23 @@ class TestInvalidWrites:
         number_of_channels = random.randint(1, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
 
-        with nidaqmx.Task() as task:
-            task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
+        )
 
-            # Generate random values to test.
-            number_of_data_rows = random.randint(number_of_channels + 1, number_of_channels + 10)
-            values_to_test = [
-                [random.uniform(-10, 10) for _ in range(10)] for _ in range(number_of_data_rows)
-            ]
+        # Generate random values to test.
+        number_of_data_rows = random.randint(number_of_channels + 1, number_of_channels + 10)
+        values_to_test = [
+            [random.uniform(-10, 10) for _ in range(10)] for _ in range(number_of_data_rows)
+        ]
 
-            with pytest.raises(DaqError) as e:
-                task.write(values_to_test, auto_start=True)
+        with pytest.raises(DaqError) as e:
+            task.write(values_to_test, auto_start=True)
 
-            assert e.value.error_code == -200524
+        assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_extraneous_numpy_write_data(self, any_x_series_device, seed):
+    def test_extraneous_numpy_write_data(self, task, any_x_series_device, seed):
         """Test for validating write functionality with extraneous data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -102,26 +96,25 @@ class TestInvalidWrites:
         number_of_channels = random.randint(1, len(any_x_series_device.ao_physical_chans))
         channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
 
-        with nidaqmx.Task() as task:
-            task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
+        )
 
-            # Generate random values to test.
-            number_of_data_rows = random.randint(number_of_channels + 1, number_of_channels + 10)
-            values_to_test = [
-                [random.uniform(-10, 10) for _ in range(10)] for _ in range(number_of_data_rows)
-            ]
+        # Generate random values to test.
+        number_of_data_rows = random.randint(number_of_channels + 1, number_of_channels + 10)
+        values_to_test = [
+            [random.uniform(-10, 10) for _ in range(10)] for _ in range(number_of_data_rows)
+        ]
 
-            numpy_data = numpy.float64(values_to_test)
+        numpy_data = numpy.float64(values_to_test)
 
-            with pytest.raises(DaqError) as e:
-                task.write(numpy_data, auto_start=True)
+        with pytest.raises(DaqError) as e:
+            task.write(numpy_data, auto_start=True)
 
-            assert e.value.error_code == -200524
+        assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_numpy_write_incorrectly_shaped_data(self, any_x_series_device, seed):
+    def test_numpy_write_incorrectly_shaped_data(self, task, any_x_series_device, seed):
         """Test for validating write functionality with incorrectly shaped data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -131,23 +124,22 @@ class TestInvalidWrites:
         channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
         number_of_samples = random.randint(50, 100)
 
-        with nidaqmx.Task() as task:
-            task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
-            )
-            task.timing.cfg_samp_clk_timing(1000, samps_per_chan=number_of_samples)
+        task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
+        )
+        task.timing.cfg_samp_clk_timing(1000, samps_per_chan=number_of_samples)
 
-            # Generate write data but swap the rows and columns so the numpy
-            # array is shaped incorrectly, but the amount of samples is still
-            # the same.
-            values_to_test = numpy.float64(
-                [
-                    [random.uniform(-10, 10) for _ in range(number_of_channels)]
-                    for _ in range(number_of_samples)
-                ]
-            )
+        # Generate write data but swap the rows and columns so the numpy
+        # array is shaped incorrectly, but the amount of samples is still
+        # the same.
+        values_to_test = numpy.float64(
+            [
+                [random.uniform(-10, 10) for _ in range(number_of_channels)]
+                for _ in range(number_of_samples)
+            ]
+        )
 
-            with pytest.raises(DaqError) as e:
-                task.write(values_to_test, auto_start=True)
+        with pytest.raises(DaqError) as e:
+            task.write(values_to_test, auto_start=True)
 
-            assert e.value.error_code == -200524
+        assert e.value.error_code == -200524

--- a/tests/legacy/test_properties.py
+++ b/tests/legacy/test_properties.py
@@ -3,8 +3,6 @@ import random
 
 import pytest
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx import DaqError
 from nidaqmx.constants import AcquisitionType, UsageTypeAI
 from tests.helpers import generate_random_seed
@@ -16,133 +14,127 @@ class TestPropertyBasicDataTypes:
     This validates the property getter,setter and deleter methods for different basic data types.
     """
 
-    def test_boolean_property(self, any_x_series_device):
+    def test_boolean_property(self, task, any_x_series_device):
         """Test for validating boolean property."""
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-            task.timing.cfg_samp_clk_timing(1000)
-            task.triggers.start_trigger.cfg_dig_edge_start_trig(
-                f"/{any_x_series_device.name}/Ctr0InternalOutput"
-            )
+        task.timing.cfg_samp_clk_timing(1000)
+        task.triggers.start_trigger.cfg_dig_edge_start_trig(
+            f"/{any_x_series_device.name}/Ctr0InternalOutput"
+        )
 
-            # Test property initial value.
-            assert not task.triggers.start_trigger.retriggerable
+        # Test property initial value.
+        assert not task.triggers.start_trigger.retriggerable
 
-            # Test property setter and getter.
-            task.triggers.start_trigger.retriggerable = True
-            assert task.triggers.start_trigger.retriggerable
+        # Test property setter and getter.
+        task.triggers.start_trigger.retriggerable = True
+        assert task.triggers.start_trigger.retriggerable
 
-            # Test property deleter.
-            del task.triggers.start_trigger.retriggerable
-            assert not task.triggers.start_trigger.retriggerable
+        # Test property deleter.
+        del task.triggers.start_trigger.retriggerable
+        assert not task.triggers.start_trigger.retriggerable
 
-    def test_enum_property(self, any_x_series_device):
+    def test_enum_property(self, task, any_x_series_device):
         """Test for validating enum property."""
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-            task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
+        task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
-            # Test property initial value.
-            assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
+        # Test property initial value.
+        assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
-            # Test property setter and getter.
-            task.timing.samp_quant_samp_mode = AcquisitionType.FINITE
-            assert task.timing.samp_quant_samp_mode == AcquisitionType.FINITE
+        # Test property setter and getter.
+        task.timing.samp_quant_samp_mode = AcquisitionType.FINITE
+        assert task.timing.samp_quant_samp_mode == AcquisitionType.FINITE
 
-            # Test property deleter.
-            del task.timing.samp_quant_samp_mode
-            assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
+        # Test property deleter.
+        del task.timing.samp_quant_samp_mode
+        assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
-    def test_float_property(self, any_x_series_device):
+    def test_float_property(self, task, any_x_series_device):
         """Test for validating float property."""
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_voltage_chan(
-                any_x_series_device.ai_physical_chans[0].name, max_val=5
-            )
+        ai_channel = task.ai_channels.add_ai_voltage_chan(
+            any_x_series_device.ai_physical_chans[0].name, max_val=5
+        )
 
-            # Test property default value.
-            assert ai_channel.ai_max == 5
+        # Test property default value.
+        assert ai_channel.ai_max == 5
 
-            # Test property setter and getter.
-            max_value = 10
-            ai_channel.ai_max = max_value
-            assert ai_channel.ai_max == max_value
+        # Test property setter and getter.
+        max_value = 10
+        ai_channel.ai_max = max_value
+        assert ai_channel.ai_max == max_value
 
-            # Test property deleter. Reading this property will throw an
-            # error after being reset.
-            del ai_channel.ai_max
-            with pytest.raises(DaqError) as e:
-                read_value = ai_channel.ai_max  # noqa: F841
-            assert e.value.error_code == -200695
+        # Test property deleter. Reading this property will throw an
+        # error after being reset.
+        del ai_channel.ai_max
+        with pytest.raises(DaqError) as e:
+            read_value = ai_channel.ai_max  # noqa: F841
+        assert e.value.error_code == -200695
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_int_property(self, any_x_series_device, seed):
+    def test_int_property(self, task, any_x_series_device, seed):
         """Test for validating integer property."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        with nidaqmx.Task() as task:
-            task.ci_channels.add_ci_count_edges_chan(any_x_series_device.ci_physical_chans[0].name)
+        task.ci_channels.add_ci_count_edges_chan(any_x_series_device.ci_physical_chans[0].name)
 
-            # Test property default value.
-            assert task.in_stream.offset == 0
+        # Test property default value.
+        assert task.in_stream.offset == 0
 
-            # Test property setter and getter.
-            value_to_test = random.randint(0, 100)
-            task.in_stream.offset = value_to_test
-            assert task.in_stream.offset == value_to_test
+        # Test property setter and getter.
+        value_to_test = random.randint(0, 100)
+        task.in_stream.offset = value_to_test
+        assert task.in_stream.offset == value_to_test
 
-            value_to_test = random.randint(-100, 0)
-            task.in_stream.offset = value_to_test
-            assert task.in_stream.offset == value_to_test
+        value_to_test = random.randint(-100, 0)
+        task.in_stream.offset = value_to_test
+        assert task.in_stream.offset == value_to_test
 
-            # Test property deleter.
-            del task.in_stream.offset
-            assert task.in_stream.offset == 0
+        # Test property deleter.
+        del task.in_stream.offset
+        assert task.in_stream.offset == 0
 
-    def test_string_property(self, any_x_series_device):
+    def test_string_property(self, task, any_x_series_device):
         """Test for validating string property."""
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_voltage_chan(
-                any_x_series_device.ai_physical_chans[0].name
-            )
+        ai_channel = task.ai_channels.add_ai_voltage_chan(
+            any_x_series_device.ai_physical_chans[0].name
+        )
 
-            # Test property default value.
-            assert ai_channel.description == ""
+        # Test property default value.
+        assert ai_channel.description == ""
 
-            # Test property setter and getter.
-            description = "Channel description."
-            ai_channel.description = description
-            assert ai_channel.description == description
+        # Test property setter and getter.
+        description = "Channel description."
+        ai_channel.description = description
+        assert ai_channel.description == description
 
-            # Test property deleter.
-            del ai_channel.description
-            assert ai_channel.description == ""
+        # Test property deleter.
+        del ai_channel.description
+        assert ai_channel.description == ""
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_uint_property(self, any_x_series_device, seed):
+    def test_uint_property(self, task, any_x_series_device, seed):
         """Test for validating uint property."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        with nidaqmx.Task() as task:
-            task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
 
-            task.timing.cfg_samp_clk_timing(1000)
+        task.timing.cfg_samp_clk_timing(1000)
 
-            # Test property initial value.
-            assert task.timing.samp_clk_timebase_div == 100000
+        # Test property initial value.
+        assert task.timing.samp_clk_timebase_div == 100000
 
-            # Test property setter and getter.
-            value_to_test = random.randint(500, 10000)
-            task.timing.samp_clk_timebase_div = value_to_test
-            assert task.timing.samp_clk_timebase_div == value_to_test
+        # Test property setter and getter.
+        value_to_test = random.randint(500, 10000)
+        task.timing.samp_clk_timebase_div = value_to_test
+        assert task.timing.samp_clk_timebase_div == value_to_test
 
-            # Test property deleter.
-            del task.timing.samp_clk_timebase_div
-            assert task.timing.samp_clk_timebase_div == 100000
+        # Test property deleter.
+        del task.timing.samp_clk_timebase_div
+        assert task.timing.samp_clk_timebase_div == 100000
 
 
 class TestPropertyListDataTypes:
@@ -169,26 +161,23 @@ class TestPropertyListDataTypes:
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     @pytest.mark.parametrize("device_by_name", ["bridgeTester"], indirect=True)
-    def test_list_of_floats_property(self, device_by_name, seed):
+    def test_list_of_floats_property(self, task, device_by_name, seed):
         """Test for validating list of float property."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_ai_bridge_chan(
-                device_by_name.ai_physical_chans[0].name
-            )
+        ai_channel = task.ai_channels.add_ai_bridge_chan(device_by_name.ai_physical_chans[0].name)
 
-            # Test default property value.
-            assert isinstance(ai_channel.ai_bridge_poly_forward_coeff, list)
-            assert len(ai_channel.ai_bridge_poly_forward_coeff) == 0
+        # Test default property value.
+        assert isinstance(ai_channel.ai_bridge_poly_forward_coeff, list)
+        assert len(ai_channel.ai_bridge_poly_forward_coeff) == 0
 
-            # Test property setter and getter.
-            value_to_test = [random.randint(-10, 10) for _ in range(random.randint(2, 5))]
-            ai_channel.ai_bridge_poly_forward_coeff = value_to_test
-            assert ai_channel.ai_bridge_poly_forward_coeff == value_to_test
+        # Test property setter and getter.
+        value_to_test = [random.randint(-10, 10) for _ in range(random.randint(2, 5))]
+        ai_channel.ai_bridge_poly_forward_coeff = value_to_test
+        assert ai_channel.ai_bridge_poly_forward_coeff == value_to_test
 
-            # Test property deleter.
-            del ai_channel.ai_bridge_poly_forward_coeff
-            assert isinstance(ai_channel.ai_bridge_poly_forward_coeff, list)
-            assert len(ai_channel.ai_bridge_poly_forward_coeff) == 0
+        # Test property deleter.
+        del ai_channel.ai_bridge_poly_forward_coeff
+        assert isinstance(ai_channel.ai_bridge_poly_forward_coeff, list)
+        assert len(ai_channel.ai_bridge_poly_forward_coeff) == 0

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -15,7 +15,7 @@ class TestReadExceptions:
     loopback routes on the device.
     """
 
-    def test_timeout(self, real_x_series_device):
+    def test_timeout(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
         if not (
@@ -28,50 +28,50 @@ class TestReadExceptions:
         clocks_to_give = 100
         sample_rate = 1000
 
-        with nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Use a counter output pulse train task as the sample clock source
-            # for both the AI and AO tasks.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
-            )
-            sample_clk_task.timing.cfg_implicit_timing(
-                samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
-            )
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        # Use a counter output pulse train task as the sample clock source
+        # for both the AI and AO tasks.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(
+            f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
+        )
+        sample_clk_task.timing.cfg_implicit_timing(
+            samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
+        )
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
-            )
-            read_task.timing.cfg_samp_clk_timing(
-                sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
-            )
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            # Start the read task before the clock.
-            read_task.start()
+        read_task.ai_channels.add_ai_voltage_chan(
+            real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
+        )
+        read_task.timing.cfg_samp_clk_timing(
+            sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
+        )
 
-            # Generate all the clocks.
-            sample_clk_task.start()
-            sample_clk_task.wait_until_done()
-            sample_clk_task.stop()
+        # Start the read task before the clock.
+        read_task.start()
 
-            # Do a partial read which succeeds.
+        # Generate all the clocks.
+        sample_clk_task.start()
+        sample_clk_task.wait_until_done()
+        sample_clk_task.stop()
+
+        # Do a partial read which succeeds.
+        values_read = read_task.read(number_of_samples_per_channel=samples_to_read, timeout=2.0)
+        assert len(values_read) == samples_to_read
+
+        # Now read more data than is available.
+        with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
             values_read = read_task.read(number_of_samples_per_channel=samples_to_read, timeout=2.0)
-            assert len(values_read) == samples_to_read
 
-            # Now read more data than is available.
-            with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
-                values_read = read_task.read(
-                    number_of_samples_per_channel=samples_to_read, timeout=2.0
-                )
+        assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
+        # We should have read a partial dataset.
+        number_of_samples_expected = clocks_to_give - samples_to_read
+        assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-            assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
-            # We should have read a partial dataset.
-            number_of_samples_expected = clocks_to_give - samples_to_read
-            assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
-
-    def test_timeout_raw(self, real_x_series_device):
+    def test_timeout_raw(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
         if not (
@@ -84,53 +84,53 @@ class TestReadExceptions:
         clocks_to_give = 100
         sample_rate = 1000
 
-        with nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Use a counter output pulse train task as the sample clock source
-            # for both the AI and AO tasks.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
-            )
-            sample_clk_task.timing.cfg_implicit_timing(
-                samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
-            )
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        # Use a counter output pulse train task as the sample clock source
+        # for both the AI and AO tasks.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(
+            f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
+        )
+        sample_clk_task.timing.cfg_implicit_timing(
+            samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
+        )
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
-            )
-            read_task.timing.cfg_samp_clk_timing(
-                sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
-            )
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            # Start the read task before the clock.
-            read_task.start()
+        read_task.ai_channels.add_ai_voltage_chan(
+            real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
+        )
+        read_task.timing.cfg_samp_clk_timing(
+            sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
+        )
 
-            # Generate all the clocks.
-            sample_clk_task.start()
-            sample_clk_task.wait_until_done()
-            sample_clk_task.stop()
+        # Start the read task before the clock.
+        read_task.start()
 
-            # Set read timeout.
-            read_task.in_stream.timeout = 2.0
+        # Generate all the clocks.
+        sample_clk_task.start()
+        sample_clk_task.wait_until_done()
+        sample_clk_task.stop()
 
-            # Do a partial read which should succeed.
+        # Set read timeout.
+        read_task.in_stream.timeout = 2.0
+
+        # Do a partial read which should succeed.
+        values_read = read_task.in_stream.read(number_of_samples_per_channel=samples_to_read)
+        assert len(values_read) == samples_to_read
+
+        # Now read more data than is available.
+        with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
             values_read = read_task.in_stream.read(number_of_samples_per_channel=samples_to_read)
-            assert len(values_read) == samples_to_read
 
-            # Now read more data than is available.
-            with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
-                values_read = read_task.in_stream.read(
-                    number_of_samples_per_channel=samples_to_read
-                )
+        assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
+        # We should have read a partial dataset.
+        number_of_samples_expected = clocks_to_give - samples_to_read
+        assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-            assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
-            # We should have read a partial dataset.
-            number_of_samples_expected = clocks_to_give - samples_to_read
-            assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
-
-    def test_timeout_stream(self, real_x_series_device):
+    def test_timeout_stream(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
         if not (
@@ -145,62 +145,61 @@ class TestReadExceptions:
         # Choose a sentinel value that can't be returned by the read.
         sentinel_value = -100.0
 
-        with nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Use a counter output pulse train task as the sample clock source
-            # for both the AI and AO tasks.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
-            )
-            sample_clk_task.timing.cfg_implicit_timing(
-                samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
-            )
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
+        read_task = generate_task()
+        sample_clk_task = generate_task()
+        # Use a counter output pulse train task as the sample clock source
+        # for both the AI and AO tasks.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(
+            f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
+        )
+        sample_clk_task.timing.cfg_implicit_timing(
+            samps_per_chan=clocks_to_give, sample_mode=AcquisitionType.FINITE
+        )
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
-            )
-            read_task.timing.cfg_samp_clk_timing(
-                sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
-            )
+        read_task.ai_channels.add_ai_voltage_chan(
+            real_x_series_device.ai_physical_chans[0].name, max_val=10, min_val=-10
+        )
+        read_task.timing.cfg_samp_clk_timing(
+            sample_rate, source=samp_clk_terminal, sample_mode=AcquisitionType.CONTINUOUS
+        )
 
-            reader = nidaqmx.stream_readers.AnalogSingleChannelReader(read_task.in_stream)
+        reader = nidaqmx.stream_readers.AnalogSingleChannelReader(read_task.in_stream)
 
-            # Start the read task before the clock.
-            read_task.start()
+        # Start the read task before the clock.
+        read_task.start()
 
-            # Generate all the clocks.
-            sample_clk_task.start()
-            sample_clk_task.wait_until_done()
-            sample_clk_task.stop()
+        # Generate all the clocks.
+        sample_clk_task.start()
+        sample_clk_task.wait_until_done()
+        sample_clk_task.stop()
 
-            # Set read timeout.
-            read_task.in_stream.timeout = 2
+        # Set read timeout.
+        read_task.in_stream.timeout = 2
 
-            # Do a partial read which should succeed.
-            data = numpy.full(samples_to_read, sentinel_value, dtype=numpy.float64)
+        # Do a partial read which should succeed.
+        data = numpy.full(samples_to_read, sentinel_value, dtype=numpy.float64)
+        num_values_read = reader.read_many_sample(
+            data, number_of_samples_per_channel=samples_to_read, timeout=2.0
+        )
+        assert num_values_read == samples_to_read
+        # All the data should have been overwritten.
+        assert not any(element == sentinel_value for element in data)
+
+        # Now read more data than is available.
+        data = numpy.full(samples_to_read, sentinel_value, dtype=numpy.float64)
+        with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
             num_values_read = reader.read_many_sample(
                 data, number_of_samples_per_channel=samples_to_read, timeout=2.0
             )
-            assert num_values_read == samples_to_read
-            # All the data should have been overwritten.
-            assert not any(element == sentinel_value for element in data)
 
-            # Now read more data than is available.
-            data = numpy.full(samples_to_read, sentinel_value, dtype=numpy.float64)
-            with pytest.raises(nidaqmx.DaqReadError) as timeout_exception:
-                num_values_read = reader.read_many_sample(
-                    data, number_of_samples_per_channel=samples_to_read, timeout=2.0
-                )
-
-            assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
-            # We should have read a partial dataset.
-            number_of_samples_expected = clocks_to_give - samples_to_read
-            assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
-            # The data that was succesfully read should have been overwritten.
-            assert not any(
-                element == sentinel_value for element in data[:number_of_samples_expected]
-            )
-            # The data that wasn't read should have been unmodified.
-            assert all(element == sentinel_value for element in data[number_of_samples_expected:])
+        assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_NOT_YET_AVAILABLE
+        # We should have read a partial dataset.
+        number_of_samples_expected = clocks_to_give - samples_to_read
+        assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
+        # The data that was succesfully read should have been overwritten.
+        assert not any(element == sentinel_value for element in data[:number_of_samples_expected])
+        # The data that wasn't read should have been unmodified.
+        assert all(element == sentinel_value for element in data[number_of_samples_expected:])

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -285,35 +285,34 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_bool_1_chan_1_samp(self, real_x_series_device, seed):
+    def test_bool_1_chan_1_samp(self, task, real_x_series_device, seed):
         """Test to validate reading and writing boolean data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_line = random.choice(real_x_series_device.do_lines).name
 
-        with nidaqmx.Task() as task:
-            task.do_channels.add_do_chan(do_line, line_grouping=LineGrouping.CHAN_PER_LINE)
+        task.do_channels.add_do_chan(do_line, line_grouping=LineGrouping.CHAN_PER_LINE)
 
-            # Generate random values to test.
-            values_to_test = [bool(random.getrandbits(1)) for _ in range(10)]
+        # Generate random values to test.
+        values_to_test = [bool(random.getrandbits(1)) for _ in range(10)]
 
-            values_read = []
-            for value_to_test in values_to_test:
-                task.write(value_to_test)
-                time.sleep(0.001)
-                values_read.append(task.read())
+        values_read = []
+        for value_to_test in values_to_test:
+            task.write(value_to_test)
+            time.sleep(0.001)
+            values_read.append(task.read())
 
-            assert values_read == values_to_test
+        assert values_read == values_to_test
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list.
-            value_read = task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert len(value_read) == 1
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list.
+        value_read = task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert len(value_read) == 1
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_bool_n_chan_1_samp(self, real_x_series_device, seed):
+    def test_bool_n_chan_1_samp(self, task, real_x_series_device, seed):
         """Test to validate reading and writing boolean data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -321,59 +320,55 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
         number_of_channels = random.randint(2, len(real_x_series_device.do_lines))
         do_lines = random.sample(real_x_series_device.do_lines, number_of_channels)
 
-        with nidaqmx.Task() as task:
-            task.do_channels.add_do_chan(
-                flatten_channel_string([d.name for d in do_lines]),
-                line_grouping=LineGrouping.CHAN_PER_LINE,
-            )
+        task.do_channels.add_do_chan(
+            flatten_channel_string([d.name for d in do_lines]),
+            line_grouping=LineGrouping.CHAN_PER_LINE,
+        )
 
-            # Generate random values to test.
-            values_to_test = [bool(random.getrandbits(1)) for _ in range(number_of_channels)]
+        # Generate random values to test.
+        values_to_test = [bool(random.getrandbits(1)) for _ in range(number_of_channels)]
 
-            task.write(values_to_test)
-            time.sleep(0.001)
-            values_read = task.read()
+        task.write(values_to_test)
+        time.sleep(0.001)
+        values_read = task.read()
 
-            assert values_read == values_to_test
+        assert values_read == values_to_test
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list of lists.
-            value_read = task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert isinstance(value_read[0], list)
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list of lists.
+        value_read = task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert isinstance(value_read[0], list)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_uint_1_chan_1_samp(self, real_x_series_device, seed):
+    def test_uint_1_chan_1_samp(self, task, real_x_series_device, seed):
         """Test to validate reading and writing uint data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_port = random.choice(real_x_series_device.do_ports)
 
-        with nidaqmx.Task() as task:
-            task.do_channels.add_do_chan(
-                do_port.name, line_grouping=LineGrouping.CHAN_FOR_ALL_LINES
-            )
+        task.do_channels.add_do_chan(do_port.name, line_grouping=LineGrouping.CHAN_FOR_ALL_LINES)
 
-            # Generate random values to test.
-            values_to_test = [int(random.getrandbits(do_port.do_port_width)) for _ in range(10)]
+        # Generate random values to test.
+        values_to_test = [int(random.getrandbits(do_port.do_port_width)) for _ in range(10)]
 
-            values_read = []
-            for value_to_test in values_to_test:
-                task.write(value_to_test)
-                time.sleep(0.001)
-                values_read.append(task.read())
+        values_read = []
+        for value_to_test in values_to_test:
+            task.write(value_to_test)
+            time.sleep(0.001)
+            values_read.append(task.read())
 
-            assert values_read == values_to_test
+        assert values_read == values_to_test
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list.
-            value_read = task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert len(value_read) == 1
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list.
+        value_read = task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert len(value_read) == 1
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_uint_multi_port(self, real_x_series_device, seed):
+    def test_uint_multi_port(self, task, real_x_series_device, seed):
         """Test to validate reading and writing uint data ."""
         if len([d.do_port_width <= 16 for d in real_x_series_device.do_ports]) < 2:
             pytest.skip("task.read() accepts max of 32 bits for digital uint reads.")
@@ -387,22 +382,21 @@ class TestDigitalReadWrite(TestDAQmxIOBase):
 
         total_port_width = sum([d.do_port_width for d in do_ports])
 
-        with nidaqmx.Task() as task:
-            task.do_channels.add_do_chan(
-                flatten_channel_string([d.name for d in do_ports]),
-                line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
-            )
+        task.do_channels.add_do_chan(
+            flatten_channel_string([d.name for d in do_ports]),
+            line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+        )
 
-            # Generate random values to test.
-            values_to_test = [int(random.getrandbits(total_port_width)) for _ in range(10)]
+        # Generate random values to test.
+        values_to_test = [int(random.getrandbits(total_port_width)) for _ in range(10)]
 
-            values_read = []
-            for value_to_test in values_to_test:
-                task.write(value_to_test)
-                time.sleep(0.001)
-                values_read.append(task.read())
+        values_read = []
+        for value_to_test in values_to_test:
+            task.write(value_to_test)
+            time.sleep(0.001)
+            values_read.append(task.read())
 
-            assert values_read == values_to_test
+        assert values_read == values_to_test
 
 
 class TestCounterReadWrite(TestDAQmxIOBase):

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -76,7 +76,7 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_1_chan_1_samp(self, real_x_series_device, seed):
+    def test_1_chan_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate reading and writing a sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -84,34 +84,35 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
         loopback_channel_pairs = self._get_analog_loopback_channels(real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.ao_channels.add_ao_voltage_chan(
-                loopback_channel_pair.output_channel, max_val=10, min_val=-10
-            )
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.ao_channels.add_ao_voltage_chan(
+            loopback_channel_pair.output_channel, max_val=10, min_val=-10
+        )
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                loopback_channel_pair.input_channel, max_val=10, min_val=-10
-            )
+        read_task.ai_channels.add_ai_voltage_chan(
+            loopback_channel_pair.input_channel, max_val=10, min_val=-10
+        )
 
-            # Generate random values to test.
-            values_to_test = [random.uniform(-10, 10) for _ in range(10)]
+        # Generate random values to test.
+        values_to_test = [random.uniform(-10, 10) for _ in range(10)]
 
-            values_read = []
-            for value_to_test in values_to_test:
-                write_task.write(value_to_test)
-                time.sleep(0.001)
-                values_read.append(read_task.read())
+        values_read = []
+        for value_to_test in values_to_test:
+            write_task.write(value_to_test)
+            time.sleep(0.001)
+            values_read.append(read_task.read())
 
-            numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
+        numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list.
-            value_read = read_task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert len(value_read) == 1
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list.
+        value_read = read_task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert len(value_read) == 1
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_n_chan_1_samp(self, real_x_series_device, seed):
+    def test_n_chan_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate reading and writing sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -122,36 +123,37 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(loopback_channel_pairs, number_of_channels)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.output_channel for c in channels_to_test]),
-                max_val=10,
-                min_val=-10,
-            )
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.output_channel for c in channels_to_test]),
+            max_val=10,
+            min_val=-10,
+        )
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                flatten_channel_string([c.input_channel for c in channels_to_test]),
-                max_val=10,
-                min_val=-10,
-            )
+        read_task.ai_channels.add_ai_voltage_chan(
+            flatten_channel_string([c.input_channel for c in channels_to_test]),
+            max_val=10,
+            min_val=-10,
+        )
 
-            # Generate random values to test.
-            values_to_test = [random.uniform(-10, 10) for _ in range(number_of_channels)]
+        # Generate random values to test.
+        values_to_test = [random.uniform(-10, 10) for _ in range(number_of_channels)]
 
-            write_task.write(values_to_test)
-            time.sleep(0.001)
-            values_read = read_task.read()
+        write_task.write(values_to_test)
+        time.sleep(0.001)
+        values_read = read_task.read()
 
-            numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
+        numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list of lists.
-            value_read = read_task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert isinstance(value_read[0], list)
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list of lists.
+        value_read = read_task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert isinstance(value_read[0], list)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_1_chan_n_samp(self, real_x_series_device, seed):
+    def test_1_chan_n_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate reading and writing sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -163,53 +165,56 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
         loopback_channel_pairs = self._get_analog_loopback_channels(real_x_series_device)
         loopback_channel_pair = random.choice(loopback_channel_pairs)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Use a counter output pulse train task as the sample clock source
-            # for both the AI and AO tasks.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
-            )
-            sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
+        write_task = generate_task()
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        # Use a counter output pulse train task as the sample clock source
+        # for both the AI and AO tasks.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(
+            f"{real_x_series_device.name}/ctr0", freq=sample_rate, idle_state=Level.LOW
+        )
+        sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            write_task.ao_channels.add_ao_voltage_chan(
-                loopback_channel_pair.output_channel, max_val=10, min_val=-10
-            )
-            write_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                active_edge=Edge.RISING,
-                samps_per_chan=number_of_samples,
-            )
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                loopback_channel_pair.input_channel, max_val=10, min_val=-10
-            )
-            read_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                active_edge=Edge.FALLING,
-                samps_per_chan=number_of_samples,
-            )
+        write_task.ao_channels.add_ao_voltage_chan(
+            loopback_channel_pair.output_channel, max_val=10, min_val=-10
+        )
+        write_task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            active_edge=Edge.RISING,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Generate random values to test.
-            values_to_test = [random.uniform(-10, 10) for _ in range(number_of_samples)]
-            write_task.write(values_to_test)
+        read_task.ai_channels.add_ai_voltage_chan(
+            loopback_channel_pair.input_channel, max_val=10, min_val=-10
+        )
+        read_task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            active_edge=Edge.FALLING,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Start the read and write tasks before starting the sample clock
-            # source task.
-            read_task.start()
-            write_task.start()
-            sample_clk_task.start()
+        # Generate random values to test.
+        values_to_test = [random.uniform(-10, 10) for _ in range(number_of_samples)]
+        write_task.write(values_to_test)
 
-            values_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
+        # Start the read and write tasks before starting the sample clock
+        # source task.
+        read_task.start()
+        write_task.start()
+        sample_clk_task.start()
 
-            numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
+        values_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
+
+        numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_n_chan_n_samp(self, real_x_series_device, seed):
+    def test_n_chan_n_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate reading and writing sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -223,57 +228,60 @@ class TestAnalogReadWrite(TestDAQmxIOBase):
         number_of_channels = random.randint(2, len(loopback_channel_pairs))
         channels_to_test = random.sample(loopback_channel_pairs, number_of_channels)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Use a counter output pulse train task as the sample clock source
-            # for both the AI and AO tasks.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(
-                f"{real_x_series_device.name}/ctr0", freq=sample_rate
-            )
-            sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
+        write_task = generate_task()
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        # Use a counter output pulse train task as the sample clock source
+        # for both the AI and AO tasks.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(
+            f"{real_x_series_device.name}/ctr0", freq=sample_rate
+        )
+        sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
 
-            write_task.ao_channels.add_ao_voltage_chan(
-                flatten_channel_string([c.output_channel for c in channels_to_test]),
-                max_val=10,
-                min_val=-10,
-            )
-            write_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                active_edge=Edge.RISING,
-                samps_per_chan=number_of_samples,
-            )
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            read_task.ai_channels.add_ai_voltage_chan(
-                flatten_channel_string([c.input_channel for c in channels_to_test]),
-                max_val=10,
-                min_val=-10,
-            )
-            read_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                active_edge=Edge.FALLING,
-                samps_per_chan=number_of_samples,
-            )
+        write_task.ao_channels.add_ao_voltage_chan(
+            flatten_channel_string([c.output_channel for c in channels_to_test]),
+            max_val=10,
+            min_val=-10,
+        )
+        write_task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            active_edge=Edge.RISING,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Generate random values to test.
-            values_to_test = [
-                [random.uniform(-10, 10) for _ in range(number_of_samples)]
-                for _ in range(number_of_channels)
-            ]
-            write_task.write(values_to_test)
+        read_task.ai_channels.add_ai_voltage_chan(
+            flatten_channel_string([c.input_channel for c in channels_to_test]),
+            max_val=10,
+            min_val=-10,
+        )
+        read_task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            active_edge=Edge.FALLING,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Start the read and write tasks before starting the sample clock
-            # source task.
-            read_task.start()
-            write_task.start()
-            sample_clk_task.start()
+        # Generate random values to test.
+        values_to_test = [
+            [random.uniform(-10, 10) for _ in range(number_of_samples)]
+            for _ in range(number_of_channels)
+        ]
+        write_task.write(values_to_test)
 
-            values_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
+        # Start the read and write tasks before starting the sample clock
+        # source task.
+        read_task.start()
+        write_task.start()
+        sample_clk_task.start()
 
-            numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
+        values_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
+
+        numpy.testing.assert_allclose(values_read, values_to_test, rtol=0.05, atol=0.005)
 
 
 class TestDigitalReadWrite(TestDAQmxIOBase):
@@ -408,7 +416,7 @@ class TestCounterReadWrite(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_count_edges_1_samp(self, real_x_series_device, seed):
+    def test_count_edges_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate the set and read operations of edge count."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -419,29 +427,30 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
 
-            ci_channel = read_task.ci_channels.add_ci_count_edges_chan(counters[1])
-            ci_channel.ci_count_edges_term = f"/{counters[0]}InternalOutput"
+        ci_channel = read_task.ci_channels.add_ci_count_edges_chan(counters[1])
+        ci_channel.ci_count_edges_term = f"/{counters[0]}InternalOutput"
 
-            read_task.start()
-            write_task.start()
-            write_task.wait_until_done(timeout=2)
+        read_task.start()
+        write_task.start()
+        write_task.wait_until_done(timeout=2)
 
-            value_read = read_task.read()
-            assert value_read == number_of_pulses
+        value_read = read_task.read()
+        assert value_read == number_of_pulses
 
-            # Verify setting number_of_samples_per_channel (even to 1)
-            # returns a list.
-            value_read = read_task.read(number_of_samples_per_channel=1)
-            assert isinstance(value_read, list)
-            assert len(value_read) == 1
-            assert value_read[0] == number_of_pulses
+        # Verify setting number_of_samples_per_channel (even to 1)
+        # returns a list.
+        value_read = read_task.read(number_of_samples_per_channel=1)
+        assert isinstance(value_read, list)
+        assert len(value_read) == 1
+        assert value_read[0] == number_of_pulses
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_count_edges_n_samp(self, real_x_series_device, seed):
+    def test_count_edges_n_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate the set and read operations of edge count."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -452,43 +461,46 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Create a finite pulse train task that acts as the sample clock
-            # for the read task and the arm start trigger for the write task.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
-            actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
-            sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            sample_clk_task.control(TaskMode.TASK_COMMIT)
-            samp_clk_terminal = f"/{counters[0]}InternalOutput"
+        write_task = generate_task()
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            write_task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
-            write_task.triggers.arm_start_trigger.dig_edge_edge = Edge.RISING
-            write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
+        # Create a finite pulse train task that acts as the sample clock
+        # for the read task and the arm start trigger for the write task.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
+        actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
+        sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        sample_clk_task.control(TaskMode.TASK_COMMIT)
+        samp_clk_terminal = f"/{counters[0]}InternalOutput"
 
-            read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
-            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
-            read_task.timing.cfg_samp_clk_timing(
-                actual_frequency,
-                source=samp_clk_terminal,
-                active_edge=Edge.FALLING,
-                samps_per_chan=number_of_samples,
-            )
+        write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        write_task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
+        write_task.triggers.arm_start_trigger.dig_edge_edge = Edge.RISING
+        write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
 
-            read_task.start()
-            write_task.start()
-            sample_clk_task.start()
-            sample_clk_task.wait_until_done(timeout=2)
+        read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
+        read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
+        read_task.timing.cfg_samp_clk_timing(
+            actual_frequency,
+            source=samp_clk_terminal,
+            active_edge=Edge.FALLING,
+            samps_per_chan=number_of_samples,
+        )
 
-            value_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
+        read_task.start()
+        write_task.start()
+        sample_clk_task.start()
+        sample_clk_task.wait_until_done(timeout=2)
 
-            expected_values = [i + 1 for i in range(number_of_samples)]
+        value_read = read_task.read(number_of_samples_per_channel=number_of_samples, timeout=2)
 
-            assert value_read == expected_values
+        expected_values = [i + 1 for i in range(number_of_samples)]
+
+        assert value_read == expected_values
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pulse_freq_1_samp(self, real_x_series_device, seed):
+    def test_pulse_freq_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate the set and read operations of pulse frequency."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -500,27 +512,28 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(
-                counters[0], freq=frequency, duty_cycle=duty_cycle
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.co_channels.add_co_pulse_chan_freq(
+            counters[0], freq=frequency, duty_cycle=duty_cycle
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=100, max_val=1000)
-            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
-            read_task.ci_channels.all.ci_pulse_freq_starting_edge = starting_edge
+        read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=100, max_val=1000)
+        read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.all.ci_pulse_freq_starting_edge = starting_edge
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            value_read = read_task.read(timeout=2)
-            write_task.stop()
+        value_read = read_task.read(timeout=2)
+        write_task.stop()
 
-            assert numpy.isclose(value_read.freq, frequency, rtol=0.01)
-            assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.01)
+        assert numpy.isclose(value_read.freq, frequency, rtol=0.01)
+        assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.01)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pulse_time_1_samp(self, real_x_series_device, seed):
+    def test_pulse_time_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate the set and read operations of pulse time."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -532,27 +545,28 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_time(
-                counters[0], high_time=high_time, low_time=low_time
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.co_channels.add_co_pulse_chan_time(
+            counters[0], high_time=high_time, low_time=low_time
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.001, max_val=0.01)
-            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
-            read_task.ci_channels.all.ci_pulse_time_starting_edge = starting_edge
+        read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.001, max_val=0.01)
+        read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.all.ci_pulse_time_starting_edge = starting_edge
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            value_read = read_task.read(timeout=2)
-            write_task.stop()
+        value_read = read_task.read(timeout=2)
+        write_task.stop()
 
-            assert numpy.isclose(value_read.high_time, high_time, rtol=0.01)
-            assert numpy.isclose(value_read.low_time, low_time, rtol=0.01)
+        assert numpy.isclose(value_read.high_time, high_time, rtol=0.01)
+        assert numpy.isclose(value_read.low_time, low_time, rtol=0.01)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pulse_ticks_1_samp(self, real_x_series_device, seed):
+    def test_pulse_ticks_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate the set and read operations of pulse ticks."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -564,32 +578,33 @@ class TestCounterReadWrite(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_ticks(
-                counters[0],
-                f"/{real_x_series_device.name}/100kHzTimebase",
-                high_ticks=high_ticks,
-                low_ticks=low_ticks,
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.co_channels.add_co_pulse_chan_ticks(
+            counters[0],
+            f"/{real_x_series_device.name}/100kHzTimebase",
+            high_ticks=high_ticks,
+            low_ticks=low_ticks,
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_ticks(
-                counters[1],
-                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
-                min_val=100,
-                max_val=1000,
-            )
-            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
-            read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
+        read_task.ci_channels.add_ci_pulse_chan_ticks(
+            counters[1],
+            source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
+            min_val=100,
+            max_val=1000,
+        )
+        read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            value_read = read_task.read(timeout=2)
-            write_task.stop()
+        value_read = read_task.read(timeout=2)
+        write_task.stop()
 
-            assert value_read.high_tick == high_ticks
-            assert value_read.low_tick == low_ticks
+        assert value_read.high_tick == high_ticks
+        assert value_read.low_tick == low_ticks
 
 
 class TestPowerRead(TestDAQmxIOBase):
@@ -602,7 +617,7 @@ class TestPowerRead(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_1_samp(self, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_1_samp(self, task, sim_ts_power_device, seed, output_enable):
         """Test to validate the set and read operations of power."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -610,23 +625,22 @@ class TestPowerRead(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
-            )
+        task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
 
-            read_task.start()
-            value_read = read_task.read()
+        task.start()
+        value_read = task.read()
 
-            if output_enable:
-                assert value_read.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                assert value_read.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-            else:
-                assert math.isnan(value_read.voltage)
-                assert math.isnan(value_read.current)
+        if output_enable:
+            assert value_read.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+            assert value_read.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+        else:
+            assert math.isnan(value_read.voltage)
+            assert math.isnan(value_read.current)
 
     @pytest.mark.parametrize(
         "seed,output_enables",
@@ -637,7 +651,7 @@ class TestPowerRead(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_1_samp(self, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_1_samp(self, task, sim_ts_power_devices, seed, output_enables):
         """Test to validate the set and read operations of power."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -645,31 +659,30 @@ class TestPowerRead(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        with nidaqmx.Task() as read_task:
-            for device, output_enable in zip(sim_ts_power_devices, output_enables):
-                read_task.ai_channels.add_ai_power_chan(
-                    f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+        for device, output_enable in zip(sim_ts_power_devices, output_enables):
+            task.ai_channels.add_ai_power_chan(
+                f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+            )
+
+        task.start()
+        value_read = task.read()
+
+        for data_idx, output_enable in enumerate(output_enables):
+            if output_enable:
+                assert value_read[data_idx].voltage == pytest.approx(
+                    voltage_setpoint, abs=POWER_ABS_EPSILON
                 )
-
-            read_task.start()
-            value_read = read_task.read()
-
-            for data_idx, output_enable in enumerate(output_enables):
-                if output_enable:
-                    assert value_read[data_idx].voltage == pytest.approx(
-                        voltage_setpoint, abs=POWER_ABS_EPSILON
-                    )
-                    assert value_read[data_idx].current == pytest.approx(
-                        current_setpoint, abs=POWER_ABS_EPSILON
-                    )
-                else:
-                    assert math.isnan(value_read[data_idx].voltage)
-                    assert math.isnan(value_read[data_idx].current)
+                assert value_read[data_idx].current == pytest.approx(
+                    current_setpoint, abs=POWER_ABS_EPSILON
+                )
+            else:
+                assert math.isnan(value_read[data_idx].voltage)
+                assert math.isnan(value_read[data_idx].current)
 
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_n_samp(self, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_n_samp(self, task, sim_ts_power_device, seed, output_enable):
         """Test to validate the set and read operations of power."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -677,29 +690,28 @@ class TestPowerRead(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
+        task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
+
+        task.start()
+        values_read = task.read(number_of_samples_per_channel=10)
+
+        if output_enable:
+            assert all(
+                sample.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+                for sample in values_read
             )
-
-            read_task.start()
-            values_read = read_task.read(number_of_samples_per_channel=10)
-
-            if output_enable:
-                assert all(
-                    sample.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                    for sample in values_read
-                )
-                assert all(
-                    sample.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-                    for sample in values_read
-                )
-            else:
-                assert all(math.isnan(sample.voltage) for sample in values_read)
-                assert all(math.isnan(sample.current) for sample in values_read)
+            assert all(
+                sample.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+                for sample in values_read
+            )
+        else:
+            assert all(math.isnan(sample.voltage) for sample in values_read)
+            assert all(math.isnan(sample.current) for sample in values_read)
 
     @pytest.mark.parametrize(
         "seed,output_enables",
@@ -710,7 +722,7 @@ class TestPowerRead(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_n_samp(self, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_n_samp(self, task, sim_ts_power_devices, seed, output_enables):
         """Test to validate the set and read operations of power."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -718,51 +730,49 @@ class TestPowerRead(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        with nidaqmx.Task() as read_task:
-            for device, output_enable in zip(sim_ts_power_devices, output_enables):
-                read_task.ai_channels.add_ai_power_chan(
-                    f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+        for device, output_enable in zip(sim_ts_power_devices, output_enables):
+            task.ai_channels.add_ai_power_chan(
+                f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+            )
+
+        task.start()
+        values_read = task.read(number_of_samples_per_channel=10)
+
+        for data_idx, output_enable in enumerate(output_enables):
+            # Get the data for just this channel
+            channel_values = values_read[data_idx]
+            if output_enable:
+                assert all(
+                    sample.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+                    for sample in channel_values
                 )
-
-            read_task.start()
-            values_read = read_task.read(number_of_samples_per_channel=10)
-
-            for data_idx, output_enable in enumerate(output_enables):
-                # Get the data for just this channel
-                channel_values = values_read[data_idx]
-                if output_enable:
-                    assert all(
-                        sample.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                        for sample in channel_values
-                    )
-                    assert all(
-                        sample.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-                        for sample in channel_values
-                    )
-                else:
-                    assert all(math.isnan(sample.voltage) for sample in channel_values)
-                    assert all(math.isnan(sample.current) for sample in channel_values)
+                assert all(
+                    sample.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+                    for sample in channel_values
+                )
+            else:
+                assert all(math.isnan(sample.voltage) for sample in channel_values)
+                assert all(math.isnan(sample.current) for sample in channel_values)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_mixed_chans(self, sim_x_series_device, seed):
+    def test_mixed_chans(self, task, sim_x_series_device, seed):
         """Test to validate mixed channels."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_voltage_chan(
-                f"{sim_x_series_device.name}/ai0", max_val=10, min_val=-10
-            )
-            read_task.ai_channels.add_ai_current_chan(
-                f"{sim_x_series_device.name}/ai1", max_val=0.01, min_val=-0.01
-            )
+        task.ai_channels.add_ai_voltage_chan(
+            f"{sim_x_series_device.name}/ai0", max_val=10, min_val=-10
+        )
+        task.ai_channels.add_ai_current_chan(
+            f"{sim_x_series_device.name}/ai1", max_val=0.01, min_val=-0.01
+        )
 
-            read_task.start()
-            # We aren't validating data, just assuring that it doesn't fail.
-            values_read = read_task.read(number_of_samples_per_channel=10)  # noqa: F841
+        task.start()
+        # We aren't validating data, just assuring that it doesn't fail.
+        values_read = task.read(number_of_samples_per_channel=10)  # noqa: F841
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_mixed_chans_with_power(self, sim_ts_power_device, sim_ts_voltage_device, seed):
+    def test_mixed_chans_with_power(self, task, sim_ts_power_device, sim_ts_voltage_device, seed):
         """Test to validate mixed channels with power."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -771,19 +781,18 @@ class TestPowerRead(TestDAQmxIOBase):
         current_setpoint = 0.03
         output_enable = False
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
-            )
-            read_task.ai_channels.add_ai_voltage_chan(
-                f"{sim_ts_voltage_device.name}/ai0", max_val=10, min_val=-10
-            )
+        task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
+        task.ai_channels.add_ai_voltage_chan(
+            f"{sim_ts_voltage_device.name}/ai0", max_val=10, min_val=-10
+        )
 
-            read_task.start()
-            # We aren't validating data, just assuring that it fails. The error
-            # code is currently not very good, so we'll ignore that for now.
-            with pytest.raises(nidaqmx.errors.DaqReadError):
-                values_read = read_task.read(number_of_samples_per_channel=10)  # noqa: F841
+        task.start()
+        # We aren't validating data, just assuring that it fails. The error
+        # code is currently not very good, so we'll ignore that for now.
+        with pytest.raises(nidaqmx.errors.DaqReadError):
+            values_read = task.read(number_of_samples_per_channel=10)  # noqa: F841

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -11,14 +11,15 @@ class TestResourceWarnings:
     These validate the ResourceWarning behavior of the Python NI-DAQmx API.
     """
 
-    def test_task_double_close(self):
+    def test_task_double_close(self, init_kwargs):
         """Test to validate double closure of tasks."""
         with pytest.warns(DaqResourceWarning):
-            with nidaqmx.Task() as task:
+            with nidaqmx.Task(**init_kwargs) as task:
                 task.close()
 
-    def test_unclosed_task(self, task):
+    def test_unclosed_task(self, init_kwargs):
         """Test to validate unclosed tasks."""
+        task = nidaqmx.Task(**init_kwargs)
         # Since __del__ is not guaranteed to be called, for the purposes of
         # consistent test results call __del__ manually.
         with pytest.warns(DaqResourceWarning):

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -17,9 +17,8 @@ class TestResourceWarnings:
             with nidaqmx.Task() as task:
                 task.close()
 
-    def test_unclosed_task(self):
+    def test_unclosed_task(self, task):
         """Test to validate unclosed tasks."""
-        task = nidaqmx.Task()
         # Since __del__ is not guaranteed to be called, for the purposes of
         # consistent test results call __del__ manually.
         with pytest.warns(DaqResourceWarning):

--- a/tests/legacy/test_stream_counter_readers_writers.py
+++ b/tests/legacy/test_stream_counter_readers_writers.py
@@ -4,7 +4,6 @@ import random
 import numpy
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import AcquisitionType, Edge, Level, TaskMode, TriggerType
 from nidaqmx.stream_readers import CounterReader
 from nidaqmx.stream_writers import CounterWriter
@@ -21,7 +20,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_one_sample_uint32(self, real_x_series_device, seed):
+    def test_one_sample_uint32(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -32,25 +31,26 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
+        write_task = generate_task()
+        read_task = generate_task()
+        write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_pulses)
 
-            read_task.ci_channels.add_ci_count_edges_chan(counters[1])
-            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.add_ci_count_edges_chan(counters[1])
+        read_task.ci_channels.all.ci_count_edges_term = f"/{counters[0]}InternalOutput"
 
-            reader = CounterReader(read_task.in_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            write_task.wait_until_done(timeout=2)
+        write_task.wait_until_done(timeout=2)
 
-            value_read = reader.read_one_sample_uint32()
-            assert value_read == number_of_pulses
+        value_read = reader.read_one_sample_uint32()
+        assert value_read == number_of_pulses
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_multi_sample_uint32(self, real_x_series_device, seed):
+    def test_multi_sample_uint32(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -61,47 +61,50 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task, nidaqmx.Task() as sample_clk_task:
-            # Create a finite pulse train task that acts as the sample clock
-            # for the read task and the arm start trigger for the write task.
-            sample_clk_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
-            actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
-            sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            samp_clk_terminal = f"/{counters[0]}InternalOutput"
+        write_task = generate_task()
+        read_task = generate_task()
+        sample_clk_task = generate_task()
 
-            write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
-            write_task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
-            write_task.triggers.arm_start_trigger.dig_edge_edge = Edge.RISING
-            write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
+        # Create a finite pulse train task that acts as the sample clock
+        # for the read task and the arm start trigger for the write task.
+        sample_clk_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
+        actual_frequency = sample_clk_task.co_channels.all.co_pulse_freq
+        sample_clk_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        samp_clk_terminal = f"/{counters[0]}InternalOutput"
 
-            read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
-            read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
-            read_task.timing.cfg_samp_clk_timing(
-                actual_frequency,
-                source=samp_clk_terminal,
-                active_edge=Edge.FALLING,
-                samps_per_chan=number_of_samples,
-            )
+        write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=actual_frequency)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        write_task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
+        write_task.triggers.arm_start_trigger.dig_edge_edge = Edge.RISING
+        write_task.triggers.arm_start_trigger.dig_edge_src = samp_clk_terminal
 
-            read_task.start()
-            write_task.start()
-            sample_clk_task.start()
-            sample_clk_task.wait_until_done(timeout=2)
+        read_task.ci_channels.add_ci_count_edges_chan(counters[2], edge=Edge.RISING)
+        read_task.ci_channels.all.ci_count_edges_term = f"/{counters[1]}InternalOutput"
+        read_task.timing.cfg_samp_clk_timing(
+            actual_frequency,
+            source=samp_clk_terminal,
+            active_edge=Edge.FALLING,
+            samps_per_chan=number_of_samples,
+        )
 
-            reader = CounterReader(read_task.in_stream)
+        read_task.start()
+        write_task.start()
+        sample_clk_task.start()
+        sample_clk_task.wait_until_done(timeout=2)
 
-            values_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
-            reader.read_many_sample_uint32(
-                values_read, number_of_samples_per_channel=number_of_samples, timeout=2
-            )
+        reader = CounterReader(read_task.in_stream)
 
-            expected_values = [i + 1 for i in range(number_of_samples)]
+        values_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
+        reader.read_many_sample_uint32(
+            values_read, number_of_samples_per_channel=number_of_samples, timeout=2
+        )
 
-            assert values_read.tolist() == expected_values
+        expected_values = [i + 1 for i in range(number_of_samples)]
+
+        assert values_read.tolist() == expected_values
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_one_sample_double(self, real_x_series_device, seed):
+    def test_one_sample_double(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -111,25 +114,26 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
-            actual_frequency = write_task.co_channels.all.co_pulse_freq
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        actual_frequency = write_task.co_channels.all.co_pulse_freq
 
-            read_task.ci_channels.add_ci_freq_chan(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_freq_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.add_ci_freq_chan(counters[1], min_val=1000, max_val=10000)
+        read_task.ci_channels.all.ci_freq_term = f"/{counters[0]}InternalOutput"
 
-            reader = CounterReader(read_task.in_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            value_read = reader.read_one_sample_double()
+        value_read = reader.read_one_sample_double()
 
-            numpy.testing.assert_allclose([value_read], [actual_frequency], rtol=0.05)
+        numpy.testing.assert_allclose([value_read], [actual_frequency], rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_multi_sample_double(self, real_x_series_device, seed):
+    def test_multi_sample_double(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -140,33 +144,34 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=frequency)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=frequency)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
 
-            read_task.ci_channels.add_ci_freq_chan(
-                counters[2], min_val=1000, max_val=10000, edge=Edge.RISING
-            )
-            read_task.ci_channels.all.ci_freq_term = f"/{counters[1]}InternalOutput"
-            read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        read_task.ci_channels.add_ci_freq_chan(
+            counters[2], min_val=1000, max_val=10000, edge=Edge.RISING
+        )
+        read_task.ci_channels.all.ci_freq_term = f"/{counters[1]}InternalOutput"
+        read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            read_task.start()
-            write_task.start()
-            write_task.wait_until_done(timeout=2)
+        read_task.start()
+        write_task.start()
+        write_task.wait_until_done(timeout=2)
 
-            reader = CounterReader(read_task.in_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            values_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
-            reader.read_many_sample_double(
-                values_read, number_of_samples_per_channel=number_of_samples, timeout=2
-            )
+        values_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
+        reader.read_many_sample_double(
+            values_read, number_of_samples_per_channel=number_of_samples, timeout=2
+        )
 
-            expected_values = [frequency for _ in range(number_of_samples)]
+        expected_values = [frequency for _ in range(number_of_samples)]
 
-            numpy.testing.assert_allclose(values_read, expected_values, rtol=0.05)
+        numpy.testing.assert_allclose(values_read, expected_values, rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_one_sample_pulse_freq(self, real_x_series_device, seed):
+    def test_one_sample_pulse_freq(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -177,28 +182,29 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(
-                counters[0], freq=frequency, duty_cycle=duty_cycle
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_freq(
+            counters[0], freq=frequency, duty_cycle=duty_cycle
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
+        read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            reader = CounterReader(read_task.in_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            value_read = reader.read_one_sample_pulse_frequency()
-            write_task.stop()
+        value_read = reader.read_one_sample_pulse_frequency()
+        write_task.stop()
 
-            assert numpy.isclose(value_read.freq, frequency, rtol=0.05)
-            assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.05)
+        assert numpy.isclose(value_read.freq, frequency, rtol=0.05)
+        assert numpy.isclose(value_read.duty_cycle, duty_cycle, rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_many_sample_pulse_freq(self, real_x_series_device, seed):
+    def test_many_sample_pulse_freq(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -208,48 +214,49 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_freq(counters[0], idle_state=Level.HIGH)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
-            write_task.control(TaskMode.TASK_COMMIT)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_freq(counters[0], idle_state=Level.HIGH)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
+        write_task.control(TaskMode.TASK_COMMIT)
 
-            read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
-            read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
-            read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        read_task.ci_channels.add_ci_pulse_chan_freq(counters[1], min_val=1000, max_val=10000)
+        read_task.ci_channels.all.ci_pulse_freq_term = f"/{counters[0]}InternalOutput"
+        read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            frequencies_to_test = numpy.array(
-                [random.uniform(1000, 10000) for _ in range(number_of_samples + 1)],
-                dtype=numpy.float64,
-            )
+        frequencies_to_test = numpy.array(
+            [random.uniform(1000, 10000) for _ in range(number_of_samples + 1)],
+            dtype=numpy.float64,
+        )
 
-            duty_cycles_to_test = numpy.array(
-                [random.uniform(0.2, 0.8) for _ in range(number_of_samples + 1)],
-                dtype=numpy.float64,
-            )
+        duty_cycles_to_test = numpy.array(
+            [random.uniform(0.2, 0.8) for _ in range(number_of_samples + 1)],
+            dtype=numpy.float64,
+        )
 
-            writer = CounterWriter(write_task.out_stream)
-            reader = CounterReader(read_task.in_stream)
+        writer = CounterWriter(write_task.out_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            writer.write_many_sample_pulse_frequency(frequencies_to_test, duty_cycles_to_test)
+        writer.write_many_sample_pulse_frequency(frequencies_to_test, duty_cycles_to_test)
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            frequencies_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
-            duty_cycles_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
+        frequencies_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
+        duty_cycles_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
 
-            reader.read_many_sample_pulse_frequency(
-                frequencies_read,
-                duty_cycles_read,
-                number_of_samples_per_channel=number_of_samples,
-                timeout=2,
-            )
+        reader.read_many_sample_pulse_frequency(
+            frequencies_read,
+            duty_cycles_read,
+            number_of_samples_per_channel=number_of_samples,
+            timeout=2,
+        )
 
-            numpy.testing.assert_allclose(frequencies_read, frequencies_to_test[1:], rtol=0.05)
-            numpy.testing.assert_allclose(duty_cycles_read, duty_cycles_to_test[1:], rtol=0.05)
+        numpy.testing.assert_allclose(frequencies_read, frequencies_to_test[1:], rtol=0.05)
+        numpy.testing.assert_allclose(duty_cycles_read, duty_cycles_to_test[1:], rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_one_sample_pulse_time(self, real_x_series_device, seed):
+    def test_one_sample_pulse_time(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -260,27 +267,28 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_time(
-                counters[0], high_time=high_time, low_time=low_time
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_time(
+            counters[0], high_time=high_time, low_time=low_time
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
-            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
+        read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            reader = CounterReader(read_task.in_stream)
-            value_read = reader.read_one_sample_pulse_time()
-            write_task.stop()
+        reader = CounterReader(read_task.in_stream)
+        value_read = reader.read_one_sample_pulse_time()
+        write_task.stop()
 
-            assert numpy.isclose(value_read.high_time, high_time, rtol=0.05)
-            assert numpy.isclose(value_read.low_time, low_time, rtol=0.05)
+        assert numpy.isclose(value_read.high_time, high_time, rtol=0.05)
+        assert numpy.isclose(value_read.low_time, low_time, rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_many_sample_pulse_time(self, real_x_series_device, seed):
+    def test_many_sample_pulse_time(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with sample data ."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -290,48 +298,49 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_time(counters[0], idle_state=Level.HIGH)
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
-            write_task.control(TaskMode.TASK_COMMIT)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_time(counters[0], idle_state=Level.HIGH)
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
+        write_task.control(TaskMode.TASK_COMMIT)
 
-            read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
-            read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
-            read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        read_task.ci_channels.add_ci_pulse_chan_time(counters[1], min_val=0.0001, max_val=0.001)
+        read_task.ci_channels.all.ci_pulse_time_term = f"/{counters[0]}InternalOutput"
+        read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            high_times_to_test = numpy.array(
-                [random.uniform(0.0001, 0.001) for _ in range(number_of_samples + 1)],
-                dtype=numpy.float64,
-            )
+        high_times_to_test = numpy.array(
+            [random.uniform(0.0001, 0.001) for _ in range(number_of_samples + 1)],
+            dtype=numpy.float64,
+        )
 
-            low_times_to_test = numpy.array(
-                [random.uniform(0.0001, 0.001) for _ in range(number_of_samples + 1)],
-                dtype=numpy.float64,
-            )
+        low_times_to_test = numpy.array(
+            [random.uniform(0.0001, 0.001) for _ in range(number_of_samples + 1)],
+            dtype=numpy.float64,
+        )
 
-            writer = CounterWriter(write_task.out_stream)
-            reader = CounterReader(read_task.in_stream)
+        writer = CounterWriter(write_task.out_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            writer.write_many_sample_pulse_time(high_times_to_test, low_times_to_test)
+        writer.write_many_sample_pulse_time(high_times_to_test, low_times_to_test)
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            high_times_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
-            low_times_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
+        high_times_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
+        low_times_read = numpy.zeros(number_of_samples, dtype=numpy.float64)
 
-            reader.read_many_sample_pulse_time(
-                high_times_read,
-                low_times_read,
-                number_of_samples_per_channel=number_of_samples,
-                timeout=2,
-            )
+        reader.read_many_sample_pulse_time(
+            high_times_read,
+            low_times_read,
+            number_of_samples_per_channel=number_of_samples,
+            timeout=2,
+        )
 
-            numpy.testing.assert_allclose(high_times_read, high_times_to_test[1:], rtol=0.05)
-            numpy.testing.assert_allclose(low_times_read, low_times_to_test[1:], rtol=0.05)
+        numpy.testing.assert_allclose(high_times_read, high_times_to_test[1:], rtol=0.05)
+        numpy.testing.assert_allclose(low_times_read, low_times_to_test[1:], rtol=0.05)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pulse_ticks_1_samp(self, real_x_series_device, seed):
+    def test_pulse_ticks_1_samp(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with pulse ticks."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -343,36 +352,37 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_ticks(
-                counters[0],
-                f"/{real_x_series_device.name}/100kHzTimebase",
-                high_ticks=high_ticks,
-                low_ticks=low_ticks,
-            )
-            write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_ticks(
+            counters[0],
+            f"/{real_x_series_device.name}/100kHzTimebase",
+            high_ticks=high_ticks,
+            low_ticks=low_ticks,
+        )
+        write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            read_task.ci_channels.add_ci_pulse_chan_ticks(
-                counters[1],
-                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
-                min_val=100,
-                max_val=1000,
-            )
-            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
-            read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
+        read_task.ci_channels.add_ci_pulse_chan_ticks(
+            counters[1],
+            source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
+            min_val=100,
+            max_val=1000,
+        )
+        read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
+        read_task.ci_channels.all.ci_pulse_ticks_starting_edge = starting_edge
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            reader = CounterReader(read_task.in_stream)
-            value_read = reader.read_one_sample_pulse_ticks()
-            write_task.stop()
+        reader = CounterReader(read_task.in_stream)
+        value_read = reader.read_one_sample_pulse_ticks()
+        write_task.stop()
 
-            assert numpy.isclose(value_read.high_tick, high_ticks, rtol=0.05, atol=1)
-            assert numpy.isclose(value_read.low_tick, low_ticks, rtol=0.05, atol=1)
+        assert numpy.isclose(value_read.high_tick, high_ticks, rtol=0.05, atol=1)
+        assert numpy.isclose(value_read.low_tick, low_ticks, rtol=0.05, atol=1)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_many_sample_pulse_ticks(self, real_x_series_device, seed):
+    def test_many_sample_pulse_ticks(self, generate_task, real_x_series_device, seed):
         """Test to validate counter read and write operation with pulse ticks."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -382,53 +392,52 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         # Select random counters from the device.
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
-        with nidaqmx.Task() as write_task, nidaqmx.Task() as read_task:
-            write_task.co_channels.add_co_pulse_chan_ticks(
-                counters[0],
-                f"/{real_x_series_device.name}/100kHzTimebase",
-                idle_state=Level.HIGH,
-            )
-            write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
-            write_task.control(TaskMode.TASK_COMMIT)
+        write_task = generate_task()
+        read_task = write_task()
+        write_task.co_channels.add_co_pulse_chan_ticks(
+            counters[0],
+            f"/{real_x_series_device.name}/100kHzTimebase",
+            idle_state=Level.HIGH,
+        )
+        write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
+        write_task.control(TaskMode.TASK_COMMIT)
 
-            read_task.ci_channels.add_ci_pulse_chan_ticks(
-                counters[1],
-                source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
-                min_val=100,
-                max_val=1000,
-            )
-            read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
-            read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
+        read_task.ci_channels.add_ci_pulse_chan_ticks(
+            counters[1],
+            source_terminal=f"/{real_x_series_device.name}/100kHzTimebase",
+            min_val=100,
+            max_val=1000,
+        )
+        read_task.ci_channels.all.ci_pulse_ticks_term = f"/{counters[0]}InternalOutput"
+        read_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples)
 
-            high_ticks_to_test = numpy.array(
-                [random.randint(100, 1000) for _ in range(number_of_samples + 1)],
-                dtype=numpy.uint32,
-            )
+        high_ticks_to_test = numpy.array(
+            [random.randint(100, 1000) for _ in range(number_of_samples + 1)],
+            dtype=numpy.uint32,
+        )
 
-            low_ticks_to_test = numpy.array(
-                [random.randint(100, 1000) for _ in range(number_of_samples + 1)],
-                dtype=numpy.uint32,
-            )
+        low_ticks_to_test = numpy.array(
+            [random.randint(100, 1000) for _ in range(number_of_samples + 1)],
+            dtype=numpy.uint32,
+        )
 
-            writer = CounterWriter(write_task.out_stream)
-            reader = CounterReader(read_task.in_stream)
+        writer = CounterWriter(write_task.out_stream)
+        reader = CounterReader(read_task.in_stream)
 
-            writer.write_many_sample_pulse_ticks(high_ticks_to_test, low_ticks_to_test)
+        writer.write_many_sample_pulse_ticks(high_ticks_to_test, low_ticks_to_test)
 
-            read_task.start()
-            write_task.start()
+        read_task.start()
+        write_task.start()
 
-            high_ticks_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
-            low_ticks_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
+        high_ticks_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
+        low_ticks_read = numpy.zeros(number_of_samples, dtype=numpy.uint32)
 
-            reader.read_many_sample_pulse_ticks(
-                high_ticks_read,
-                low_ticks_read,
-                number_of_samples_per_channel=number_of_samples,
-                timeout=2,
-            )
+        reader.read_many_sample_pulse_ticks(
+            high_ticks_read,
+            low_ticks_read,
+            number_of_samples_per_channel=number_of_samples,
+            timeout=2,
+        )
 
-            numpy.testing.assert_allclose(
-                high_ticks_read, high_ticks_to_test[1:], rtol=0.05, atol=1
-            )
-            numpy.testing.assert_allclose(low_ticks_read, low_ticks_to_test[1:], rtol=0.05, atol=1)
+        numpy.testing.assert_allclose(high_ticks_read, high_ticks_to_test[1:], rtol=0.05, atol=1)
+        numpy.testing.assert_allclose(low_ticks_read, low_ticks_to_test[1:], rtol=0.05, atol=1)

--- a/tests/legacy/test_stream_counter_readers_writers.py
+++ b/tests/legacy/test_stream_counter_readers_writers.py
@@ -145,7 +145,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 3)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_freq(counters[1], freq=frequency)
         write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
 
@@ -183,7 +183,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_freq(
             counters[0], freq=frequency, duty_cycle=duty_cycle
         )
@@ -215,7 +215,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_freq(counters[0], idle_state=Level.HIGH)
         write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
         write_task.control(TaskMode.TASK_COMMIT)
@@ -268,7 +268,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_time(
             counters[0], high_time=high_time, low_time=low_time
         )
@@ -299,7 +299,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_time(counters[0], idle_state=Level.HIGH)
         write_task.timing.cfg_implicit_timing(samps_per_chan=number_of_samples + 1)
         write_task.control(TaskMode.TASK_COMMIT)
@@ -353,7 +353,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_ticks(
             counters[0],
             f"/{real_x_series_device.name}/100kHzTimebase",
@@ -393,7 +393,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_ticks(
             counters[0],
             f"/{real_x_series_device.name}/100kHzTimebase",

--- a/tests/legacy/test_stream_counter_readers_writers.py
+++ b/tests/legacy/test_stream_counter_readers_writers.py
@@ -115,7 +115,7 @@ class TestCounterReaderWriter(TestDAQmxIOBase):
         counters = random.sample(self._get_device_counters(real_x_series_device), 2)
 
         write_task = generate_task()
-        read_task = write_task()
+        read_task = generate_task()
         write_task.co_channels.add_co_pulse_chan_freq(counters[0], freq=frequency)
         write_task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
         actual_frequency = write_task.co_channels.all.co_pulse_freq

--- a/tests/legacy/test_stream_power_readers.py
+++ b/tests/legacy/test_stream_power_readers.py
@@ -25,7 +25,7 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_1_samp(self, generate_task, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_1_samp(self, task, sim_ts_power_device, seed, output_enable):
         """Test to validate power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -33,17 +33,16 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        read_task = generate_task()
-        read_task.ai_channels.add_ai_power_chan(
+        task.ai_channels.add_ai_power_chan(
             f"{sim_ts_power_device.name}/power",
             voltage_setpoint,
             current_setpoint,
             output_enable,
         )
 
-        reader = PowerSingleChannelReader(read_task.in_stream)
+        reader = PowerSingleChannelReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         value_read = reader.read_one_sample()
 
         if output_enable:
@@ -56,7 +55,7 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_n_samp(self, generate_task, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_n_samp(self, task, sim_ts_power_device, seed, output_enable):
         """Test to validate power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -69,17 +68,16 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
         voltage_data = numpy.full(number_of_samples_per_channel, -1.0, dtype=numpy.float64)
         current_data = numpy.full(number_of_samples_per_channel, -1.0, dtype=numpy.float64)
 
-        read_task = generate_task()
-        read_task.ai_channels.add_ai_power_chan(
+        task.ai_channels.add_ai_power_chan(
             f"{sim_ts_power_device.name}/power",
             voltage_setpoint,
             current_setpoint,
             output_enable,
         )
 
-        reader = PowerSingleChannelReader(read_task.in_stream)
+        reader = PowerSingleChannelReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         reader.read_many_sample(
             voltage_data,
             current_data,
@@ -120,7 +118,7 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_1_samp(self, generate_task, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_1_samp(self, task, sim_ts_power_devices, seed, output_enables):
         """Test to validate multi channel power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -132,15 +130,14 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
         voltage_data = numpy.full(len(sim_ts_power_devices), -1.0, dtype=numpy.float64)
         current_data = numpy.full(len(sim_ts_power_devices), -1.0, dtype=numpy.float64)
 
-        read_task = generate_task()
         for device, output_enable in zip(sim_ts_power_devices, output_enables):
-            read_task.ai_channels.add_ai_power_chan(
+            task.ai_channels.add_ai_power_chan(
                 f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
             )
 
-        reader = PowerMultiChannelReader(read_task.in_stream)
+        reader = PowerMultiChannelReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         reader.read_one_sample(voltage_data, current_data)
 
         for chan_index, output_enable in enumerate(output_enables):
@@ -164,7 +161,7 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_n_samp(self, generate_task, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_n_samp(self, task, sim_ts_power_devices, seed, output_enables):
         """Test to validate multi channel power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -181,15 +178,14 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (len(sim_ts_power_devices), number_of_samples_per_channel), -1.0, dtype=numpy.float64
         )
 
-        read_task = generate_task()
         for device, output_enable in zip(sim_ts_power_devices, output_enables):
-            read_task.ai_channels.add_ai_power_chan(
+            task.ai_channels.add_ai_power_chan(
                 f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
             )
 
-        reader = PowerMultiChannelReader(read_task.in_stream)
+        reader = PowerMultiChannelReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         reader.read_many_sample(
             voltage_data,
             current_data,
@@ -229,7 +225,7 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
     def test_power_1_chan_n_samp_binary(
-        self, generate_task, sim_ts_power_device, seed, output_enable
+        self, task, sim_ts_power_device, seed, output_enable
     ):
         """Test to validate power binary read operation with sample binary data."""
         # Reset the pseudorandom number generator with seed.
@@ -243,17 +239,16 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
         voltage_data = numpy.full((1, number_of_samples_per_channel), -32768, dtype=numpy.int16)
         current_data = numpy.full((1, number_of_samples_per_channel), -32768, dtype=numpy.int16)
 
-        read_task = generate_task()
-        read_task.ai_channels.add_ai_power_chan(
+        task.ai_channels.add_ai_power_chan(
             f"{sim_ts_power_device.name}/power",
             voltage_setpoint,
             current_setpoint,
             output_enable,
         )
 
-        reader = PowerBinaryReader(read_task.in_stream)
+        reader = PowerBinaryReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         reader.read_many_sample(
             voltage_data,
             current_data,
@@ -281,7 +276,7 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
         ],
     )
     def test_power_n_chan_many_sample_binary(
-        self, generate_task, sim_ts_power_devices, seed, output_enables
+        self, task, sim_ts_power_devices, seed, output_enables
     ):
         """Test to validate power binary read operation with sample binary data."""
         # Reset the pseudorandom number generator with seed.
@@ -299,15 +294,14 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
             (len(sim_ts_power_devices), number_of_samples_per_channel), -32768, dtype=numpy.int16
         )
 
-        read_task = generate_task()
         for device, output_enable in zip(sim_ts_power_devices, output_enables):
-            read_task.ai_channels.add_ai_power_chan(
+            task.ai_channels.add_ai_power_chan(
                 f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
             )
 
-        reader = PowerBinaryReader(read_task.in_stream)
+        reader = PowerBinaryReader(task.in_stream)
 
-        read_task.start()
+        task.start()
         reader.read_many_sample(
             voltage_data,
             current_data,

--- a/tests/legacy/test_stream_power_readers.py
+++ b/tests/legacy/test_stream_power_readers.py
@@ -5,7 +5,6 @@ import random
 import numpy
 import pytest
 
-import nidaqmx
 from nidaqmx.stream_readers import (
     PowerBinaryReader,
     PowerMultiChannelReader,
@@ -26,7 +25,7 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_1_samp(self, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_1_samp(self, generate_task, sim_ts_power_device, seed, output_enable):
         """Test to validate power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -34,30 +33,30 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
         voltage_setpoint = 0.0
         current_setpoint = 0.03
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
-            )
+        read_task = generate_task()
+        read_task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
 
-            reader = PowerSingleChannelReader(read_task.in_stream)
+        reader = PowerSingleChannelReader(read_task.in_stream)
 
-            read_task.start()
-            value_read = reader.read_one_sample()
+        read_task.start()
+        value_read = reader.read_one_sample()
 
-            if output_enable:
-                assert value_read.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                assert value_read.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-            else:
-                assert math.isnan(value_read.voltage)
-                assert math.isnan(value_read.current)
+        if output_enable:
+            assert value_read.voltage == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+            assert value_read.current == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+        else:
+            assert math.isnan(value_read.voltage)
+            assert math.isnan(value_read.current)
 
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_n_samp(self, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_n_samp(self, generate_task, sim_ts_power_device, seed, output_enable):
         """Test to validate power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -70,39 +69,39 @@ class TestPowerSingleChannelReader(TestDAQmxIOBase):
         voltage_data = numpy.full(number_of_samples_per_channel, -1.0, dtype=numpy.float64)
         current_data = numpy.full(number_of_samples_per_channel, -1.0, dtype=numpy.float64)
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
+        read_task = generate_task()
+        read_task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
+
+        reader = PowerSingleChannelReader(read_task.in_stream)
+
+        read_task.start()
+        reader.read_many_sample(
+            voltage_data,
+            current_data,
+            number_of_samples_per_channel=number_of_samples_per_channel,
+        )
+
+        if output_enable:
+            assert all(
+                [
+                    sample == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+                    for sample in voltage_data
+                ]
             )
-
-            reader = PowerSingleChannelReader(read_task.in_stream)
-
-            read_task.start()
-            reader.read_many_sample(
-                voltage_data,
-                current_data,
-                number_of_samples_per_channel=number_of_samples_per_channel,
+            assert all(
+                [
+                    sample == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+                    for sample in current_data
+                ]
             )
-
-            if output_enable:
-                assert all(
-                    [
-                        sample == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                        for sample in voltage_data
-                    ]
-                )
-                assert all(
-                    [
-                        sample == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-                        for sample in current_data
-                    ]
-                )
-            else:
-                assert all([math.isnan(sample) for sample in voltage_data])
-                assert all([math.isnan(sample) for sample in current_data])
+        else:
+            assert all([math.isnan(sample) for sample in voltage_data])
+            assert all([math.isnan(sample) for sample in current_data])
 
 
 class TestPowerMultiChannelReader(TestDAQmxIOBase):
@@ -121,7 +120,7 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_1_samp(self, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_1_samp(self, generate_task, sim_ts_power_devices, seed, output_enables):
         """Test to validate multi channel power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -133,28 +132,28 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
         voltage_data = numpy.full(len(sim_ts_power_devices), -1.0, dtype=numpy.float64)
         current_data = numpy.full(len(sim_ts_power_devices), -1.0, dtype=numpy.float64)
 
-        with nidaqmx.Task() as read_task:
-            for device, output_enable in zip(sim_ts_power_devices, output_enables):
-                read_task.ai_channels.add_ai_power_chan(
-                    f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+        read_task = generate_task()
+        for device, output_enable in zip(sim_ts_power_devices, output_enables):
+            read_task.ai_channels.add_ai_power_chan(
+                f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
+            )
+
+        reader = PowerMultiChannelReader(read_task.in_stream)
+
+        read_task.start()
+        reader.read_one_sample(voltage_data, current_data)
+
+        for chan_index, output_enable in enumerate(output_enables):
+            if output_enable:
+                assert voltage_data[chan_index] == pytest.approx(
+                    voltage_setpoint, abs=POWER_ABS_EPSILON
                 )
-
-            reader = PowerMultiChannelReader(read_task.in_stream)
-
-            read_task.start()
-            reader.read_one_sample(voltage_data, current_data)
-
-            for chan_index, output_enable in enumerate(output_enables):
-                if output_enable:
-                    assert voltage_data[chan_index] == pytest.approx(
-                        voltage_setpoint, abs=POWER_ABS_EPSILON
-                    )
-                    assert current_data[chan_index] == pytest.approx(
-                        current_setpoint, abs=POWER_ABS_EPSILON
-                    )
-                else:
-                    assert math.isnan(voltage_data[chan_index])
-                    assert math.isnan(current_data[chan_index])
+                assert current_data[chan_index] == pytest.approx(
+                    current_setpoint, abs=POWER_ABS_EPSILON
+                )
+            else:
+                assert math.isnan(voltage_data[chan_index])
+                assert math.isnan(current_data[chan_index])
 
     @pytest.mark.parametrize(
         "seed,output_enables",
@@ -165,7 +164,7 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_n_samp(self, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_n_samp(self, generate_task, sim_ts_power_devices, seed, output_enables):
         """Test to validate multi channel power read operation with sample data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -182,41 +181,41 @@ class TestPowerMultiChannelReader(TestDAQmxIOBase):
             (len(sim_ts_power_devices), number_of_samples_per_channel), -1.0, dtype=numpy.float64
         )
 
-        with nidaqmx.Task() as read_task:
-            for device, output_enable in zip(sim_ts_power_devices, output_enables):
-                read_task.ai_channels.add_ai_power_chan(
-                    f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
-                )
-
-            reader = PowerMultiChannelReader(read_task.in_stream)
-
-            read_task.start()
-            reader.read_many_sample(
-                voltage_data,
-                current_data,
-                number_of_samples_per_channel=number_of_samples_per_channel,
+        read_task = generate_task()
+        for device, output_enable in zip(sim_ts_power_devices, output_enables):
+            read_task.ai_channels.add_ai_power_chan(
+                f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
             )
 
-            for chan_index, output_enable in enumerate(output_enables):
-                # Get the data for just this channel
-                voltage_channel_data = voltage_data[chan_index]
-                current_channel_data = current_data[chan_index]
-                if output_enable:
-                    assert all(
-                        [
-                            sample == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
-                            for sample in voltage_channel_data
-                        ]
-                    )
-                    assert all(
-                        [
-                            sample == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
-                            for sample in current_channel_data
-                        ]
-                    )
-                else:
-                    assert all([math.isnan(sample) for sample in voltage_channel_data])
-                    assert all([math.isnan(sample) for sample in current_channel_data])
+        reader = PowerMultiChannelReader(read_task.in_stream)
+
+        read_task.start()
+        reader.read_many_sample(
+            voltage_data,
+            current_data,
+            number_of_samples_per_channel=number_of_samples_per_channel,
+        )
+
+        for chan_index, output_enable in enumerate(output_enables):
+            # Get the data for just this channel
+            voltage_channel_data = voltage_data[chan_index]
+            current_channel_data = current_data[chan_index]
+            if output_enable:
+                assert all(
+                    [
+                        sample == pytest.approx(voltage_setpoint, abs=POWER_ABS_EPSILON)
+                        for sample in voltage_channel_data
+                    ]
+                )
+                assert all(
+                    [
+                        sample == pytest.approx(current_setpoint, abs=POWER_ABS_EPSILON)
+                        for sample in current_channel_data
+                    ]
+                )
+            else:
+                assert all([math.isnan(sample) for sample in voltage_channel_data])
+                assert all([math.isnan(sample) for sample in current_channel_data])
 
 
 class TestPowerBinaryReader(TestDAQmxIOBase):
@@ -229,7 +228,9 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_n_samp_binary(self, sim_ts_power_device, seed, output_enable):
+    def test_power_1_chan_n_samp_binary(
+        self, generate_task, sim_ts_power_device, seed, output_enable
+    ):
         """Test to validate power binary read operation with sample binary data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -242,33 +243,33 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
         voltage_data = numpy.full((1, number_of_samples_per_channel), -32768, dtype=numpy.int16)
         current_data = numpy.full((1, number_of_samples_per_channel), -32768, dtype=numpy.int16)
 
-        with nidaqmx.Task() as read_task:
-            read_task.ai_channels.add_ai_power_chan(
-                f"{sim_ts_power_device.name}/power",
-                voltage_setpoint,
-                current_setpoint,
-                output_enable,
-            )
+        read_task = generate_task()
+        read_task.ai_channels.add_ai_power_chan(
+            f"{sim_ts_power_device.name}/power",
+            voltage_setpoint,
+            current_setpoint,
+            output_enable,
+        )
 
-            reader = PowerBinaryReader(read_task.in_stream)
+        reader = PowerBinaryReader(read_task.in_stream)
 
-            read_task.start()
-            reader.read_many_sample(
-                voltage_data,
-                current_data,
-                number_of_samples_per_channel=number_of_samples_per_channel,
-            )
+        read_task.start()
+        reader.read_many_sample(
+            voltage_data,
+            current_data,
+            number_of_samples_per_channel=number_of_samples_per_channel,
+        )
 
-            channel_voltage_data = voltage_data[0]
-            channel_current_data = current_data[0]
-            if output_enable:
-                # Scaling is complicated, just ensure everything was overwritten.
-                assert not any([sample == -32768 for sample in channel_voltage_data])
-                assert not any([sample == -32768 for sample in channel_current_data])
-            else:
-                # Simulated data is 0 when output is disabled for binary reads.
-                assert all([sample == 0 for sample in channel_voltage_data])
-                assert all([sample == 0 for sample in channel_current_data])
+        channel_voltage_data = voltage_data[0]
+        channel_current_data = current_data[0]
+        if output_enable:
+            # Scaling is complicated, just ensure everything was overwritten.
+            assert not any([sample == -32768 for sample in channel_voltage_data])
+            assert not any([sample == -32768 for sample in channel_current_data])
+        else:
+            # Simulated data is 0 when output is disabled for binary reads.
+            assert all([sample == 0 for sample in channel_voltage_data])
+            assert all([sample == 0 for sample in channel_current_data])
 
     @pytest.mark.parametrize(
         "seed,output_enables",
@@ -279,7 +280,9 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
             (generate_random_seed(), [False, False]),
         ],
     )
-    def test_power_n_chan_many_sample_binary(self, sim_ts_power_devices, seed, output_enables):
+    def test_power_n_chan_many_sample_binary(
+        self, generate_task, sim_ts_power_devices, seed, output_enables
+    ):
         """Test to validate power binary read operation with sample binary data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -296,30 +299,30 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
             (len(sim_ts_power_devices), number_of_samples_per_channel), -32768, dtype=numpy.int16
         )
 
-        with nidaqmx.Task() as read_task:
-            for device, output_enable in zip(sim_ts_power_devices, output_enables):
-                read_task.ai_channels.add_ai_power_chan(
-                    f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
-                )
-
-            reader = PowerBinaryReader(read_task.in_stream)
-
-            read_task.start()
-            reader.read_many_sample(
-                voltage_data,
-                current_data,
-                number_of_samples_per_channel=number_of_samples_per_channel,
+        read_task = generate_task()
+        for device, output_enable in zip(sim_ts_power_devices, output_enables):
+            read_task.ai_channels.add_ai_power_chan(
+                f"{device.name}/power", voltage_setpoint, current_setpoint, output_enable
             )
 
-            for chan_index, output_enable in enumerate(output_enables):
-                # Get the data for just this channel
-                voltage_channel_data = voltage_data[chan_index]
-                current_channel_data = current_data[chan_index]
-                if output_enable:
-                    # Scaling is complicated, just ensure everything was overwritten.
-                    assert not any([sample == -32768 for sample in voltage_channel_data])
-                    assert not any([sample == -32768 for sample in current_channel_data])
-                else:
-                    # Simulated data is 0 when output is disabled for binary reads.
-                    assert all([sample == 0 for sample in voltage_channel_data])
-                    assert all([sample == 0 for sample in current_channel_data])
+        reader = PowerBinaryReader(read_task.in_stream)
+
+        read_task.start()
+        reader.read_many_sample(
+            voltage_data,
+            current_data,
+            number_of_samples_per_channel=number_of_samples_per_channel,
+        )
+
+        for chan_index, output_enable in enumerate(output_enables):
+            # Get the data for just this channel
+            voltage_channel_data = voltage_data[chan_index]
+            current_channel_data = current_data[chan_index]
+            if output_enable:
+                # Scaling is complicated, just ensure everything was overwritten.
+                assert not any([sample == -32768 for sample in voltage_channel_data])
+                assert not any([sample == -32768 for sample in current_channel_data])
+            else:
+                # Simulated data is 0 when output is disabled for binary reads.
+                assert all([sample == 0 for sample in voltage_channel_data])
+                assert all([sample == 0 for sample in current_channel_data])

--- a/tests/legacy/test_stream_power_readers.py
+++ b/tests/legacy/test_stream_power_readers.py
@@ -224,9 +224,7 @@ class TestPowerBinaryReader(TestDAQmxIOBase):
     @pytest.mark.parametrize(
         "seed,output_enable", [(generate_random_seed(), True), (generate_random_seed(), False)]
     )
-    def test_power_1_chan_n_samp_binary(
-        self, task, sim_ts_power_device, seed, output_enable
-    ):
+    def test_power_1_chan_n_samp_binary(self, task, sim_ts_power_device, seed, output_enable):
         """Test to validate power binary read operation with sample binary data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)

--- a/tests/legacy/test_teds.py
+++ b/tests/legacy/test_teds.py
@@ -3,7 +3,6 @@ import random
 
 import pytest
 
-import nidaqmx
 from nidaqmx.constants import TEDSUnits, TerminalConfiguration
 from tests.helpers import generate_random_seed
 
@@ -15,7 +14,9 @@ class TestTEDS:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_teds_ai_voltage_chan(self, any_x_series_device, seed, test_assets_directory):
+    def test_create_teds_ai_voltage_chan(
+        self, task, any_x_series_device, seed, test_assets_directory
+    ):
         """Test to validate TEDS functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -33,17 +34,16 @@ class TestTEDS:
         assert ai_phys_chan.teds_version_num == 1
         assert ai_phys_chan.teds_template_ids == [30]
 
-        with nidaqmx.Task() as task:
-            ai_channel = task.ai_channels.add_teds_ai_voltage_chan(
-                ai_phys_chan.name,
-                name_to_assign_to_channel="TEDSVoltageChannel",
-                terminal_config=TerminalConfiguration.DEFAULT,
-                min_val=-300.0,
-                max_val=100.0,
-                units=TEDSUnits.FROM_TEDS,
-            )
+        ai_channel = task.ai_channels.add_teds_ai_voltage_chan(
+            ai_phys_chan.name,
+            name_to_assign_to_channel="TEDSVoltageChannel",
+            terminal_config=TerminalConfiguration.DEFAULT,
+            min_val=-300.0,
+            max_val=100.0,
+            units=TEDSUnits.FROM_TEDS,
+        )
 
-            assert ai_channel.ai_teds_is_teds
-            assert ai_channel.ai_teds_units == "Kelvin"
-            assert ai_channel.ai_min == -300.0
-            assert ai_channel.ai_max == 100.0
+        assert ai_channel.ai_teds_is_teds
+        assert ai_channel.ai_teds_units == "Kelvin"
+        assert ai_channel.ai_min == -300.0
+        assert ai_channel.ai_max == 100.0

--- a/tests/legacy/test_triggers.py
+++ b/tests/legacy/test_triggers.py
@@ -3,7 +3,6 @@ import random
 
 import pytest
 
-import nidaqmx
 from nidaqmx import DaqError
 from nidaqmx.constants import AcquisitionType, Edge, TriggerType
 from tests.helpers import generate_random_seed
@@ -17,71 +16,67 @@ class TestTriggers(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_arm_start_trigger(self, any_x_series_device, seed):
+    def test_arm_start_trigger(self, task, any_x_series_device, seed):
         """Test to validate start trigger functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         counter = random.choice(self._get_device_counters(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.co_channels.add_co_pulse_chan_freq(counter)
-            task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
-            assert task.triggers.arm_start_trigger.trig_type == TriggerType.DIGITAL_EDGE
+        task.co_channels.add_co_pulse_chan_freq(counter)
+        task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
+        assert task.triggers.arm_start_trigger.trig_type == TriggerType.DIGITAL_EDGE
 
-            task.triggers.arm_start_trigger.trig_type = TriggerType.NONE
-            assert task.triggers.arm_start_trigger.trig_type == TriggerType.NONE
+        task.triggers.arm_start_trigger.trig_type = TriggerType.NONE
+        assert task.triggers.arm_start_trigger.trig_type == TriggerType.NONE
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_handshake_trigger(self, any_x_series_device, seed):
+    def test_handshake_trigger(self, task, any_x_series_device, seed):
         """Test to validate trigger handshake."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         counter = random.choice(self._get_device_counters(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.co_channels.add_co_pulse_chan_freq(counter)
+        task.co_channels.add_co_pulse_chan_freq(counter)
 
-            with pytest.raises(DaqError) as e:
-                task.triggers.handshake_trigger.trig_type = TriggerType.INTERLOCKED
-            assert e.value.error_code == -200452
+        with pytest.raises(DaqError) as e:
+            task.triggers.handshake_trigger.trig_type = TriggerType.INTERLOCKED
+        assert e.value.error_code == -200452
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pause_trigger(self, any_x_series_device, seed):
+    def test_pause_trigger(self, task, any_x_series_device, seed):
         """Test to validate pause trigger."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         counter = random.choice(self._get_device_counters(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.co_channels.add_co_pulse_chan_freq(counter)
-            task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
+        task.co_channels.add_co_pulse_chan_freq(counter)
+        task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
 
-            task.triggers.pause_trigger.trig_type = TriggerType.DIGITAL_LEVEL
-            assert task.triggers.pause_trigger.trig_type == TriggerType.DIGITAL_LEVEL
+        task.triggers.pause_trigger.trig_type = TriggerType.DIGITAL_LEVEL
+        assert task.triggers.pause_trigger.trig_type == TriggerType.DIGITAL_LEVEL
 
-            task.triggers.pause_trigger.trig_type = TriggerType.NONE
-            assert task.triggers.pause_trigger.trig_type == TriggerType.NONE
+        task.triggers.pause_trigger.trig_type = TriggerType.NONE
+        assert task.triggers.pause_trigger.trig_type == TriggerType.NONE
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_reference_trigger(self, any_x_series_device, seed):
+    def test_reference_trigger(self, task, any_x_series_device, seed):
         """Test to validate reference trigger."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         counter = random.choice(self._get_device_counters(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.co_channels.add_co_pulse_chan_freq(counter)
+        task.co_channels.add_co_pulse_chan_freq(counter)
 
-            with pytest.raises(DaqError) as e:
-                task.triggers.reference_trigger.trig_type = TriggerType.NONE
-            assert e.value.error_code == -200452
+        with pytest.raises(DaqError) as e:
+            task.triggers.reference_trigger.trig_type = TriggerType.NONE
+        assert e.value.error_code == -200452
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_start_trigger(self, any_x_series_device, seed):
+    def test_start_trigger(self, task, any_x_series_device, seed):
         """Test to validate start trigger functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -89,9 +84,8 @@ class TestTriggers(TestDAQmxIOBase):
         counter = random.choice(self._get_device_counters(any_x_series_device))
         pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
 
-        with nidaqmx.Task() as task:
-            task.co_channels.add_co_pulse_chan_freq(counter)
-            task.triggers.start_trigger.cfg_dig_edge_start_trig(pfi_line, trigger_edge=Edge.FALLING)
+        task.co_channels.add_co_pulse_chan_freq(counter)
+        task.triggers.start_trigger.cfg_dig_edge_start_trig(pfi_line, trigger_edge=Edge.FALLING)
 
-            assert task.triggers.start_trigger.trig_type == TriggerType.DIGITAL_EDGE
-            assert task.triggers.start_trigger.dig_edge_edge == Edge.FALLING
+        assert task.triggers.start_trigger.trig_type == TriggerType.DIGITAL_EDGE
+        assert task.triggers.start_trigger.dig_edge_edge == Edge.FALLING

--- a/tests/legacy/test_write_exceptions.py
+++ b/tests/legacy/test_write_exceptions.py
@@ -15,7 +15,7 @@ class TestWriteExceptions:
     loopback routes on the device.
     """
 
-    def test_overwrite(self, real_x_series_device):
+    def test_overwrite(self, task, real_x_series_device):
         """Test to validate overwrite functionality."""
         # USB streaming is very tricky.
         if not (
@@ -29,46 +29,43 @@ class TestWriteExceptions:
         fifo_size = 8191
         host_buffer_size = 1000
 
-        with nidaqmx.Task() as write_task:
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            write_task.ao_channels.add_ao_voltage_chan(
-                real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10
-            )
-            write_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                sample_mode=AcquisitionType.CONTINUOUS,
-                samps_per_chan=number_of_samples,
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10
+        )
+        task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            sample_mode=AcquisitionType.CONTINUOUS,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Don't allow regeneration - this enables explicit hardware flow control.
-            write_task.out_stream.regen_mode = RegenerationMode.DONT_ALLOW_REGENERATION
+        # Don't allow regeneration - this enables explicit hardware flow control.
+        task.out_stream.regen_mode = RegenerationMode.DONT_ALLOW_REGENERATION
 
-            # This is the only entrypoint that correctly sets number_of_samples_written in error
-            # conditions prior to DAQmx 21.8.
-            writer = nidaqmx.stream_writers.AnalogUnscaledWriter(
-                write_task.out_stream, auto_start=False
-            )
+        # This is the only entrypoint that correctly sets number_of_samples_written in error
+        # conditions prior to DAQmx 21.8.
+        writer = nidaqmx.stream_writers.AnalogUnscaledWriter(task.out_stream, auto_start=False)
 
-            # Fill up the host buffer first.
-            initial_write_data = numpy.zeros((1, host_buffer_size), dtype=numpy.int16)
-            writer.write_int16(initial_write_data)
+        # Fill up the host buffer first.
+        initial_write_data = numpy.zeros((1, host_buffer_size), dtype=numpy.int16)
+        writer.write_int16(initial_write_data)
 
-            # Start the write task. All data from the host buffer should be in the FIFO.
-            write_task.start()
+        # Start the write task. All data from the host buffer should be in the FIFO.
+        task.start()
 
-            # Now write more data than can fit in the FIFO + host buffer.
-            large_write_data = numpy.zeros((1, fifo_size * 2), dtype=numpy.int16)
-            with pytest.raises(nidaqmx.DaqWriteError) as timeout_exception:
-                writer.write_int16(large_write_data, timeout=2.0)
+        # Now write more data than can fit in the FIFO + host buffer.
+        large_write_data = numpy.zeros((1, fifo_size * 2), dtype=numpy.int16)
+        with pytest.raises(nidaqmx.DaqWriteError) as timeout_exception:
+            writer.write_int16(large_write_data, timeout=2.0)
 
-            assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_CAN_NOT_YET_BE_WRITTEN
-            # Some of the data should have been written successfully. This test doesn't
-            # need to get into the nitty gritty device details on how much.
-            assert timeout_exception.value.samps_per_chan_written > 0
+        assert timeout_exception.value.error_code == DAQmxErrors.SAMPLES_CAN_NOT_YET_BE_WRITTEN
+        # Some of the data should have been written successfully. This test doesn't
+        # need to get into the nitty gritty device details on how much.
+        assert timeout_exception.value.samps_per_chan_written > 0
 
-    def test_overwrite_during_prime(self, real_x_series_device):
+    def test_overwrite_during_prime(self, task, real_x_series_device):
         """Test to validate overwrite functionality during prime."""
         # USB streaming is very tricky.
         if not (
@@ -83,35 +80,32 @@ class TestWriteExceptions:
         host_buffer_size = 1000
         total_buffer_size = fifo_size + host_buffer_size
 
-        with nidaqmx.Task() as write_task:
-            samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
+        samp_clk_terminal = f"/{real_x_series_device.name}/Ctr0InternalOutput"
 
-            write_task.ao_channels.add_ao_voltage_chan(
-                real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10
-            )
-            write_task.timing.cfg_samp_clk_timing(
-                sample_rate,
-                source=samp_clk_terminal,
-                sample_mode=AcquisitionType.CONTINUOUS,
-                samps_per_chan=number_of_samples,
-            )
+        task.ao_channels.add_ao_voltage_chan(
+            real_x_series_device.ao_physical_chans[0].name, max_val=10, min_val=-10
+        )
+        task.timing.cfg_samp_clk_timing(
+            sample_rate,
+            source=samp_clk_terminal,
+            sample_mode=AcquisitionType.CONTINUOUS,
+            samps_per_chan=number_of_samples,
+        )
 
-            # Don't allow regeneration - this enables explicit hardware flow control.
-            write_task.out_stream.regen_mode = RegenerationMode.DONT_ALLOW_REGENERATION
-            # Make the host buffer small.
-            write_task.out_stream.output_buf_size = number_of_samples
+        # Don't allow regeneration - this enables explicit hardware flow control.
+        task.out_stream.regen_mode = RegenerationMode.DONT_ALLOW_REGENERATION
+        # Make the host buffer small.
+        task.out_stream.output_buf_size = number_of_samples
 
-            # This is the only entrypoint that correctly sets number_of_samples_written in error
-            # conditions prior to DAQmx 21.8.
-            writer = nidaqmx.stream_writers.AnalogUnscaledWriter(
-                write_task.out_stream, auto_start=False
-            )
+        # This is the only entrypoint that correctly sets number_of_samples_written in error
+        # conditions prior to DAQmx 21.8.
+        writer = nidaqmx.stream_writers.AnalogUnscaledWriter(task.out_stream, auto_start=False)
 
-            # This is more data than can be primed, so this should fail.
-            initial_write_data = numpy.zeros((1, total_buffer_size * 2), dtype=numpy.int16)
-            with pytest.raises(nidaqmx.DaqWriteError) as timeout_exception:
-                writer.write_int16(initial_write_data)
+        # This is more data than can be primed, so this should fail.
+        initial_write_data = numpy.zeros((1, total_buffer_size * 2), dtype=numpy.int16)
+        with pytest.raises(nidaqmx.DaqWriteError) as timeout_exception:
+            writer.write_int16(initial_write_data)
 
-            assert timeout_exception.value.error_code == DAQmxErrors.NO_MORE_SPACE
-            # The driver detects that the write will fail immediately, so no data was written.
-            assert timeout_exception.value.samps_per_chan_written == 0
+        assert timeout_exception.value.error_code == DAQmxErrors.NO_MORE_SPACE
+        # The driver detects that the write will fail immediately, so no data was written.
+        assert timeout_exception.value.samps_per_chan_written == 0


### PR DESCRIPTION
What does this PR accomplish?
This PR updated all the existing nidaqmx tests that use the task instance to use the task fixture.

Why should this PR be merged?
- This PR updates all the test functions that uses a task instance to have the task fixture as a parameter and directly use the task instance returned by the fixture.
- A fixture has been created called `generate_task`, which follows [factory as fixture pattern](https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#factories-as-fixtures). This is used in tests where more than one task instance is required.
- The existing task fixture has also been updated to work based on the `generate_task` fixture.