### PR TITLE
Test Failures | TypeError: Value must be iterable fix

### DIFF
--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3345,7 +3345,8 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteDigitalLinesRequest(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=bytes(write_array)))
+                data_layout_raw=data_layout,
+                write_array=write_array.tobytes()))
         return response.samps_per_chan_written
 
     def write_digital_scalar_u32(self, task, auto_start, timeout, value):
@@ -3388,7 +3389,8 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteDigitalU8Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=bytes(write_array)))
+                data_layout_raw=data_layout,
+                write_array=write_array.tobytes()))
         return response.samps_per_chan_written
 
     def write_raw(self, task, num_samps, auto_start, timeout, write_array):
@@ -3397,7 +3399,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             self._client.WriteRaw,
             grpc_types.WriteRawRequest(
                 task=task, num_samps=num_samps, auto_start=auto_start,
-                timeout=timeout, write_array=bytes(write_array)))
+                timeout=timeout, write_array=write_array.tobytes()))
         return response.samps_per_chan_written
 
     def write_to_teds_from_array(

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3212,7 +3212,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteAnalogF64Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_analog_scalar_f64(self, task, auto_start, timeout, value):
@@ -3231,7 +3231,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteBinaryI16Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_binary_i32(
@@ -3243,7 +3243,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteBinaryI32Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_binary_u16(
@@ -3255,7 +3255,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteBinaryU16Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_binary_u32(
@@ -3267,7 +3267,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteBinaryU32Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_ctr_freq(
@@ -3280,8 +3280,8 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteCtrFreqRequest(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, frequency=frequency,
-                duty_cycle=duty_cycle))
+                data_layout_raw=data_layout, frequency=frequency.flat,
+                duty_cycle=duty_cycle.flat))
         return response.num_samps_per_chan_written
 
     def write_ctr_freq_scalar(
@@ -3302,8 +3302,8 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteCtrTicksRequest(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, high_ticks=high_ticks,
-                low_ticks=low_ticks))
+                data_layout_raw=data_layout, high_ticks=high_ticks.flat,
+                low_ticks=low_ticks.flat))
         return response.num_samps_per_chan_written
 
     def write_ctr_ticks_scalar(
@@ -3324,8 +3324,8 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteCtrTimeRequest(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, high_time=high_time,
-                low_time=low_time))
+                data_layout_raw=data_layout, high_time=high_time.flat,
+                low_time=low_time.flat))
         return response.num_samps_per_chan_written
 
     def write_ctr_time_scalar(
@@ -3364,7 +3364,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteDigitalU16Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_digital_u32(
@@ -3376,7 +3376,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WriteDigitalU32Request(
                 task=task, num_samps_per_chan=num_samps_per_chan,
                 auto_start=auto_start, timeout=timeout,
-                data_layout_raw=data_layout, write_array=write_array))
+                data_layout_raw=data_layout, write_array=write_array.flat))
         return response.samps_per_chan_written
 
     def write_digital_u8(

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -477,7 +477,6 @@ class Task:
         else:
             array_shape = number_of_samples_per_channel
 
-        # Analog Input
         if read_chan_type == ChannelType.ANALOG_INPUT:
             has_power_chan = False
             for chan in channels_to_read:
@@ -528,7 +527,6 @@ class Task:
                     self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Digital Input or Digital Output
         elif (read_chan_type == ChannelType.DIGITAL_INPUT or
                 read_chan_type == ChannelType.DIGITAL_OUTPUT):
             if self.in_stream.di_num_booleans_per_chan == 1:
@@ -542,7 +540,6 @@ class Task:
                     self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Counter Input
         elif read_chan_type == ChannelType.COUNTER_INPUT:
             meas_type = channels_to_read.ci_meas_type
 
@@ -1005,14 +1002,12 @@ class Task:
             else:
                 auto_start = True
 
-        # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
                 timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Digital Input
         elif write_chan_type == ChannelType.DIGITAL_OUTPUT:
             if self.out_stream.do_num_booleans_per_chan == 1:
                 if (not isinstance(element, bool) and
@@ -1043,7 +1038,6 @@ class Task:
                     self._handle, number_of_samples_per_channel,
                     auto_start, timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Counter Input
         elif write_chan_type == ChannelType.COUNTER_OUTPUT:
             output_type = channels_to_write.co_output_type
 

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -1007,8 +1007,6 @@ class Task:
 
         # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
-            if number_of_samples_per_channel == 1  and number_of_channels == 1:
-                data = [data]
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
@@ -1039,9 +1037,6 @@ class Task:
                         'multiple digital lines per channel in a task.\n\n'
                         'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
-                
-                if number_of_samples_per_channel == 1  and number_of_channels == 1:
-                    data = [data]
 
                 data = numpy.asarray(data, dtype=numpy.uint32)
                 return self._interpreter.write_digital_u32(

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -1007,6 +1007,8 @@ class Task:
 
         # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
+            if number_of_samples_per_channel == 1  and number_of_channels == 1:
+                data = [data]
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
@@ -1037,6 +1039,9 @@ class Task:
                         'multiple digital lines per channel in a task.\n\n'
                         'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
+                
+                if number_of_samples_per_channel == 1  and number_of_channels == 1:
+                    data = [data]
 
                 data = numpy.asarray(data, dtype=numpy.uint32)
                 return self._interpreter.write_digital_u32(

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -562,7 +562,7 @@ def get_numpy_array_params(func):
 
 
 def get_write_array_param(param):
-    """Assigns the write array to a flat of write_array."""
+    """Assigns the numpy array to a flattened numpy array."""
     if is_numpy_array_datatype(param):
         return f"{param.parameter_name}={param.parameter_name}.flat"
     return f"{param.parameter_name}={param.parameter_name}"

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -278,8 +278,11 @@ def get_grpc_interpreter_call_params(func, params):
             elif param.is_grpc_enum or (param.is_enum and not param.is_list):
                 grpc_params.append(f"{name}_raw={param.parameter_name}")
             else:
-                if is_write_function and is_write_bytes_param(param):
-                    grpc_params.append(f"{name}=bytes({param.parameter_name})")
+                if is_write_function:
+                    if is_write_bytes_param(param):
+                        grpc_params.append(f"{name}=bytes({param.parameter_name})")
+                    else:
+                        grpc_params.append(get_write_array_param(param))
                 else:
                     grpc_params.append(f"{name}={param.parameter_name}")
     if func.is_init_method:
@@ -556,3 +559,10 @@ def get_numpy_array_params(func):
             numpy_params[param.parameter_name] = "numpy.int16"
 
     return numpy_params
+
+
+def get_write_array_param(param):
+    """Assigns the write array to a flat of write_array not of type bytes."""
+    if is_numpy_array_datatype(param):
+            return f"{param.parameter_name}={param.parameter_name}.flat"        
+    return f"{param.parameter_name}={param.parameter_name}"

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -562,7 +562,7 @@ def get_numpy_array_params(func):
 
 
 def get_write_array_param(param):
-    """Assigns the write array to a flat of write_array not of type bytes."""
+    """Assigns the write array to a flat of write_array."""
     if is_numpy_array_datatype(param):
             return f"{param.parameter_name}={param.parameter_name}.flat"        
     return f"{param.parameter_name}={param.parameter_name}"

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -280,7 +280,7 @@ def get_grpc_interpreter_call_params(func, params):
             else:
                 if is_write_function:
                     if is_write_bytes_param(param):
-                        grpc_params.append(f"{name}=bytes({param.parameter_name})")
+                        grpc_params.append(f"{name}={param.parameter_name}.tobytes()")
                     else:
                         grpc_params.append(get_write_array_param(param))
                 else:

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -564,5 +564,5 @@ def get_numpy_array_params(func):
 def get_write_array_param(param):
     """Assigns the write array to a flat of write_array."""
     if is_numpy_array_datatype(param):
-            return f"{param.parameter_name}={param.parameter_name}.flat"        
+        return f"{param.parameter_name}={param.parameter_name}.flat"
     return f"{param.parameter_name}={param.parameter_name}"

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -477,7 +477,6 @@ class Task:
         else:
             array_shape = number_of_samples_per_channel
 
-        # Analog Input
         if read_chan_type == ChannelType.ANALOG_INPUT:
             has_power_chan = False
             for chan in channels_to_read:
@@ -528,7 +527,6 @@ class Task:
                     self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Digital Input or Digital Output
         elif (read_chan_type == ChannelType.DIGITAL_INPUT or
                 read_chan_type == ChannelType.DIGITAL_OUTPUT):
             if self.in_stream.di_num_booleans_per_chan == 1:
@@ -542,7 +540,6 @@ class Task:
                     self._handle, number_of_samples_per_channel, timeout,
                     FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Counter Input
         elif read_chan_type == ChannelType.COUNTER_INPUT:
             meas_type = channels_to_read.ci_meas_type
 
@@ -1005,14 +1002,12 @@ class Task:
             else:
                 auto_start = True
 
-        # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
                 timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Digital Input
         elif write_chan_type == ChannelType.DIGITAL_OUTPUT:
             if self.out_stream.do_num_booleans_per_chan == 1:
                 if (not isinstance(element, bool) and
@@ -1043,7 +1038,6 @@ class Task:
                     self._handle, number_of_samples_per_channel,
                     auto_start, timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
-        # Counter Input
         elif write_chan_type == ChannelType.COUNTER_OUTPUT:
             output_type = channels_to_write.co_output_type
 

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1007,8 +1007,6 @@ class Task:
 
         # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
-            if number_of_samples_per_channel == 1  and number_of_channels == 1:
-                data = [data]
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
@@ -1039,9 +1037,6 @@ class Task:
                         'multiple digital lines per channel in a task.\n\n'
                         'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
-                
-                if number_of_samples_per_channel == 1  and number_of_channels == 1:
-                    data = [data]
 
                 data = numpy.asarray(data, dtype=numpy.uint32)
                 return self._interpreter.write_digital_u32(

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1007,6 +1007,8 @@ class Task:
 
         # Analog Input
         if write_chan_type == ChannelType.ANALOG_OUTPUT:
+            if number_of_samples_per_channel == 1  and number_of_channels == 1:
+                data = [data]
             data = numpy.asarray(data, dtype=numpy.float64)
             return self._interpreter.write_analog_f64(
                 self._handle, number_of_samples_per_channel, auto_start,
@@ -1037,6 +1039,9 @@ class Task:
                         'multiple digital lines per channel in a task.\n\n'
                         'Requested sample type: {}'.format(type(element)),
                         DAQmxErrors.UNKNOWN, task_name=self.name)
+                
+                if number_of_samples_per_channel == 1  and number_of_channels == 1:
+                    data = [data]
 
                 data = numpy.asarray(data, dtype=numpy.uint32)
                 return self._interpreter.write_digital_u32(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
When single sample is passed to a single channel and is converted to `numpy.ndarray` as `data = numpy.asarray(data, dtype=bool)`, `TypeError: Value must be iterable fix` is thrown from grpc tests which are using this conversion. So to fix this

- Added a if block in `task.py` to check `number_of_samples_per_channel/number_of_channels == 1`, then change the type of data from `int/float/bool..` to `list`.

### Why should this Pull Request be merged?
This PR fixes the error **TypeError: Value must be iterable fix**

### What testing has been done?
Ran `poetry run pytest`