### PR TITLE
Test Failures | Validate numpy.dtype for read/write arrays in grpc interpreter

### DIFF
--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -10,7 +10,6 @@ from nidaqmx._base_interpreter import BaseInterpreter
 from nidaqmx._stubs import nidaqmx_pb2 as grpc_types
 from nidaqmx._stubs import nidaqmx_pb2_grpc as nidaqmx_grpc
 from nidaqmx._stubs import session_pb2 as session_grpc_types
-from nidaqmx.error_codes import DAQmxErrors
 
 
 
@@ -3440,6 +3439,6 @@ def _assign_numpy_array(numpy_array, grpc_array):
         numpy_array.flat[:grpc_array_size] = grpc_array
 
 def _validate_array_dtype(numpy_array, expected_numpy_array_dtype):
-    """Raises Typerror if array type doesn't match with expected numpy.dtype"""
+    """Raises TypeError if array type doesn't match with expected numpy.dtype"""
     if expected_numpy_array_dtype != numpy.generic and numpy_array.dtype != expected_numpy_array_dtype:
-        raise errors.DaqError(f"TypeError: array must have data type {expected_numpy_array_dtype}", DAQmxErrors.UNKNOWN)
+        raise TypeError(f"array must have data type {expected_numpy_array_dtype}")

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -10,6 +10,7 @@ from nidaqmx._base_interpreter import BaseInterpreter
 from nidaqmx._stubs import nidaqmx_pb2 as grpc_types
 from nidaqmx._stubs import nidaqmx_pb2_grpc as nidaqmx_grpc
 from nidaqmx._stubs import session_pb2 as session_grpc_types
+from nidaqmx.error_codes import DAQmxErrors
 
 
 
@@ -2319,6 +2320,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_analog_f64(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.float64)
         response = self._invoke(
             self._client.ReadAnalogF64,
             grpc_types.ReadAnalogF64Request(
@@ -2336,6 +2338,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_binary_i16(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.int16)
         response = self._invoke(
             self._client.ReadBinaryI16,
             grpc_types.ReadBinaryI16Request(
@@ -2347,6 +2350,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_binary_i32(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.int32)
         response = self._invoke(
             self._client.ReadBinaryI32,
             grpc_types.ReadBinaryI32Request(
@@ -2358,6 +2362,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_binary_u16(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint16)
         response = self._invoke(
             self._client.ReadBinaryU16,
             grpc_types.ReadBinaryU16Request(
@@ -2369,6 +2374,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_binary_u32(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint32)
         response = self._invoke(
             self._client.ReadBinaryU32,
             grpc_types.ReadBinaryU32Request(
@@ -2379,6 +2385,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         return read_array, response.samps_per_chan_read
 
     def read_counter_f64(self, task, num_samps_per_chan, timeout, read_array):
+        _validate_array_dtype(read_array, numpy.float64)
         response = self._invoke(
             self._client.ReadCounterF64,
             grpc_types.ReadCounterF64Request(
@@ -2389,6 +2396,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_counter_f64_ex(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.float64)
         response = self._invoke(
             self._client.ReadCounterF64Ex,
             grpc_types.ReadCounterF64ExRequest(
@@ -2411,6 +2419,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         return response.value
 
     def read_counter_u32(self, task, num_samps_per_chan, timeout, read_array):
+        _validate_array_dtype(read_array, numpy.uint32)
         response = self._invoke(
             self._client.ReadCounterU32,
             grpc_types.ReadCounterU32Request(
@@ -2421,6 +2430,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_counter_u32_ex(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint32)
         response = self._invoke(
             self._client.ReadCounterU32Ex,
             grpc_types.ReadCounterU32ExRequest(
@@ -2433,6 +2443,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def read_ctr_freq(
             self, task, num_samps_per_chan, timeout, interleaved,
             read_array_frequency, read_array_duty_cycle):
+        _validate_array_dtype(read_array_frequency, numpy.float64)
+        _validate_array_dtype(read_array_duty_cycle, numpy.float64)
         response = self._invoke(
             self._client.ReadCtrFreq,
             grpc_types.ReadCtrFreqRequest(
@@ -2452,6 +2464,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def read_ctr_ticks(
             self, task, num_samps_per_chan, timeout, interleaved,
             read_array_high_ticks, read_array_low_ticks):
+        _validate_array_dtype(read_array_high_ticks, numpy.uint32)
+        _validate_array_dtype(read_array_low_ticks, numpy.uint32)
         response = self._invoke(
             self._client.ReadCtrTicks,
             grpc_types.ReadCtrTicksRequest(
@@ -2471,6 +2485,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def read_ctr_time(
             self, task, num_samps_per_chan, timeout, interleaved,
             read_array_high_time, read_array_low_time):
+        _validate_array_dtype(read_array_high_time, numpy.float64)
+        _validate_array_dtype(read_array_low_time, numpy.float64)
         response = self._invoke(
             self._client.ReadCtrTime,
             grpc_types.ReadCtrTimeRequest(
@@ -2489,6 +2505,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_digital_lines(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, bool)
         response = self._invoke(
             self._client.ReadDigitalLines,
             grpc_types.ReadDigitalLinesRequest(
@@ -2506,6 +2523,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_digital_u16(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint16)
         response = self._invoke(
             self._client.ReadDigitalU16,
             grpc_types.ReadDigitalU16Request(
@@ -2517,6 +2535,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_digital_u32(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint32)
         response = self._invoke(
             self._client.ReadDigitalU32,
             grpc_types.ReadDigitalU32Request(
@@ -2528,6 +2547,7 @@ class GrpcStubInterpreter(BaseInterpreter):
 
     def read_digital_u8(
             self, task, num_samps_per_chan, timeout, fill_mode, read_array):
+        _validate_array_dtype(read_array, numpy.uint8)
         response = self._invoke(
             self._client.ReadDigitalU8,
             grpc_types.ReadDigitalU8Request(
@@ -2540,6 +2560,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def read_power_binary_i16(
             self, task, num_samps_per_chan, timeout, fill_mode,
             read_array_voltage, read_array_current):
+        _validate_array_dtype(read_array_voltage, numpy.int16)
+        _validate_array_dtype(read_array_current, numpy.int16)
         response = self._invoke(
             self._client.ReadPowerBinaryI16,
             grpc_types.ReadPowerBinaryI16Request(
@@ -2553,6 +2575,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def read_power_f64(
             self, task, num_samps_per_chan, timeout, fill_mode,
             read_array_voltage, read_array_current):
+        _validate_array_dtype(read_array_voltage, numpy.float64)
+        _validate_array_dtype(read_array_current, numpy.float64)
         response = self._invoke(
             self._client.ReadPowerF64,
             grpc_types.ReadPowerF64Request(
@@ -2570,6 +2594,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         return response.voltage, response.current
 
     def read_raw(self, task, num_samps_per_chan, timeout, read_array):
+        _validate_array_dtype(read_array, numpy.generic)
         response = self._invoke(
             self._client.ReadRaw,
             grpc_types.ReadRawRequest(
@@ -3190,6 +3215,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_analog_f64(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.float64)
         response = self._invoke(
             self._client.WriteAnalogF64,
             grpc_types.WriteAnalogF64Request(
@@ -3208,6 +3234,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_binary_i16(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.int16)
         response = self._invoke(
             self._client.WriteBinaryI16,
             grpc_types.WriteBinaryI16Request(
@@ -3219,6 +3246,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_binary_i32(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.int32)
         response = self._invoke(
             self._client.WriteBinaryI32,
             grpc_types.WriteBinaryI32Request(
@@ -3230,6 +3258,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_binary_u16(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.uint16)
         response = self._invoke(
             self._client.WriteBinaryU16,
             grpc_types.WriteBinaryU16Request(
@@ -3241,6 +3270,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_binary_u32(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.uint32)
         response = self._invoke(
             self._client.WriteBinaryU32,
             grpc_types.WriteBinaryU32Request(
@@ -3252,6 +3282,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_ctr_freq(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             frequency, duty_cycle):
+        _validate_array_dtype(frequency, numpy.float64)
+        _validate_array_dtype(duty_cycle, numpy.float64)
         response = self._invoke(
             self._client.WriteCtrFreq,
             grpc_types.WriteCtrFreqRequest(
@@ -3272,6 +3304,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_ctr_ticks(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             high_ticks, low_ticks):
+        _validate_array_dtype(high_ticks, numpy.uint32)
+        _validate_array_dtype(low_ticks, numpy.uint32)
         response = self._invoke(
             self._client.WriteCtrTicks,
             grpc_types.WriteCtrTicksRequest(
@@ -3292,6 +3326,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_ctr_time(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             high_time, low_time):
+        _validate_array_dtype(high_time, numpy.float64)
+        _validate_array_dtype(low_time, numpy.float64)
         response = self._invoke(
             self._client.WriteCtrTime,
             grpc_types.WriteCtrTimeRequest(
@@ -3312,6 +3348,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_digital_lines(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, bool)
         response = self._invoke(
             self._client.WriteDigitalLines,
             grpc_types.WriteDigitalLinesRequest(
@@ -3330,6 +3367,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_digital_u16(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.uint16)
         response = self._invoke(
             self._client.WriteDigitalU16,
             grpc_types.WriteDigitalU16Request(
@@ -3341,6 +3379,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_digital_u32(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.uint32)
         response = self._invoke(
             self._client.WriteDigitalU32,
             grpc_types.WriteDigitalU32Request(
@@ -3352,6 +3391,7 @@ class GrpcStubInterpreter(BaseInterpreter):
     def write_digital_u8(
             self, task, num_samps_per_chan, auto_start, timeout, data_layout,
             write_array):
+        _validate_array_dtype(write_array, numpy.uint8)
         response = self._invoke(
             self._client.WriteDigitalU8,
             grpc_types.WriteDigitalU8Request(
@@ -3361,6 +3401,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         return response.samps_per_chan_written
 
     def write_raw(self, task, num_samps, auto_start, timeout, write_array):
+        _validate_array_dtype(write_array, numpy.generic)
         response = self._invoke(
             self._client.WriteRaw,
             grpc_types.WriteRawRequest(
@@ -3397,3 +3438,8 @@ def _assign_numpy_array(numpy_array, grpc_array):
         numpy_array.flat[:grpc_array_size] = numpy.frombuffer(grpc_array, dtype=numpy.uint8)
     else:
         numpy_array.flat[:grpc_array_size] = grpc_array
+
+def _validate_array_dtype(numpy_array, expected_numpy_array_dtype):
+    """Raises Typerror if array type doesn't match with expected numpy.dtype"""
+    if expected_numpy_array_dtype != numpy.generic and numpy_array.dtype != expected_numpy_array_dtype:
+        raise errors.DaqError(f"TypeError: array must have data type {expected_numpy_array_dtype}", DAQmxErrors.UNKNOWN)

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -17,7 +17,6 @@ from nidaqmx._base_interpreter import BaseInterpreter
 from nidaqmx._stubs import nidaqmx_pb2 as grpc_types
 from nidaqmx._stubs import nidaqmx_pb2_grpc as nidaqmx_grpc
 from nidaqmx._stubs import session_pb2 as session_grpc_types
-from nidaqmx.error_codes import DAQmxErrors
 
 
 
@@ -167,6 +166,6 @@ def _assign_numpy_array(numpy_array, grpc_array):
         numpy_array.flat[:grpc_array_size] = grpc_array
 
 def _validate_array_dtype(numpy_array, expected_numpy_array_dtype):
-    """Raises Typerror if array type doesn't match with expected numpy.dtype"""
+    """Raises TypeError if array type doesn't match with expected numpy.dtype"""
     if expected_numpy_array_dtype != numpy.generic and numpy_array.dtype != expected_numpy_array_dtype:
-        raise errors.DaqError(f"TypeError: array must have data type {expected_numpy_array_dtype}", DAQmxErrors.UNKNOWN)
+        raise TypeError(f"array must have data type {expected_numpy_array_dtype}")

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -1,5 +1,5 @@
 <%
-    from codegen.utilities.interpreter_helpers import get_interpreter_functions, get_grpc_interpreter_call_params, get_params_for_function_signature, get_interpreter_parameter_signature, get_output_params, get_response_parameters, get_compound_parameter, create_compound_parameter_request, get_input_arguments_for_compound_params, check_if_parameters_contain_read_array, get_read_array_parameters
+    from codegen.utilities.interpreter_helpers import get_interpreter_functions, get_grpc_interpreter_call_params, get_params_for_function_signature, get_interpreter_parameter_signature, get_output_params, get_response_parameters, get_compound_parameter, create_compound_parameter_request, get_input_arguments_for_compound_params, check_if_parameters_contain_read_array, get_read_array_parameters, get_numpy_array_params, is_custom_read_write_function
     from codegen.utilities.function_helpers import order_function_parameters_by_optional
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
     from codegen.utilities.helpers import snake_to_pascal
@@ -17,6 +17,7 @@ from nidaqmx._base_interpreter import BaseInterpreter
 from nidaqmx._stubs import nidaqmx_pb2 as grpc_types
 from nidaqmx._stubs import nidaqmx_pb2_grpc as nidaqmx_grpc
 from nidaqmx._stubs import session_pb2 as session_grpc_types
+from nidaqmx.error_codes import DAQmxErrors
 
 
 
@@ -118,6 +119,11 @@ class GrpcStubInterpreter(BaseInterpreter):
             ('ni-api-key', self._grpc_options.api_key),
         )
     %endif
+    %if is_custom_read_write_function(func):
+    %for parameter_name, parameter_dtype in get_numpy_array_params(func).items():
+        _validate_array_dtype(${parameter_name}, ${parameter_dtype})
+    %endfor
+    %endif
         response = self._invoke(
             self._client.${snake_to_pascal(func.function_name)},
         %if (len(func.function_name) + len(grpc_interpreter_params)) > 68:
@@ -159,3 +165,8 @@ def _assign_numpy_array(numpy_array, grpc_array):
         numpy_array.flat[:grpc_array_size] = numpy.frombuffer(grpc_array, dtype=numpy.uint8)
     else:
         numpy_array.flat[:grpc_array_size] = grpc_array
+
+def _validate_array_dtype(numpy_array, expected_numpy_array_dtype):
+    """Raises Typerror if array type doesn't match with expected numpy.dtype"""
+    if expected_numpy_array_dtype != numpy.generic and numpy_array.dtype != expected_numpy_array_dtype:
+        raise errors.DaqError(f"TypeError: array must have data type {expected_numpy_array_dtype}", DAQmxErrors.UNKNOWN)

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -514,7 +514,7 @@ def type_cast_attribute_set_function_parameter(param):
 
 def is_numpy_array_datatype(param):
     """Checks if datatype is a numpy array or not."""
-    if param.ctypes_data_type.startswith("numpy."):
+    if param.ctypes_data_type and param.ctypes_data_type.startswith("numpy."):
         return True
     return False
 
@@ -529,3 +529,23 @@ def is_write_bytes_param(param):
         return True
     else:
         return False
+
+    
+def get_numpy_array_params(func):
+    """Returns a dictionary of numpy data type parameters."""
+    numpy_params = {}
+    for param in func.base_parameters:
+        if is_numpy_array_datatype(param):
+            if param.ctypes_data_type == "numpy.bool":
+                numpy_params[param.parameter_name] = "bool"
+            else:
+                numpy_params[param.parameter_name] = param.ctypes_data_type
+
+        # This is a special case for these functions.
+        # since its metadata is incorrect in daqmxAPISharp.json file.
+        if func.function_name == "read_power_f64" and "read_array" in param.parameter_name:
+            numpy_params[param.parameter_name] = "numpy.float64"
+        if func.function_name == "read_power_binary_i16" and "read_array" in param.parameter_name:
+            numpy_params[param.parameter_name] = "numpy.int16"
+
+    return numpy_params


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR allows grpc_interpreter to validate `dtype` of a numpy array. 
Following the [Bug 2390189](https://dev.azure.com/ni/DevCentral/_workitems/edit/2390189): GrpcStubInterpreter reads/writes invalid data when NumPy array has wrong dtype context here, 
Unlike library interpreter, grpc interpreter doesn't raise error when wrong dtype is passed to the numpy array. Thus

- Created a custom method `_validate_array_dtype` in `_grpc_interpreter.py.mako` to validate expected and actual `dtype` of a `numpy` array of read/write functions.
- Create a custom `Error` to be raised when actual dtype doesn't match with expected dtype.
- Added helpers method `get_numpy_array_params` in `interpreter_helpers.py` to get `read/write` array parameters.
- Since `numpy.generic` can take in any numpy dtype, so excluded it from validation.

### Why should this Pull Request be merged?
This PR fixes the [Bug 2390189](https://dev.azure.com/ni/DevCentral/_workitems/edit/2390189): GrpcStubInterpreter reads/writes invalid data when NumPy array has wrong dtype

### What testing has been done?
- Ran `poetry run pytest` -> Existing test results maintained
- Passed in incorrect dtypes to the code snippet in the first comment given below and observed the Custom Error been raised by the grpc interpreter.