### PR TITLE
tests: Add tests for reader/writer dtype checks

### DIFF
--- a/tests/component/test_stream_readers.py
+++ b/tests/component/test_stream_readers.py
@@ -1,0 +1,80 @@
+import ctypes
+import math
+
+import numpy
+import pytest
+
+import nidaqmx
+from nidaqmx.stream_readers import AnalogMultiChannelReader, AnalogSingleChannelReader
+
+
+@pytest.fixture
+def ai_single_channel_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    return task
+
+
+@pytest.fixture
+def ai_multi_channel_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[1].name)
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[2].name)
+    return task
+
+
+def test___analog_single_channel_reader___read_many_sample___returns_valid_samples(
+    ai_single_channel_task: nidaqmx.Task,
+):
+    reader = AnalogSingleChannelReader(ai_single_channel_task.in_stream)
+
+    samples_to_read = 10
+    data = numpy.full(samples_to_read, math.inf, dtype=numpy.float64)
+    samples_read = reader.read_many_sample(data, samples_to_read)
+
+    assert samples_read == samples_to_read
+    assert (-11.0 <= data).all() and (data <= 11.0).all()
+
+
+def test___analog_single_channel_reader___read_many_sample_with_wrong_dtype___raises_error_with_correct_dtype(
+    ai_single_channel_task: nidaqmx.Task,
+):
+    reader = AnalogSingleChannelReader(ai_single_channel_task.in_stream)
+
+    samples_to_read = 10
+    data = numpy.full(samples_to_read, math.inf, dtype=numpy.float32)
+    with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
+        _ = reader.read_many_sample(data, samples_to_read)
+
+    assert "float64" in exc_info.value.args[0]
+
+
+def test___analog_multi_channel_reader___read_many_sample___returns_valid_samples(
+    ai_multi_channel_task: nidaqmx.Task,
+):
+    reader = AnalogMultiChannelReader(ai_multi_channel_task.in_stream)
+    num_channels = ai_multi_channel_task.number_of_channels
+    samples_to_read = 10
+
+    data = numpy.full((num_channels, samples_to_read), math.inf, dtype=numpy.float64)
+    samples_read = reader.read_many_sample(data, samples_to_read)
+
+    assert samples_read == samples_to_read
+    assert (-11.0 <= data).all() and (data <= 11.0).all()
+
+
+def test___analog_multi_channel_reader___read_many_sample_with_wrong_dtype___raises_error_with_correct_dtype(
+    ai_multi_channel_task: nidaqmx.Task,
+):
+    reader = AnalogMultiChannelReader(ai_multi_channel_task.in_stream)
+    num_channels = ai_multi_channel_task.number_of_channels
+    samples_to_read = 10
+
+    data = numpy.full((num_channels, samples_to_read), math.inf, dtype=numpy.float32)
+    with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
+        _ = reader.read_many_sample(data, samples_to_read)
+
+    assert "float64" in exc_info.value.args[0]

--- a/tests/component/test_stream_writers.py
+++ b/tests/component/test_stream_writers.py
@@ -1,0 +1,82 @@
+import ctypes
+
+import numpy
+import pytest
+
+import nidaqmx
+from nidaqmx.stream_writers import AnalogMultiChannelWriter, AnalogSingleChannelWriter
+
+
+@pytest.fixture
+def ao_single_channel_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    return task
+
+
+@pytest.fixture
+def ao_multi_channel_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[1].name)
+    return task
+
+
+def test___analog_single_channel_writer___write_many_sample___writes_samples(
+    ao_single_channel_task: nidaqmx.Task,
+):
+    writer = AnalogSingleChannelWriter(ao_single_channel_task.in_stream, auto_start=True)
+
+    samples_to_write = 10
+    data = numpy.full(samples_to_write, 1.234, dtype=numpy.float64)
+    samples_written = writer.write_many_sample(data)
+
+    assert samples_written == samples_to_write
+
+
+def test___analog_single_channel_writer___write_many_sample_with_wrong_dtype___raises_error_with_correct_dtype(
+    ao_single_channel_task: nidaqmx.Task,
+):
+    writer = AnalogSingleChannelWriter(ao_single_channel_task.in_stream, auto_start=True)
+
+    samples_to_write = 10
+    data = numpy.full(samples_to_write, 1.234, dtype=numpy.float32)
+    with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
+        _ = writer.write_many_sample(data)
+
+    assert "float64" in exc_info.value.args[0]
+
+
+@pytest.mark.xfail(
+    reason="AB#2393319: GrpcStubInterpreter writes empty array with AnalogMultiChannelWriter"
+)
+def test___analog_multi_channel_writer___write_many_sample___writes_samples(
+    ao_multi_channel_task: nidaqmx.Task,
+):
+    writer = AnalogMultiChannelWriter(ao_multi_channel_task.in_stream, auto_start=True)
+    num_channels = ao_multi_channel_task.number_of_channels
+    samples_to_write = 10
+
+    data = numpy.full((num_channels, samples_to_write), 1.234, dtype=numpy.float64)
+    samples_written = writer.write_many_sample(data)
+
+    assert samples_written == samples_to_write
+
+
+@pytest.mark.xfail(
+    reason="AB#2393319: GrpcStubInterpreter writes empty array with AnalogMultiChannelWriter"
+)
+def test___analog_multi_channel_writer___write_many_sample_with_wrong_dtype___raises_error_with_correct_dtype(
+    ao_multi_channel_task: nidaqmx.Task,
+):
+    writer = AnalogMultiChannelWriter(ao_multi_channel_task.in_stream, auto_start=True)
+    num_channels = ao_multi_channel_task.number_of_channels
+    samples_to_write = 10
+
+    data = numpy.full((num_channels, samples_to_write), 1.234, dtype=numpy.float32)
+    with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
+        _ = writer.write_many_sample(data)
+
+    assert "float64" in exc_info.value.args[0]

--- a/tests/component/test_stream_writers.py
+++ b/tests/component/test_stream_writers.py
@@ -24,7 +24,7 @@ def ao_multi_channel_task(
     return task
 
 
-def test___analog_single_channel_writer___write_many_sample___writes_samples(
+def test___analog_single_channel_writer___write_many_sample___returns_samples_written(
     ao_single_channel_task: nidaqmx.Task,
 ):
     writer = AnalogSingleChannelWriter(ao_single_channel_task.in_stream, auto_start=True)
@@ -52,7 +52,7 @@ def test___analog_single_channel_writer___write_many_sample_with_wrong_dtype___r
 @pytest.mark.xfail(
     reason="AB#2393319: GrpcStubInterpreter writes empty array with AnalogMultiChannelWriter"
 )
-def test___analog_multi_channel_writer___write_many_sample___writes_samples(
+def test___analog_multi_channel_writer___write_many_sample___returns_samples_written(
     ao_multi_channel_task: nidaqmx.Task,
 ):
     writer = AnalogMultiChannelWriter(ao_multi_channel_task.in_stream, auto_start=True)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Validate AB#2390189: GrpcStubInterpreter reads/writes invalid data when NumPy array has wrong dtype

### Why should this Pull Request be merged?

Adds test coverage, which uncovered AB#2393319: GrpcStubInterpreter writes empty array with AnalogMultiChannelWriter

### What testing has been done?

Ran new tests w/simulated X Series.