### PR TITLE
tests: Fix ResourceWarnings in GrpcServerProcess

### DIFF
--- a/tests/_grpc_utils.py
+++ b/tests/_grpc_utils.py
@@ -33,11 +33,13 @@ class GrpcServerProcess:
 
     def __enter__(self):
         """Returns the GrpcServerProcess instance."""
+        self._proc.__enter__()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Closes the GrpcServerProcess instance."""
         self._proc.kill()
+        self._proc.__exit__(exc_type, exc_val, exc_tb)
 
     def _get_grpc_server_exe(self):
         if os.name != "nt":

--- a/tests/_grpc_utils.py
+++ b/tests/_grpc_utils.py
@@ -29,6 +29,7 @@ class GrpcServerProcess:
             self._stdout_thread.start()
         except Exception:
             self._proc.kill()
+            # Use communicate() to close the stdout pipe and wait for the server process to exit.
             _, _ = self._proc.communicate()
             raise
 


### PR DESCRIPTION
## What does this Pull Request accomplish?

Fix these warnings:
```
subprocess.py:1052: ResourceWarning: subprocess 9604 is still running
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```
```
_pytest\fixtures.py:1045: ResourceWarning: unclosed file <_io.BufferedReader name=14>
    self.cached_result = None
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

## Why should this Pull Request be merged?

nidaqmx-python tests enable reporting `ResourceWarning` because nidaqmx-python itself reports this warning.

## What testing has been done?

`pytest -v tests/component/test_scale.py` with an updated test.
`pytest -v -k grpc`
