### PR TITLE
Fix hashing for task_handle in GrpcStubInterpreter

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -1835,3 +1835,7 @@ class BaseInterpreter(abc.ABC):
     def write_to_teds_from_file(
             self, physical_channel, file_path, basic_teds_options):
         raise NotImplementedError
+    
+    @abc.abstractmethod
+    def hash_task_sequence(self, task_handle):
+        raise NotImplementedError

--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -1837,5 +1837,5 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
     
     @abc.abstractmethod
-    def hash_task_sequence(self, task_handle):
+    def hash_task_handle(self, task_handle):
         raise NotImplementedError

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3418,6 +3418,15 @@ class GrpcStubInterpreter(BaseInterpreter):
                 physical_channel=physical_channel, file_path=file_path,
                 basic_teds_options_raw=basic_teds_options))
 
+
+    def hash_task_sequence(self, task_sequence):
+        if isinstance(task_sequence, tuple):
+            task_sequence = list(task_sequence)
+            task_sequence[0] = task_sequence[0].name
+            task_sequence = tuple(task_sequence)
+            return hash(task_sequence)
+        return hash(task_sequence.name)
+
 def _assign_numpy_array(numpy_array, grpc_array):
     """ 
     Assigns grpc array to numpy array maintaining the original shape.

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3419,13 +3419,8 @@ class GrpcStubInterpreter(BaseInterpreter):
                 basic_teds_options_raw=basic_teds_options))
 
 
-    def hash_task_sequence(self, task_sequence):
-        if isinstance(task_sequence, tuple):
-            task_sequence = list(task_sequence)
-            task_sequence[0] = task_sequence[0].name
-            task_sequence = tuple(task_sequence)
-            return hash(task_sequence)
-        return hash(task_sequence.name)
+    def hash_task_handle(self, task_handle):
+        return hash(task_handle.name)
 
 def _assign_numpy_array(numpy_array, grpc_array):
     """ 

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -6201,14 +6201,8 @@ class LibraryInterpreter(BaseInterpreter):
 
         return samps_per_chan_written.value
     
-    def hash_task_sequence(self, task_sequence):
-        if isinstance(task_sequence, tuple):
-            task_sequence = list(task_sequence)
-            task_sequence[0] = task_sequence[0].value
-            task_sequence = tuple(task_sequence)
-        if isinstance(task_sequence, ctypes.c_void_p):
-            task_sequence = task_sequence.value
-        return hash(task_sequence)
+    def hash_task_handle(self, task_handle):
+        return hash(task_handle.value)
 
 
 def check_for_error(error_code, samps_per_chan_written=None, samps_per_chan_read=None):

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -6200,6 +6200,15 @@ class LibraryInterpreter(BaseInterpreter):
         check_for_error(error_code, samps_per_chan_written=samps_per_chan_written.value)
 
         return samps_per_chan_written.value
+    
+    def hash_task_sequence(self, task_sequence):
+        if isinstance(task_sequence, tuple):
+            task_sequence = list(task_sequence)
+            task_sequence[0] = task_sequence[0].value
+            task_sequence = tuple(task_sequence)
+        if isinstance(task_sequence, ctypes.c_void_p):
+            task_sequence = task_sequence.value
+        return hash(task_sequence)
 
 
 def check_for_error(error_code, samps_per_chan_written=None, samps_per_chan_read=None):

--- a/generated/nidaqmx/_task_modules/channel_collection.py
+++ b/generated/nidaqmx/_task_modules/channel_collection.py
@@ -74,7 +74,7 @@ class ChannelCollection(Sequence):
                 'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence(self._handle)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __iter__(self):
         for channel_name in self.channel_names:

--- a/generated/nidaqmx/_task_modules/channel_collection.py
+++ b/generated/nidaqmx/_task_modules/channel_collection.py
@@ -74,7 +74,7 @@ class ChannelCollection(Sequence):
                 'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
-        return hash(self._handle.value)
+        return self._interpreter.hash_task_sequence(self._handle)
 
     def __iter__(self):
         for channel_name in self.channel_names:

--- a/generated/nidaqmx/_task_modules/channels/channel.py
+++ b/generated/nidaqmx/_task_modules/channels/channel.py
@@ -56,7 +56,7 @@ class Channel:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, frozenset(self.channel_names)))
+        return self._interpreter.hash_task_sequence((self._handle, frozenset(self.channel_names)))
 
     def __iadd__(self, other):
         return self.__add__(other)

--- a/generated/nidaqmx/_task_modules/channels/channel.py
+++ b/generated/nidaqmx/_task_modules/channels/channel.py
@@ -56,7 +56,7 @@ class Channel:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, frozenset(self.channel_names)))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(frozenset(self.channel_names))
 
     def __iadd__(self, other):
         return self.__add__(other)

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -33,7 +33,7 @@ class InStream:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._timeout))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._timeout)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -33,7 +33,7 @@ class InStream:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._timeout))
+        return self._interpreter.hash_task_sequence((self._handle, self._timeout))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -30,7 +30,7 @@ class OutStream:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._auto_start, self._timeout))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._auto_start, self._timeout)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -30,7 +30,7 @@ class OutStream:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._auto_start, self._timeout))
+        return self._interpreter.hash_task_sequence((self._handle, self._auto_start, self._timeout))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
+++ b/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
@@ -22,7 +22,7 @@ class ExpirationState:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._physical_channel))
+        return self._interpreter.hash_task_sequence((self._handle, self._physical_channel))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
+++ b/generated/nidaqmx/system/_watchdog_modules/expiration_state.py
@@ -22,7 +22,7 @@ class ExpirationState:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._physical_channel))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._physical_channel)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
+++ b/generated/nidaqmx/system/_watchdog_modules/expiration_states_collection.py
@@ -18,7 +18,7 @@ class ExpirationStatesCollection:
         return False
 
     def __hash__(self):
-        return hash(self._handle.value)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -108,7 +108,7 @@ class Task:
             self.close()
 
     def __hash__(self):
-        return hash(self._handle)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/_base_interpreter.py.mako
+++ b/src/codegen/templates/_base_interpreter.py.mako
@@ -34,5 +34,5 @@ class BaseInterpreter(abc.ABC):
 % endfor
     
     @abc.abstractmethod
-    def hash_task_sequence(self, task_handle):
+    def hash_task_handle(self, task_handle):
         raise NotImplementedError

--- a/src/codegen/templates/_base_interpreter.py.mako
+++ b/src/codegen/templates/_base_interpreter.py.mako
@@ -32,3 +32,7 @@ class BaseInterpreter(abc.ABC):
 \
         raise NotImplementedError
 % endfor
+    
+    @abc.abstractmethod
+    def hash_task_sequence(self, task_handle):
+        raise NotImplementedError

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -112,6 +112,15 @@ class GrpcStubInterpreter(BaseInterpreter):
     %endif
 
 % endfor
+
+    def hash_task_sequence(self, task_sequence):
+        if isinstance(task_sequence, tuple):
+            task_sequence = list(task_sequence)
+            task_sequence[0] = task_sequence[0].name
+            task_sequence = tuple(task_sequence)
+            return hash(task_sequence)
+        return hash(task_sequence.name)
+
 def _assign_numpy_array(numpy_array, grpc_array):
     """ 
     Assigns grpc array to numpy array maintaining the original shape.

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -113,13 +113,8 @@ class GrpcStubInterpreter(BaseInterpreter):
 
 % endfor
 
-    def hash_task_sequence(self, task_sequence):
-        if isinstance(task_sequence, tuple):
-            task_sequence = list(task_sequence)
-            task_sequence[0] = task_sequence[0].name
-            task_sequence = tuple(task_sequence)
-            return hash(task_sequence)
-        return hash(task_sequence.name)
+    def hash_task_handle(self, task_handle):
+        return hash(task_handle.name)
 
 def _assign_numpy_array(numpy_array, grpc_array):
     """ 

--- a/src/codegen/templates/_library_interpreter.py.mako
+++ b/src/codegen/templates/_library_interpreter.py.mako
@@ -170,6 +170,15 @@ class LibraryInterpreter(BaseInterpreter):
         check_for_error(error_code, samps_per_chan_written=samps_per_chan_written.value)
 
         return samps_per_chan_written.value
+    
+    def hash_task_sequence(self, task_sequence):
+        if isinstance(task_sequence, tuple):
+            task_sequence = list(task_sequence)
+            task_sequence[0] = task_sequence[0].value
+            task_sequence = tuple(task_sequence)
+        if isinstance(task_sequence, ctypes.c_void_p):
+            task_sequence = task_sequence.value
+        return hash(task_sequence)
 
 
 def check_for_error(error_code, samps_per_chan_written=None, samps_per_chan_read=None):

--- a/src/codegen/templates/_library_interpreter.py.mako
+++ b/src/codegen/templates/_library_interpreter.py.mako
@@ -171,14 +171,8 @@ class LibraryInterpreter(BaseInterpreter):
 
         return samps_per_chan_written.value
     
-    def hash_task_sequence(self, task_sequence):
-        if isinstance(task_sequence, tuple):
-            task_sequence = list(task_sequence)
-            task_sequence[0] = task_sequence[0].value
-            task_sequence = tuple(task_sequence)
-        if isinstance(task_sequence, ctypes.c_void_p):
-            task_sequence = task_sequence.value
-        return hash(task_sequence)
+    def hash_task_handle(self, task_handle):
+        return hash(task_handle.value)
 
 
 def check_for_error(error_code, samps_per_chan_written=None, samps_per_chan_read=None):

--- a/src/codegen/templates/_task_modules/channels/channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/channel.py.mako
@@ -62,7 +62,7 @@ class Channel:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, frozenset(self.channel_names)))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(frozenset(self.channel_names))
 
     def __iadd__(self, other):
         return self.__add__(other)

--- a/src/codegen/templates/_task_modules/channels/channel.py.mako
+++ b/src/codegen/templates/_task_modules/channels/channel.py.mako
@@ -62,7 +62,7 @@ class Channel:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, frozenset(self.channel_names)))
+        return self._interpreter.hash_task_sequence((self._handle, frozenset(self.channel_names)))
 
     def __iadd__(self, other):
         return self.__add__(other)

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -38,7 +38,7 @@ class InStream:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._timeout))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._timeout)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -38,7 +38,7 @@ class InStream:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._timeout))
+        return self._interpreter.hash_task_sequence((self._handle, self._timeout))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -36,7 +36,7 @@ class OutStream:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._auto_start, self._timeout))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._auto_start, self._timeout)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -36,7 +36,7 @@ class OutStream:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._auto_start, self._timeout))
+        return self._interpreter.hash_task_sequence((self._handle, self._auto_start, self._timeout))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
+++ b/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
@@ -28,7 +28,7 @@ class ExpirationState:
         return False
 
     def __hash__(self):
-        return hash((self._handle.value, self._physical_channel))
+        return self._interpreter.hash_task_sequence((self._handle, self._physical_channel))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
+++ b/src/codegen/templates/system/_watchdog_modules/expiration_state.py.mako
@@ -28,7 +28,7 @@ class ExpirationState:
         return False
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence((self._handle, self._physical_channel))
+        return self._interpreter.hash_task_handle(self._handle) ^ hash(self._physical_channel)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/handwritten/_task_modules/channel_collection.py
+++ b/src/handwritten/_task_modules/channel_collection.py
@@ -74,7 +74,7 @@ class ChannelCollection(Sequence):
                 'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
-        return self._interpreter.hash_task_sequence(self._handle)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __iter__(self):
         for channel_name in self.channel_names:

--- a/src/handwritten/_task_modules/channel_collection.py
+++ b/src/handwritten/_task_modules/channel_collection.py
@@ -74,7 +74,7 @@ class ChannelCollection(Sequence):
                 'Index used: {}'.format(index), DAQmxErrors.UNKNOWN)
 
     def __hash__(self):
-        return hash(self._handle.value)
+        return self._interpreter.hash_task_sequence(self._handle)
 
     def __iter__(self):
         for channel_name in self.channel_names:

--- a/src/handwritten/system/_watchdog_modules/expiration_states_collection.py
+++ b/src/handwritten/system/_watchdog_modules/expiration_states_collection.py
@@ -18,7 +18,7 @@ class ExpirationStatesCollection:
         return False
 
     def __hash__(self):
-        return hash(self._handle.value)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -108,7 +108,7 @@ class Task:
             self.close()
 
     def __hash__(self):
-        return hash(self._handle)
+        return self._interpreter.hash_task_handle(self._handle)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -83,7 +83,6 @@ class TestContainerOperations:
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
-
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -81,11 +81,8 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    @pytest.mark.library_only
     def test_hash_operations(self, generate_task, any_x_series_device, seed):
         """Test for hash operation."""
-        # gRPC implementation will be tested after fixing Bug 2388532
-        # Bug link: https://ni.visualstudio.com/DevCentral/_workitems/edit/2388532.
 
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The task created using the gRPC interpreter in nidaqmx is not hashable and currently throws an exception when trying to find the hash value of the task.
The fix has been done by adding hashing logic(`hash_task_sequence()`) in both gRPC and Library interpreters.

### Why should this Pull Request be merged?

Fixes [Bug 2388532](https://ni.visualstudio.com/DevCentral/_workitems/edit/2388532): The task created using grpc interpreter is non hashable

### What testing has been done?

Tested by removing `@pytest.mark.library_only` for test_case `test_hash_operations`