### PR TITLE
tests: Update pytest options for doctests, markers, testpaths, and warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,9 @@ extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates"
 extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates,src/handwritten"
 
 [tool.pytest.ini_options]
-filterwarnings = ["always::ResourceWarning"]
+addopts = "--doctest-modules --strict-markers"
+filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
+testpaths = ["tests"]
 
 [build-system]
 requires = ["poetry>=1.2"]


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Specify --doctest-modules. If we add doctests to the main package, we should run them.
- Specify --strict-markers. Require markers to be declared to avoid typos and ensure they are documented.
- Enable ImportWarning. By default, Python filters out DeprecationWarning, DeprecationPendingWarning, ImportWarning, and ResourceWarning. Pytest enables DeprecationWarning and DeprecationPendingWarning but not the others. Enabling ResourceWarning in nidaqmx-python has caught some resource leaks, so we might as well enable ImportWarning too.
- Specify testpaths to test pytest where to search for tests.

> **Note**
> I chose not to enable --cov or --verbose in pyproject.toml. These are still specified in the PR workflow.

### Why should this Pull Request be merged?

Ensure proper handling of doctests, markers, and warnings.

Specifying testpaths should reduce the number of directories that pytest searches for tests.

### What testing has been done?

Ran `poetry run pytest -v`
Ran `poetry run tox`