### PR TITLE
docs: Document GrpcSessionOptions and update hyperlinks

### DIFF
--- a/docs/grpc_session_options.rst
+++ b/docs/grpc_session_options.rst
@@ -1,0 +1,68 @@
+nidaqmx.grpc_session_options
+============================
+
+Support for using NI-DAQmx over gRPC
+
+.. note:: For MeasurementLink and NI gRPC Device Server, a NI-DAQmx task is considered to be a type of driver session.
+
+.. py:currentmodule:: nidaqmx
+
+.. py:class:: SessionInitializationBehavior
+    :canonical: nidaqmx.grpc_session_options.SessionInitializationBehavior
+
+    .. py:attribute:: SessionInitializationBehavior.AUTO
+
+        The NI gRPC Device Server will attach to an existing session with the specified name if it exists,
+        otherwise the server will initialize a new session.
+
+        .. note:: When using a :class:`~nidaqmx.task.Task` as a context manager and the context exits, the behavior depends on what happened when the constructor
+            was called. If it resulted in a new session being created on the NI gRPC Device Server, then it will automatically close the
+            server session. If it instead attached to an existing session, then it will detach from the server session and leave it open.
+
+    .. py:attribute:: SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
+
+        Require the NI gRPC Device Server to initialize a new session with the specified name.
+
+        .. note:: When using a :class:`~nidaqmx.task.Task` as a context manager and the context exits, it will automatically close the
+            server session.
+
+    .. py:attribute:: SessionInitializationBehavior.ATTACH_TO_SERVER_SESSION
+
+        Require the NI gRPC Device Server to attach to an existing session with the specified name.
+
+        .. note:: When using a :class:`~nidaqmx.task.Task` as a context manager and the context exits, it will detach from the server session
+            and leave it open.
+
+
+.. py:class:: GrpcSessionOptions(self, grpc_channel, session_name, initialization_behavior=SessionInitializationBehavior.AUTO)
+    :canonical: nidaqmx.grpc_session_options.GrpcSessionOptions
+
+    Collection of options that specifies session behaviors related to gRPC.
+
+    Creates and returns an object you can pass to a :class:`~nidaqmx.task.Task` constructor or various other constructors and methods.
+
+    :param grpc_channel:
+
+        Specifies the channel to the NI gRPC Device Server.
+
+    :type grpc_channel: :class:`grpc.Channel`
+
+    :param session_name:
+
+        User-specified name that identifies the driver session on the NI gRPC Device Server.
+
+        This is different from the resource name parameter many APIs take as a separate
+        parameter. Specifying a name makes it easy to share sessions across multiple gRPC clients.
+
+        For NI-DAQmx tasks, the driver session name is the same as the NI-DAQmx task name.
+        You can either specify the name passed to a :class:`~nidaqmx.task.Task` constructor or an empty string.
+
+    :type session_name: str
+
+    :param initialization_behavior:
+
+        Specifies whether it is acceptable to initialize a new session or attach to an existing one, or if only one of the behaviors is desired.
+
+        The driver session exists on the NI gRPC Device Server.
+
+    :type initialization_behavior: :py:data:`nidaqmx.SessionInitializationBehavior`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,12 +8,15 @@ NI-DAQmx Python Documentation
 
 .. include:: ../README.rst
 
+.. py:module:: nidaqmx
+
 .. toctree::
    :maxdepth: 3
    :caption: API Reference:
 
    constants
    errors
+   grpc_session_options
    scale
    stream_readers
    stream_writers

--- a/generated/nidaqmx/scale.py
+++ b/generated/nidaqmx/scale.py
@@ -19,7 +19,8 @@ class Scale:
         """
         Args:
             name (str): Specifies the name of the scale to create.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -286,14 +287,14 @@ class Scale:
                 3 indicates a 3rd order polynomial. A value of -1
                 indicates a reverse polynomial of the same order as the
                 forward polynomial.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            List[float]: 
-            
-            Specifies the list of coefficients for the reverse 
-            polynomial. Each element of the list corresponds to a term 
-            of the equation. For example, if index three of the list is 
+            List[float]:
+
+            Specifies the list of coefficients for the reverse
+            polynomial. Each element of the list corresponds to a term
+            of the equation. For example, if index three of the list is
             9, the fourth term of the equation is 9y^3.
         """
         forward_coeffs = numpy.float64(forward_coeffs)
@@ -325,11 +326,11 @@ class Scale:
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
             nidaqmx.scale.Scale:
-            
+
             Indicates an object that represents the created custom scale.
         """
         scale = Scale(scale_name, grpc_options=grpc_options)
@@ -370,17 +371,17 @@ class Scale:
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         scale = Scale(scale_name, grpc_options=grpc_options)
 
         scale._interpreter.create_map_scale(
-            scale_name, prescaled_min, prescaled_max, scaled_min, scaled_max, 
+            scale_name, prescaled_min, prescaled_max, scaled_min, scaled_max,
             pre_scaled_units.value, scaled_units)
 
         return scale
@@ -412,11 +413,11 @@ class Scale:
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         if forward_coeffs is None:
@@ -459,11 +460,11 @@ class Scale:
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         if prescaled_vals is None:
@@ -474,7 +475,7 @@ class Scale:
 
         prescaled_vals = numpy.float64(prescaled_vals)
         scaled_vals = numpy.float64(scaled_vals)
-        
+
         scale = Scale(scale_name, grpc_options=grpc_options)
 
         scale._interpreter.create_table_scale(
@@ -537,7 +538,7 @@ class _ScaleAlternateConstructor(Scale):
         Args:
             name: Specifies the name of the Scale.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/device.py
+++ b/generated/nidaqmx/system/device.py
@@ -27,7 +27,8 @@ class Device:
         """
         Args:
             name (str): Specifies the name of the device.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -1100,16 +1101,16 @@ class Device:
                 False.
             timeout (Optional[float]): Specifies the time in seconds to
                 wait for the device to respond before timing out.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.system.device.Device: 
-            
+            nidaqmx.system.device.Device:
+
             Specifies the object that represents the device this
             operation applied to.
         """
         device = Device("", grpc_options=grpc_options)
-        
+
         device._name = device._interpreter.add_network_device(
             ip_address, device_name, attempt_reservation, timeout)
 
@@ -1163,7 +1164,7 @@ class _DeviceAlternateConstructor(Device):
         Args:
             name: Specifies the name of the Device.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/physical_channel.py
+++ b/generated/nidaqmx/system/physical_channel.py
@@ -24,7 +24,8 @@ class PhysicalChannel:
         """
         Args:
             name (str): Specifies the name of the physical channel.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -675,7 +676,7 @@ class _PhysicalChannelAlternateConstructor(PhysicalChannel):
     """
     Provide an alternate constructor for the PhysicalChannel object.
 
-    This is a private API used to instantiate a PhysicalChannel with an existing interpreter.     
+    This is a private API used to instantiate a PhysicalChannel with an existing interpreter.
     """
     # Setting __slots__ avoids TypeError: __class__ assignment: 'Base' object layout differs from 'Derived'.
     __slots__ = []
@@ -685,7 +686,7 @@ class _PhysicalChannelAlternateConstructor(PhysicalChannel):
         Args:
             name: Specifies the name of the Physical Channel.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/storage/persisted_channel.py
+++ b/generated/nidaqmx/system/storage/persisted_channel.py
@@ -17,7 +17,8 @@ class PersistedChannel:
         """
         Args:
             name (str): Specifies the name of the global channel.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -86,7 +87,7 @@ class _PersistedChannelAlternateConstructor(PersistedChannel):
         Args:
             name: Specifies the name of the PersistedChannel.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/storage/persisted_scale.py
+++ b/generated/nidaqmx/system/storage/persisted_scale.py
@@ -18,7 +18,8 @@ class PersistedScale:
         """
         Args:
             name (str): Specifies the name of the saved scale.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -96,7 +97,7 @@ class _PersistedScaleAlternateConstructor(PersistedScale):
         Args:
             name: Specifies the name of the PersistedScale.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/storage/persisted_task.py
+++ b/generated/nidaqmx/system/storage/persisted_task.py
@@ -18,7 +18,8 @@ class PersistedTask:
         """
         Args:
             name (str): Specifies the name of the saved task.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -84,7 +85,7 @@ class PersistedTask:
         task_handle, close_on_exit = self._interpreter.load_task(self._name)
 
         return task._TaskAlternateConstructor(task_handle, self._interpreter, close_on_exit)
-    
+
 
 class _PersistedTaskAlternateConstructor(PersistedTask):
     """
@@ -100,7 +101,7 @@ class _PersistedTaskAlternateConstructor(PersistedTask):
         Args:
             name: Specifies the name of the PersistedTask.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -36,7 +36,8 @@ class System:
     def __init__(self, grpc_options=None):
         """
         Args:
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._interpreter = utils._select_interpreter(grpc_options)
 
@@ -53,7 +54,8 @@ class System:
         nidaqmx.system.system.System: Represents the remote DAQmx system.
 
         Args:
-            grpc_options: Specifies the gRPC session options.
+            grpc_options (:class:`~nidaqmx.GrpcSessionOptions`): Specifies
+                the gRPC session options.
         """
         return System(grpc_options)
 
@@ -334,7 +336,7 @@ class System:
 
         for do_line in device.do_lines:
             channel_names.append(do_line.name)
-        
+
         states =  self._interpreter.get_digital_pull_up_pull_down_states(device_name, channel_names)
 
         power_up_states = []
@@ -434,7 +436,7 @@ class System:
         channel_types = []
 
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
-        
+
         for ao_physical_chan in device.ao_physical_chans:
             channel_type = ctypes.c_int()
             channel_types.append(channel_type)

--- a/generated/nidaqmx/system/watchdog.py
+++ b/generated/nidaqmx/system/watchdog.py
@@ -45,7 +45,8 @@ class WatchdogTask:
                 Trigger to expire the watchdog task. If this time elapses, the
                 device sets the physical channels to the states you specify
                 with the digital physical channel expiration states input.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -66,6 +66,9 @@ class Task:
                 after you are finished with the task. Otherwise, NI-DAQmx
                 attempts to create multiple tasks with the same name, which
                 results in an error.
+
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None
@@ -79,7 +82,7 @@ class Task:
                 f'Unsupported session name: "{grpc_options.session_name}". If a session name is specified, it must match the task name.',
                 DAQmxErrors.UNKNOWN,
                 task_name=new_task_name)
-        
+
         self._interpreter = utils._select_interpreter(grpc_options)
         self._handle, self._close_on_exit = self._interpreter.create_task(new_task_name)
 
@@ -124,8 +127,8 @@ class Task:
     @property
     def channels(self):
         """
-        :class:`nidaqmx._task_modules.channels.channel.Channel`: Specifies 
-            a channel object that represents the entire list of virtual 
+        :class:`nidaqmx._task_modules.channels.channel.Channel`: Specifies
+            a channel object that represents the entire list of virtual
             channels in this task.
         """
         return Channel._factory(
@@ -150,7 +153,7 @@ class Task:
     @property
     def devices(self):
         """
-        List[:class:`nidaqmx.system.device.Device`]: Indicates a list 
+        List[:class:`nidaqmx.system.device.Device`]: Indicates a list
             of Device objects representing all the devices in the task.
         """
         val = self._interpreter.get_task_attribute_string(self._handle, 0x230e)
@@ -176,7 +179,7 @@ class Task:
     @property
     def ao_channels(self):
         """
-        :class:`nidaqmx._task_modules.ao_channel_collection.AOChannelCollection`: 
+        :class:`nidaqmx._task_modules.ao_channel_collection.AOChannelCollection`:
             Gets the collection of analog output channels for this task.
         """
         return self._ao_channels
@@ -184,7 +187,7 @@ class Task:
     @property
     def ci_channels(self):
         """
-        :class:`nidaqmx._task_modules.ci_channel_collection.CIChannelCollection`: 
+        :class:`nidaqmx._task_modules.ci_channel_collection.CIChannelCollection`:
             Gets the collection of counter input channels for this task.
         """
         return self._ci_channels
@@ -192,7 +195,7 @@ class Task:
     @property
     def co_channels(self):
         """
-        :class:`nidaqmx._task_modules.co_channel_collection.COChannelCollection`: 
+        :class:`nidaqmx._task_modules.co_channel_collection.COChannelCollection`:
             Gets the collection of counter output channels for this task.
         """
         return self._co_channels
@@ -200,7 +203,7 @@ class Task:
     @property
     def di_channels(self):
         """
-        :class:`nidaqmx._task_modules.di_channel_collection.DIChannelCollection`: 
+        :class:`nidaqmx._task_modules.di_channel_collection.DIChannelCollection`:
             Gets the collection of digital input channels for this task.
         """
         return self._di_channels
@@ -208,7 +211,7 @@ class Task:
     @property
     def do_channels(self):
         """
-        :class:`nidaqmx._task_modules.do_channel_collection.DOChannelCollection`: 
+        :class:`nidaqmx._task_modules.do_channel_collection.DOChannelCollection`:
             Gets the collection of digital output channels for this task.
         """
         return self._do_channels
@@ -216,7 +219,7 @@ class Task:
     @property
     def export_signals(self):
         """
-        :class:`nidaqmx._task_modules.export_signals.ExportSignals`: Gets the 
+        :class:`nidaqmx._task_modules.export_signals.ExportSignals`: Gets the
             exported signal configurations for the task.
         """
         return self._export_signals
@@ -224,7 +227,7 @@ class Task:
     @property
     def in_stream(self):
         """
-        :class:`nidaqmx._task_modules.in_stream.InStream`: Gets the read 
+        :class:`nidaqmx._task_modules.in_stream.InStream`: Gets the read
             configurations for the task.
         """
         return self._in_stream
@@ -240,7 +243,7 @@ class Task:
     @property
     def timing(self):
         """
-        :class:`nidaqmx._task_modules.timing.Timing`: Gets the timing 
+        :class:`nidaqmx._task_modules.timing.Timing`: Gets the timing
             configurations for the task.
         """
         return self._timing
@@ -343,7 +346,7 @@ class Task:
                 'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
-        
+
         self._interpreter.clear_task(self._handle)
 
         self._handle = None
@@ -488,7 +491,7 @@ class Task:
                 currents = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_power_f64(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, voltages, currents)
 
                 if number_of_channels > 1:
@@ -522,7 +525,7 @@ class Task:
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.float64)
                 _, samples_read = self._interpreter.read_analog_f64(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
         # Digital Input or Digital Output
@@ -531,7 +534,7 @@ class Task:
             if self.in_stream.di_num_booleans_per_chan == 1:
                 data = numpy.zeros(array_shape, dtype=bool)
                 _, samples_read, _ = self._interpreter.read_digital_lines(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.uint32)
@@ -548,7 +551,7 @@ class Task:
                 duty_cycles = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_ctr_freq(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, frequencies, duty_cycles)
 
                 data = []
@@ -560,7 +563,7 @@ class Task:
                 low_times = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_ctr_time(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_times, low_times)
                 data = []
                 for h, l in zip(high_times, low_times):
@@ -571,7 +574,7 @@ class Task:
                 low_ticks = numpy.zeros(array_shape, dtype=numpy.uint32)
 
                 _, _ , samples_read = self._interpreter.read_ctr_ticks(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_ticks, low_ticks)
                 data = []
                 for h, l in zip(high_ticks, low_ticks):
@@ -581,14 +584,14 @@ class Task:
                 data = numpy.zeros(array_shape, dtype=numpy.uint32)
 
                 _, samples_read = self._interpreter.read_counter_u32_ex(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, samples_read = self._interpreter.read_counter_f64_ex(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
         else:
             raise DaqError(
@@ -881,7 +884,7 @@ class Task:
 
         This write method is dynamic, and is capable of accepting the
         samples to write in the various forms for most operations:
-        
+
         - Scalar: Single sample for 1 channel.
         - List/1D numpy.ndarray: Multiple samples for 1 channel or 1
           sample for multiple channels.
@@ -893,11 +896,11 @@ class Task:
 
         For counter output pulse operations, this write method only
         accepts samples in these forms:
-        
-        - Scalar CtrFreq, CtrTime, CtrTick (from nidaqmx.types): 
+
+        - Scalar CtrFreq, CtrTime, CtrTick (from nidaqmx.types):
           Single sample for 1 channel.
         - List of CtrFreq, CtrTime, CtrTick (from nidaqmx.types):
-          Multiple samples for 1 channel or 1 sample for multiple 
+          Multiple samples for 1 channel or 1 sample for multiple
           channels.
 
         If the task uses on-demand timing, this method returns only
@@ -1058,7 +1061,7 @@ class Task:
                 duty_cycles = numpy.asarray(duty_cycles, dtype=numpy.float64)
 
                 return self._interpreter.write_ctr_freq(
-                    self._handle, number_of_samples_per_channel, auto_start, timeout, 
+                    self._handle, number_of_samples_per_channel, auto_start, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, frequencies, duty_cycles)
 
             elif output_type == UsageTypeCO.PULSE_TIME:
@@ -1086,7 +1089,7 @@ class Task:
                 low_ticks = numpy.asarray(low_ticks, dtype=numpy.uint32)
 
                 return self._interpreter.write_ctr_ticks(
-                    self._handle, number_of_samples_per_channel, auto_start, timeout, 
+                    self._handle, number_of_samples_per_channel, auto_start, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_ticks, low_ticks)
         else:
             raise DaqError(
@@ -1112,7 +1115,7 @@ class _TaskAlternateConstructor(Task):
                 Task object.
             interpreter: Specifies the interpreter instance.
             close_on_exit: Specifies whether the task's context manager closes the task.
-            
+
         """
         self._handle = task_handle
         self._interpreter = interpreter

--- a/src/codegen/templates/scale.py.mako
+++ b/src/codegen/templates/scale.py.mako
@@ -25,7 +25,8 @@ class Scale:
         """
         Args:
             name (str): Specifies the name of the scale to create.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -91,14 +92,14 @@ ${property_template.script_property(attribute)}\
                 3 indicates a 3rd order polynomial. A value of -1
                 indicates a reverse polynomial of the same order as the
                 forward polynomial.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            List[float]: 
-            
-            Specifies the list of coefficients for the reverse 
-            polynomial. Each element of the list corresponds to a term 
-            of the equation. For example, if index three of the list is 
+            List[float]:
+
+            Specifies the list of coefficients for the reverse
+            polynomial. Each element of the list corresponds to a term
+            of the equation. For example, if index three of the list is
             9, the fourth term of the equation is 9y^3.
         """
         forward_coeffs = numpy.float64(forward_coeffs)
@@ -130,11 +131,11 @@ ${property_template.script_property(attribute)}\
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
             nidaqmx.scale.Scale:
-            
+
             Indicates an object that represents the created custom scale.
         """
         scale = Scale(scale_name, grpc_options=grpc_options)
@@ -175,17 +176,17 @@ ${property_template.script_property(attribute)}\
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         scale = Scale(scale_name, grpc_options=grpc_options)
 
         scale._interpreter.create_map_scale(
-            scale_name, prescaled_min, prescaled_max, scaled_min, scaled_max, 
+            scale_name, prescaled_min, prescaled_max, scaled_min, scaled_max,
             pre_scaled_units.value, scaled_units)
 
         return scale
@@ -217,11 +218,11 @@ ${property_template.script_property(attribute)}\
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         if forward_coeffs is None:
@@ -264,11 +265,11 @@ ${property_template.script_property(attribute)}\
             scaled_units (Optional[str]): Is the units to use for the
                 scaled value. You can use an arbitrary string. NI-DAQmx
                 uses the units to label a graph or chart.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.scale.Scale: 
-            
+            nidaqmx.scale.Scale:
+
             Indicates an object that represents the created custom scale.
         """
         if prescaled_vals is None:
@@ -279,7 +280,7 @@ ${property_template.script_property(attribute)}\
 
         prescaled_vals = numpy.float64(prescaled_vals)
         scaled_vals = numpy.float64(scaled_vals)
-        
+
         scale = Scale(scale_name, grpc_options=grpc_options)
 
         scale._interpreter.create_table_scale(
@@ -342,7 +343,7 @@ class _ScaleAlternateConstructor(Scale):
         Args:
             name: Specifies the name of the Scale.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/codegen/templates/system/device.py.mako
+++ b/src/codegen/templates/system/device.py.mako
@@ -36,7 +36,8 @@ class Device:
         """
         Args:
             name (str): Specifies the name of the device.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -173,16 +174,16 @@ ${function_template.script_function(function_object)}
                 False.
             timeout (Optional[float]): Specifies the time in seconds to
                 wait for the device to respond before timing out.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the 
-                gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         Returns:
-            nidaqmx.system.device.Device: 
-            
+            nidaqmx.system.device.Device:
+
             Specifies the object that represents the device this
             operation applied to.
         """
         device = Device("", grpc_options=grpc_options)
-        
+
         device._name = device._interpreter.add_network_device(
             ip_address, device_name, attempt_reservation, timeout)
 
@@ -236,7 +237,7 @@ class _DeviceAlternateConstructor(Device):
         Args:
             name: Specifies the name of the Device.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/codegen/templates/system/physical_channel.py.mako
+++ b/src/codegen/templates/system/physical_channel.py.mako
@@ -35,7 +35,8 @@ class PhysicalChannel:
         """
         Args:
             name (str): Specifies the name of the physical channel.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -76,7 +77,7 @@ class _PhysicalChannelAlternateConstructor(PhysicalChannel):
     """
     Provide an alternate constructor for the PhysicalChannel object.
 
-    This is a private API used to instantiate a PhysicalChannel with an existing interpreter.     
+    This is a private API used to instantiate a PhysicalChannel with an existing interpreter.
     """
     # Setting __slots__ avoids TypeError: __class__ assignment: 'Base' object layout differs from 'Derived'.
     __slots__ = []
@@ -86,7 +87,7 @@ class _PhysicalChannelAlternateConstructor(PhysicalChannel):
         Args:
             name: Specifies the name of the Physical Channel.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -43,7 +43,8 @@ class System:
     def __init__(self, grpc_options=None):
         """
         Args:
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._interpreter = utils._select_interpreter(grpc_options)
 
@@ -60,7 +61,8 @@ class System:
         nidaqmx.system.system.System: Represents the remote DAQmx system.
 
         Args:
-            grpc_options: Specifies the gRPC session options.
+            grpc_options (:class:`~nidaqmx.GrpcSessionOptions`): Specifies
+                the gRPC session options.
         """
         return System(grpc_options)
 
@@ -274,7 +276,7 @@ ${function_template.script_function(function_object)}
 
         for do_line in device.do_lines:
             channel_names.append(do_line.name)
-        
+
         states =  self._interpreter.get_digital_pull_up_pull_down_states(device_name, channel_names)
 
         power_up_states = []
@@ -374,7 +376,7 @@ ${function_template.script_function(function_object)}
         channel_types = []
 
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
-        
+
         for ao_physical_chan in device.ao_physical_chans:
             channel_type = ctypes.c_int()
             channel_types.append(channel_type)

--- a/src/codegen/templates/system/watchdog.py.mako
+++ b/src/codegen/templates/system/watchdog.py.mako
@@ -51,7 +51,8 @@ class WatchdogTask:
                 Trigger to expire the watchdog task. If this time elapses, the
                 device sets the physical channels to the states you specify
                 with the digital physical channel expiration states input.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None

--- a/src/handwritten/system/storage/persisted_channel.py
+++ b/src/handwritten/system/storage/persisted_channel.py
@@ -17,7 +17,8 @@ class PersistedChannel:
         """
         Args:
             name (str): Specifies the name of the global channel.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -86,7 +87,7 @@ class _PersistedChannelAlternateConstructor(PersistedChannel):
         Args:
             name: Specifies the name of the PersistedChannel.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/handwritten/system/storage/persisted_scale.py
+++ b/src/handwritten/system/storage/persisted_scale.py
@@ -18,7 +18,8 @@ class PersistedScale:
         """
         Args:
             name (str): Specifies the name of the saved scale.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -96,7 +97,7 @@ class _PersistedScaleAlternateConstructor(PersistedScale):
         Args:
             name: Specifies the name of the PersistedScale.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/handwritten/system/storage/persisted_task.py
+++ b/src/handwritten/system/storage/persisted_task.py
@@ -18,7 +18,8 @@ class PersistedTask:
         """
         Args:
             name (str): Specifies the name of the saved task.
-            grpc_options (Optional[GrpcSessionOptions]): Specifies the gRPC session options.
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         self._name = name
         self._interpreter = utils._select_interpreter(grpc_options)
@@ -84,7 +85,7 @@ class PersistedTask:
         task_handle, close_on_exit = self._interpreter.load_task(self._name)
 
         return task._TaskAlternateConstructor(task_handle, self._interpreter, close_on_exit)
-    
+
 
 class _PersistedTaskAlternateConstructor(PersistedTask):
     """
@@ -100,7 +101,7 @@ class _PersistedTaskAlternateConstructor(PersistedTask):
         Args:
             name: Specifies the name of the PersistedTask.
             interpreter: Specifies the interpreter instance.
-            
+
         """
         self._name = name
         self._interpreter = interpreter

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -66,6 +66,9 @@ class Task:
                 after you are finished with the task. Otherwise, NI-DAQmx
                 attempts to create multiple tasks with the same name, which
                 results in an error.
+
+            grpc_options (Optional[:class:`~nidaqmx.GrpcSessionOptions`]): Specifies
+                the gRPC session options.
         """
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None
@@ -79,7 +82,7 @@ class Task:
                 f'Unsupported session name: "{grpc_options.session_name}". If a session name is specified, it must match the task name.',
                 DAQmxErrors.UNKNOWN,
                 task_name=new_task_name)
-        
+
         self._interpreter = utils._select_interpreter(grpc_options)
         self._handle, self._close_on_exit = self._interpreter.create_task(new_task_name)
 
@@ -124,8 +127,8 @@ class Task:
     @property
     def channels(self):
         """
-        :class:`nidaqmx._task_modules.channels.channel.Channel`: Specifies 
-            a channel object that represents the entire list of virtual 
+        :class:`nidaqmx._task_modules.channels.channel.Channel`: Specifies
+            a channel object that represents the entire list of virtual
             channels in this task.
         """
         return Channel._factory(
@@ -150,7 +153,7 @@ class Task:
     @property
     def devices(self):
         """
-        List[:class:`nidaqmx.system.device.Device`]: Indicates a list 
+        List[:class:`nidaqmx.system.device.Device`]: Indicates a list
             of Device objects representing all the devices in the task.
         """
         val = self._interpreter.get_task_attribute_string(self._handle, 0x230e)
@@ -176,7 +179,7 @@ class Task:
     @property
     def ao_channels(self):
         """
-        :class:`nidaqmx._task_modules.ao_channel_collection.AOChannelCollection`: 
+        :class:`nidaqmx._task_modules.ao_channel_collection.AOChannelCollection`:
             Gets the collection of analog output channels for this task.
         """
         return self._ao_channels
@@ -184,7 +187,7 @@ class Task:
     @property
     def ci_channels(self):
         """
-        :class:`nidaqmx._task_modules.ci_channel_collection.CIChannelCollection`: 
+        :class:`nidaqmx._task_modules.ci_channel_collection.CIChannelCollection`:
             Gets the collection of counter input channels for this task.
         """
         return self._ci_channels
@@ -192,7 +195,7 @@ class Task:
     @property
     def co_channels(self):
         """
-        :class:`nidaqmx._task_modules.co_channel_collection.COChannelCollection`: 
+        :class:`nidaqmx._task_modules.co_channel_collection.COChannelCollection`:
             Gets the collection of counter output channels for this task.
         """
         return self._co_channels
@@ -200,7 +203,7 @@ class Task:
     @property
     def di_channels(self):
         """
-        :class:`nidaqmx._task_modules.di_channel_collection.DIChannelCollection`: 
+        :class:`nidaqmx._task_modules.di_channel_collection.DIChannelCollection`:
             Gets the collection of digital input channels for this task.
         """
         return self._di_channels
@@ -208,7 +211,7 @@ class Task:
     @property
     def do_channels(self):
         """
-        :class:`nidaqmx._task_modules.do_channel_collection.DOChannelCollection`: 
+        :class:`nidaqmx._task_modules.do_channel_collection.DOChannelCollection`:
             Gets the collection of digital output channels for this task.
         """
         return self._do_channels
@@ -216,7 +219,7 @@ class Task:
     @property
     def export_signals(self):
         """
-        :class:`nidaqmx._task_modules.export_signals.ExportSignals`: Gets the 
+        :class:`nidaqmx._task_modules.export_signals.ExportSignals`: Gets the
             exported signal configurations for the task.
         """
         return self._export_signals
@@ -224,7 +227,7 @@ class Task:
     @property
     def in_stream(self):
         """
-        :class:`nidaqmx._task_modules.in_stream.InStream`: Gets the read 
+        :class:`nidaqmx._task_modules.in_stream.InStream`: Gets the read
             configurations for the task.
         """
         return self._in_stream
@@ -240,7 +243,7 @@ class Task:
     @property
     def timing(self):
         """
-        :class:`nidaqmx._task_modules.timing.Timing`: Gets the timing 
+        :class:`nidaqmx._task_modules.timing.Timing`: Gets the timing
             configurations for the task.
         """
         return self._timing
@@ -343,7 +346,7 @@ class Task:
                 'Attempted to close NI-DAQmx task of name "{}" but task was '
                 'already closed.'.format(self._saved_name), DaqResourceWarning)
             return
-        
+
         self._interpreter.clear_task(self._handle)
 
         self._handle = None
@@ -488,7 +491,7 @@ class Task:
                 currents = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_power_f64(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, voltages, currents)
 
                 if number_of_channels > 1:
@@ -522,7 +525,7 @@ class Task:
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.float64)
                 _, samples_read = self._interpreter.read_analog_f64(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
         # Digital Input or Digital Output
@@ -531,7 +534,7 @@ class Task:
             if self.in_stream.di_num_booleans_per_chan == 1:
                 data = numpy.zeros(array_shape, dtype=bool)
                 _, samples_read, _ = self._interpreter.read_digital_lines(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.uint32)
@@ -548,7 +551,7 @@ class Task:
                 duty_cycles = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_ctr_freq(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, frequencies, duty_cycles)
 
                 data = []
@@ -560,7 +563,7 @@ class Task:
                 low_times = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, _, samples_read = self._interpreter.read_ctr_time(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_times, low_times)
                 data = []
                 for h, l in zip(high_times, low_times):
@@ -571,7 +574,7 @@ class Task:
                 low_ticks = numpy.zeros(array_shape, dtype=numpy.uint32)
 
                 _, _ , samples_read = self._interpreter.read_ctr_ticks(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_ticks, low_ticks)
                 data = []
                 for h, l in zip(high_ticks, low_ticks):
@@ -581,14 +584,14 @@ class Task:
                 data = numpy.zeros(array_shape, dtype=numpy.uint32)
 
                 _, samples_read = self._interpreter.read_counter_u32_ex(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
             else:
                 data = numpy.zeros(array_shape, dtype=numpy.float64)
 
                 _, samples_read = self._interpreter.read_counter_f64_ex(
-                    self._handle, number_of_samples_per_channel, timeout, 
+                    self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
         else:
             raise DaqError(
@@ -881,7 +884,7 @@ class Task:
 
         This write method is dynamic, and is capable of accepting the
         samples to write in the various forms for most operations:
-        
+
         - Scalar: Single sample for 1 channel.
         - List/1D numpy.ndarray: Multiple samples for 1 channel or 1
           sample for multiple channels.
@@ -893,11 +896,11 @@ class Task:
 
         For counter output pulse operations, this write method only
         accepts samples in these forms:
-        
-        - Scalar CtrFreq, CtrTime, CtrTick (from nidaqmx.types): 
+
+        - Scalar CtrFreq, CtrTime, CtrTick (from nidaqmx.types):
           Single sample for 1 channel.
         - List of CtrFreq, CtrTime, CtrTick (from nidaqmx.types):
-          Multiple samples for 1 channel or 1 sample for multiple 
+          Multiple samples for 1 channel or 1 sample for multiple
           channels.
 
         If the task uses on-demand timing, this method returns only
@@ -1058,7 +1061,7 @@ class Task:
                 duty_cycles = numpy.asarray(duty_cycles, dtype=numpy.float64)
 
                 return self._interpreter.write_ctr_freq(
-                    self._handle, number_of_samples_per_channel, auto_start, timeout, 
+                    self._handle, number_of_samples_per_channel, auto_start, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, frequencies, duty_cycles)
 
             elif output_type == UsageTypeCO.PULSE_TIME:
@@ -1086,7 +1089,7 @@ class Task:
                 low_ticks = numpy.asarray(low_ticks, dtype=numpy.uint32)
 
                 return self._interpreter.write_ctr_ticks(
-                    self._handle, number_of_samples_per_channel, auto_start, timeout, 
+                    self._handle, number_of_samples_per_channel, auto_start, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, high_ticks, low_ticks)
         else:
             raise DaqError(
@@ -1112,7 +1115,7 @@ class _TaskAlternateConstructor(Task):
                 Task object.
             interpreter: Specifies the interpreter instance.
             close_on_exit: Specifies whether the task's context manager closes the task.
-            
+
         """
         self._handle = task_handle
         self._interpreter = interpreter


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Document the `nidaqmx.SessionInitializationBehavior` and `nidaqmx.GrpcSessionOptions` classes, using https://github.com/ni/nimi-python/blob/master/docs/nidcpower/grpc_session_options.rst as a starting point.
- Use the `:canonical:` directive to tell Sphinx where these classes are imported from.
- Make `docs/index.rst` the hyperlink target for the `nidaqmx` module.

Update the constructor documentation for the `grpc_options` parameter:
- Add `grpc_options` documentation to `nidaqmx.task.Task`
- Update `grpc_options` documentation to hyperlink to `GrpcSessionOptions`

Delete some trailing whitespace.

### Why should this Pull Request be merged?

`GrpcSessionOptions` wasn't fully documented.

### What testing has been done?

Ran `poetry run tox -e docs` and viewed output.