### PR TITLE
Test Updates | Update all test cases to use gRPC fixtures

### DIFF
--- a/tests/legacy/test_system_collections.py
+++ b/tests/legacy/test_system_collections.py
@@ -16,10 +16,8 @@ class TestSystemCollections:
     These validate the system collections functionality in the NI-DAQmx Python API.
     """
 
-    def test_devices_collection_property(self):
+    def test_devices_collection_property(self, system):
         """Test to validate device collection property."""
-        system = nidaqmx.system.System.local()
-
         devices = system.devices
         assert isinstance(devices, DeviceCollection)
         assert isinstance(devices, collections.abc.Sequence)
@@ -27,10 +25,8 @@ class TestSystemCollections:
         assert isinstance(devices[0], nidaqmx.system.Device)
         assert isinstance(devices[0].is_simulated, bool)
 
-    def test_persisted_scale_collection_property(self):
+    def test_persisted_scale_collection_property(self, system):
         """Test to validate persisted scale property."""
-        system = nidaqmx.system.System.local()
-
         scales = system.scales
         assert isinstance(scales, PersistedScaleCollection)
         assert isinstance(scales, collections.abc.Sequence)
@@ -41,10 +37,8 @@ class TestSystemCollections:
             # Test specific property on object.
             assert isinstance(scales[0].author, str)
 
-    def test_persisted_task_collection_property(self):
+    def test_persisted_task_collection_property(self, system):
         """Test to validate persisted task collection property."""
-        system = nidaqmx.system.System.local()
-
         tasks = system.tasks
         assert isinstance(tasks, PersistedTaskCollection)
         assert isinstance(tasks, collections.abc.Sequence)
@@ -55,10 +49,8 @@ class TestSystemCollections:
             # Test specific property on object.
             assert isinstance(tasks[0].author, str)
 
-    def test_persisted_channel_collection_property(self):
+    def test_persisted_channel_collection_property(self, system):
         """Test to validate persisted channel collection property."""
-        system = nidaqmx.system.System.local()
-
         global_channels = system.global_channels
         assert isinstance(global_channels, PersistedChannelCollection)
         assert isinstance(global_channels, collections.abc.Sequence)

--- a/tests/legacy/test_task.py
+++ b/tests/legacy/test_task.py
@@ -11,11 +11,12 @@ class TestTask:
     These validate duplicate and partially constructed tasks.
     """
 
-    def test_task_duplicate(self):
+    @pytest.mark.library_only
+    def test_task_duplicate(self, init_kwargs):
         """Test to validate duplicate and partially constructed tasks."""
-        with Task("task") as t:  # noqa: F841
+        with Task("task", **init_kwargs) as t:  # noqa: F841
             with pytest.raises(DaqError) as dupe_exception:
-                u = Task("task")
+                u = Task("task", **init_kwargs)
                 # u is now partially constructed, and deleting it should be safe. This previously
                 # raised an exception which was uncatchable. pytest should fail with that, but it
                 # doesn't seem to be working. Regardless it will print a warning that contributors


### PR DESCRIPTION
**What does this PR accomplish?**
This PR updates all the existing nidaqmx tests that does not use the fixtures to run the tests in both the interpreters with the appropriate fixtures.

**Why should this PR be merged?**
 Updated the tests in `test_system_collection.py` and `test_task.py`