### PR TITLE
Add markers for running tests with only library or grpc interpreters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates,src/
 addopts = "--doctest-modules --strict-markers"
 filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
-filterwarnings = ["always::ResourceWarning"]
 markers = [
   # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
   "library_only: tests only the libaray interpreter implementation.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,8 @@ addopts = "--doctest-modules --strict-markers"
 filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
 markers = [
-  # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
-  "library_only: tests only the libaray interpreter implementation.",
+  # Defines custom markers used by nidaqmx tests. Prevents PytestUnknownMarkWarning.
+  "library_only: tests only the library interpreter implementation.",
   "grpc_only: tests only the grpc interpreter implementation.",
   "new_task_name: name of the new task to be created."
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,13 @@ extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates,src/
 addopts = "--doctest-modules --strict-markers"
 filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
+filterwarnings = ["always::ResourceWarning"]
+markers = [
+  # Defines custom markers used by nidcpower system tests. Prevents PytestUnknownMarkWarning.
+  "library_only: tests only the libaray interpreter implementation.",
+  "grpc_only: tests only the grpc interpreter implementation.",
+  "new_task_name: name of the new task to be created."
+]
 
 [build-system]
 requires = ["poetry>=1.2"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,29 @@ class DeviceType(Enum):
     SIMULATED = 1
 
 
+def pytest_generate_tests(metafunc):
+    """Parametrizes the "init_kwargs" fixture by examining the the markers set for a test.
+
+    This is used to decide if tests for gRPC or Library interpreters should be run.
+    This is done based on the custom markers @pytest.mark.grpc_only and @pytest.mark.library_only.
+    """
+    if "init_kwargs" in metafunc.fixturenames:
+        # fixtures can't be parametrized more than once. this approach prevents exclusive
+        # markers from being set on the same test
+
+        grpc_only = metafunc.definition.get_closest_marker("grpc_only")
+        library_only = metafunc.definition.get_closest_marker("library_only")
+
+        if grpc_only:
+            metafunc.parametrize("init_kwargs", ["grpc_init_kwargs"], indirect=True)
+        if library_only:
+            metafunc.parametrize("init_kwargs", ["library_init_kwargs"], indirect=True)
+        if not library_only and not grpc_only:
+            metafunc.parametrize(
+                "init_kwargs", ["library_init_kwargs", "grpc_init_kwargs"], indirect=True
+            )
+
+
 def _x_series_device(device_type):
     system = nidaqmx.system.System.local()
 
@@ -285,7 +308,7 @@ def library_init_kwargs():
     return {}
 
 
-@pytest.fixture(params=("library_init_kwargs", "grpc_init_kwargs"), scope="session")
+@pytest.fixture(scope="session")
 def init_kwargs(request):
     """Gets the keyword arguments to create a nidaqmx session."""
     return request.getfixturevalue(request.param)

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -81,12 +81,12 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    @pytest.mark.library_only  
+    @pytest.mark.library_only
     def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
         # gRPC implementation will be tested after fixing Bug 2388532
         # Bug link: https://ni.visualstudio.com/DevCentral/_workitems/edit/2388532.
-        
+
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -81,6 +81,7 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
+    @pytest.mark.library_only
     def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
         # Reset the pseudorandom number generator with seed.

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -81,9 +81,12 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    @pytest.mark.library_only
+    @pytest.mark.library_only  
     def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
+        # gRPC implementation will be tested after fixing Bug 2388532
+        # Bug link: https://ni.visualstudio.com/DevCentral/_workitems/edit/2388532.
+        
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The existing implementation of `init_kwargs` fixture always runs for both the `library_init_kwargs` and `grpc_init_kwargs` implementations.  This PR adds 2 new markers namely `library_only` and `grpc_only`, which can be used to restrict the test to only run for any one of the required implementations.

### Why should this Pull Request be merged?

- Added the [`pytest_generate_tests` function](https://docs.pytest.org/en/6.2.x/parametrize.html#basic-pytest-generate-tests-example), which is a hook in pytest, which is called during test collection phase. Here based on the `library_only` and `grpc_only` markers the parameters for the `init_kwargs` fixture is passed.
- The `test_hash_operations` test only can be tested with a task instance created through the c functions calls (libaray interpreter), since the hash value cannot be obtained for a grpc task instance. Therefore, this test has been marked to work with only library interpreter implementation with the use of `library_only` marker.
- Added the known markers to `pyproject.toml` file to avoid any pytest warning related to unknown markers.

### What testing has been done?

- The `test_hash_operations` marked with `library_only` marker successfully skipped the grpc test implementation.