### PR TITLE
tests: Stop explicitly referencing the grpc_session_options module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import pytest
 
 import nidaqmx.system
 from nidaqmx.constants import ProductCategory, UsageTypeAI
-from nidaqmx.grpc_session_options import GrpcSessionOptions
 
 try:
     import grpc
@@ -304,7 +303,7 @@ def grpc_channel(grpc_server_process: GrpcServerProcess) -> grpc.Channel:
 @pytest.fixture(scope="session")
 def grpc_init_kwargs(grpc_channel: grpc.Channel) -> dict:
     """Gets the keyword arguments required for creating the gRPC interpreter."""
-    grpc_options = GrpcSessionOptions(
+    grpc_options = nidaqmx.GrpcSessionOptions(
         grpc_channel=grpc_channel,
         session_name="",
     )

--- a/tests/unit/_grpc_utils.py
+++ b/tests/unit/_grpc_utils.py
@@ -2,7 +2,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from nidaqmx.grpc_session_options import GrpcSessionOptions
+import nidaqmx
 
 try:
     import grpc
@@ -10,10 +10,10 @@ except ImportError:
     grpc = None
 
 
-def create_grpc_options(mocker: MockerFixture, session_name="") -> GrpcSessionOptions:
+def create_grpc_options(mocker: MockerFixture, session_name="") -> nidaqmx.GrpcSessionOptions:
     """Create a GrpcSessionOptions object."""
     if grpc is None:
         pytest.skip("The grpc module is not available.")
     grpc_channel = mocker.create_autospec(grpc.Channel)
-    grpc_options = GrpcSessionOptions(grpc_channel, session_name)
+    grpc_options = nidaqmx.GrpcSessionOptions(grpc_channel, session_name)
     return grpc_options


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change tests to use `nidaqmx.GrpcSessionOptions` instead of explicitly importing the `nidaqmx.grpc_session_options` submodule.

### Why should this Pull Request be merged?

Validate AB#2387046: nidaqmx-python should alias gRPC types into nidaqmx module

### What testing has been done?

Ran `poetry run pytest`