### PR TITLE
tests: Add component tests for in_stream and out_stream

### DIFF
--- a/tests/component/test_in_stream.py
+++ b/tests/component/test_in_stream.py
@@ -3,6 +3,7 @@ import pytest
 
 import nidaqmx
 
+
 @pytest.fixture(params=[1, 2, 3])
 def ai_task(
     task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
@@ -14,7 +15,9 @@ def ai_task(
 
 
 @pytest.mark.parametrize("samples_to_read", [1, 10])
-def test___ai_task___read___returns_shape_and_dtype(ai_task: nidaqmx.Task, samples_to_read: int) -> None:
+def test___ai_task___read___returns_shape_and_dtype(
+    ai_task: nidaqmx.Task, samples_to_read: int
+) -> None:
     assert ai_task.ai_channels.all.ai_raw_samp_size == 16
     assert ai_task.ai_channels.all.ai_rng_low < 0
 
@@ -25,7 +28,9 @@ def test___ai_task___read___returns_shape_and_dtype(ai_task: nidaqmx.Task, sampl
 
 
 @pytest.mark.parametrize("samples_to_read", [1, 10])
-def test___valid_array___readinto___returns_samples_read(ai_task: nidaqmx.Task, samples_to_read: int) -> None:
+def test___valid_array___readinto___returns_samples_read(
+    ai_task: nidaqmx.Task, samples_to_read: int
+) -> None:
     assert ai_task.ai_channels.all.ai_raw_samp_size == 16
     assert ai_task.ai_channels.all.ai_rng_low < 0
     data = numpy.full(ai_task.number_of_channels * samples_to_read, 0xA5A5, dtype=numpy.int16)
@@ -36,7 +41,9 @@ def test___valid_array___readinto___returns_samples_read(ai_task: nidaqmx.Task, 
     assert (data != 0xA5A5).any()
 
 
-def test___odd_sized_array___readinto___returns_whole_samples(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> None:
+def test___odd_sized_array___readinto___returns_whole_samples(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> None:
     task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
     task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[1].name)
     assert task.ai_channels.all.ai_raw_samp_size == 16

--- a/tests/component/test_in_stream.py
+++ b/tests/component/test_in_stream.py
@@ -3,55 +3,81 @@ import pytest
 
 import nidaqmx
 
+# With a simulated X Series, setting ai_max/min to +/-2.5 V coerces the hardware range
+# to +/-5 V and generates a noisy sine wave with range +/-2.5 V (raw: about +/-16383).
+# The noisy sine wave should not produce full-scale readings.
+SINE_VOLTAGE_MAX = 2.5
+SINE_VOLTAGE_MIN = -2.5
+SINE_RAW_MAX = 16383
+SINE_RAW_MIN = -16384
+FULLSCALE_RAW_MAX = 36767
+FULLSCALE_RAW_MIN = -36768
+
 
 @pytest.fixture(params=[1, 2, 3])
-def ai_task(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
+def ai_sine_task(
+    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
 ) -> nidaqmx.Task:
-    number_of_channels = request.param
-    for i in range(number_of_channels):
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[i].name)
+    """Returns an analog input task with varying number of channels and a simulated sine wave."""
+    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=request.param)
     return task
 
 
-@pytest.mark.parametrize("samples_to_read", [1, 10])
-def test___ai_task___read___returns_shape_and_dtype(
-    ai_task: nidaqmx.Task, samples_to_read: int
+def _create_ai_sine_channels(
+    task: nidaqmx.Task, device: nidaqmx.system.Device, number_of_channels: int
 ) -> None:
-    assert ai_task.ai_channels.all.ai_raw_samp_size == 16
-    assert ai_task.ai_channels.all.ai_rng_low < 0
+    """Creates the specified number of analog input channels for a simulated sine wave."""
+    for i in range(number_of_channels):
+        task.ai_channels.add_ai_voltage_chan(
+            device.ai_physical_chans[i].name,
+            min_val=SINE_VOLTAGE_MIN,
+            max_val=SINE_VOLTAGE_MAX,
+        )
 
-    data = ai_task.in_stream.read(samples_to_read)
+    # The driver's coerced ai_max/min should be wider than the desired ai_max/min.
+    assert task.ai_channels.all.ai_min < SINE_VOLTAGE_MIN
+    assert task.ai_channels.all.ai_max > SINE_VOLTAGE_MAX
 
-    assert data.shape == (ai_task.number_of_channels * samples_to_read,)
-    assert data.dtype == numpy.int16
-
-
-@pytest.mark.parametrize("samples_to_read", [1, 10])
-def test___valid_array___readinto___returns_samples_read(
-    ai_task: nidaqmx.Task, samples_to_read: int
-) -> None:
-    assert ai_task.ai_channels.all.ai_raw_samp_size == 16
-    assert ai_task.ai_channels.all.ai_rng_low < 0
-    data = numpy.full(ai_task.number_of_channels * samples_to_read, 0xA5A5, dtype=numpy.int16)
-
-    samples_read = ai_task.in_stream.readinto(data)
-
-    assert samples_read == samples_to_read
-    assert (data != 0xA5A5).any()
-
-
-def test___odd_sized_array___readinto___returns_whole_samples(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
-) -> None:
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[1].name)
+    # This test assumes the data format is int16.
     assert task.ai_channels.all.ai_raw_samp_size == 16
     assert task.ai_channels.all.ai_rng_low < 0
-    data = numpy.full(19, 0xA5A5, dtype=numpy.int16)
+
+
+@pytest.mark.parametrize("samples_to_read", [1, 10])
+def test___ai_task___read___returns_valid_samples_shape_and_dtype(
+    ai_sine_task: nidaqmx.Task, samples_to_read: int
+) -> None:
+    data = ai_sine_task.in_stream.read(samples_to_read)
+
+    assert data.shape == (ai_sine_task.number_of_channels * samples_to_read,)
+    assert data.dtype == numpy.int16
+    assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
+
+@pytest.mark.parametrize("samples_to_read", [1, 10])
+def test___valid_array___readinto___returns_valid_samples(
+    ai_sine_task: nidaqmx.Task, samples_to_read: int
+) -> None:
+    # Initialize the array to full-scale readings to ensure it is overwritten.
+    data = numpy.full(
+        ai_sine_task.number_of_channels * samples_to_read, FULLSCALE_RAW_MAX, dtype=numpy.int16
+    )
+
+    samples_read = ai_sine_task.in_stream.readinto(data)
+
+    assert samples_read == samples_to_read
+    assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
+
+def test___odd_sized_array___readinto___returns_whole_samples_and_clears_padding(
+    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device
+) -> None:
+    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
+    # Initialize the array to full-scale readings to ensure it is overwritten.
+    data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
 
     samples_read = task.in_stream.readinto(data)
 
     assert samples_read == 9
-    assert (data[:-1] != 0xA5A5).any()
-    assert data[-1] == 0
+    assert (SINE_RAW_MIN <= data[:-1]).all() and (data[:-1] <= SINE_RAW_MAX).all()
+    assert data[-1] == 0  # not FULLSCALE_RAW_MIN

--- a/tests/component/test_in_stream.py
+++ b/tests/component/test_in_stream.py
@@ -1,0 +1,50 @@
+import numpy
+import pytest
+
+import nidaqmx
+
+@pytest.fixture(params=[1, 2, 3])
+def ai_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
+) -> nidaqmx.Task:
+    number_of_channels = request.param
+    for i in range(number_of_channels):
+        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[i].name)
+    return task
+
+
+@pytest.mark.parametrize("samples_to_read", [1, 10])
+def test___ai_task___read___returns_shape_and_dtype(ai_task: nidaqmx.Task, samples_to_read: int) -> None:
+    assert ai_task.ai_channels.all.ai_raw_samp_size == 16
+    assert ai_task.ai_channels.all.ai_rng_low < 0
+
+    data = ai_task.in_stream.read(samples_to_read)
+
+    assert data.shape == (ai_task.number_of_channels * samples_to_read,)
+    assert data.dtype == numpy.int16
+
+
+@pytest.mark.parametrize("samples_to_read", [1, 10])
+def test___valid_array___readinto___returns_samples_read(ai_task: nidaqmx.Task, samples_to_read: int) -> None:
+    assert ai_task.ai_channels.all.ai_raw_samp_size == 16
+    assert ai_task.ai_channels.all.ai_rng_low < 0
+    data = numpy.full(ai_task.number_of_channels * samples_to_read, 0xA5A5, dtype=numpy.int16)
+
+    samples_read = ai_task.in_stream.readinto(data)
+
+    assert samples_read == samples_to_read
+    assert (data != 0xA5A5).any()
+
+
+def test___odd_sized_array___readinto___returns_whole_samples(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> None:
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[1].name)
+    assert task.ai_channels.all.ai_raw_samp_size == 16
+    assert task.ai_channels.all.ai_rng_low < 0
+    data = numpy.full(19, 0xA5A5, dtype=numpy.int16)
+
+    samples_read = task.in_stream.readinto(data)
+
+    assert samples_read == 9
+    assert (data[:-1] != 0xA5A5).any()
+    assert data[-1] == 0

--- a/tests/component/test_out_stream.py
+++ b/tests/component/test_out_stream.py
@@ -1,0 +1,37 @@
+import numpy
+import pytest
+
+import nidaqmx
+
+@pytest.fixture(params=[1, 2])
+def ao_task(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
+) -> nidaqmx.Task:
+    number_of_channels = request.param
+    for i in range(number_of_channels):
+        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[i].name)
+    assert task.ao_channels.all.ao_resolution == 16
+    return task
+
+
+@pytest.mark.parametrize("samples_to_write", [1, 10])
+def test___valid_array___write___returns_samples_written(ao_task: nidaqmx.Task, samples_to_write: int) -> None:
+    assert ao_task.ao_channels.all.ao_resolution == 16
+    ao_task.out_stream.auto_start = True
+    data = numpy.full(ao_task.number_of_channels * samples_to_write, 0x1234, dtype=numpy.int16)
+
+    samples_written = ao_task.out_stream.write(data)
+
+    assert samples_written == samples_to_write
+
+
+def test___odd_sized_array___write___returns_whole_samples(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> None:
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[1].name)
+    assert task.ao_channels.all.ao_resolution == 16
+    task.out_stream.auto_start = True
+    data = numpy.full(19, 0x1234, dtype=numpy.int16)
+
+    samples_written = task.out_stream.write(data)
+
+    assert samples_written == 9

--- a/tests/component/test_out_stream.py
+++ b/tests/component/test_out_stream.py
@@ -3,6 +3,7 @@ import pytest
 
 import nidaqmx
 
+
 @pytest.fixture(params=[1, 2])
 def ao_task(
     task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
@@ -15,7 +16,9 @@ def ao_task(
 
 
 @pytest.mark.parametrize("samples_to_write", [1, 10])
-def test___valid_array___write___returns_samples_written(ao_task: nidaqmx.Task, samples_to_write: int) -> None:
+def test___valid_array___write___returns_samples_written(
+    ao_task: nidaqmx.Task, samples_to_write: int
+) -> None:
     assert ao_task.ao_channels.all.ao_resolution == 16
     ao_task.out_stream.auto_start = True
     data = numpy.full(ao_task.number_of_channels * samples_to_write, 0x1234, dtype=numpy.int16)
@@ -25,7 +28,9 @@ def test___valid_array___write___returns_samples_written(ao_task: nidaqmx.Task, 
     assert samples_written == samples_to_write
 
 
-def test___odd_sized_array___write___returns_whole_samples(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> None:
+def test___odd_sized_array___write___returns_whole_samples(
+    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+) -> None:
     task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
     task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[1].name)
     assert task.ao_channels.all.ao_resolution == 16

--- a/tests/component/test_out_stream.py
+++ b/tests/component/test_out_stream.py
@@ -8,18 +8,26 @@ import nidaqmx
 def ao_task(
     task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
 ) -> nidaqmx.Task:
-    number_of_channels = request.param
-    for i in range(number_of_channels):
-        task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[i].name)
-    assert task.ao_channels.all.ao_resolution == 16
+    """Returns an analog output task with a varying number of channels."""
+    _create_ao_channels(task, any_x_series_device, number_of_channels=request.param)
     return task
+
+
+def _create_ao_channels(
+    task: nidaqmx.Task, device: nidaqmx.system.Device, number_of_channels: int
+) -> None:
+    """Creates the specified number of analog output channels."""
+    for i in range(number_of_channels):
+        task.ao_channels.add_ao_voltage_chan(device.ao_physical_chans[i].name)
+
+    # This test assumes the data format is int16.
+    assert task.ao_channels.all.ao_resolution == 16
 
 
 @pytest.mark.parametrize("samples_to_write", [1, 10])
 def test___valid_array___write___returns_samples_written(
     ao_task: nidaqmx.Task, samples_to_write: int
 ) -> None:
-    assert ao_task.ao_channels.all.ao_resolution == 16
     ao_task.out_stream.auto_start = True
     data = numpy.full(ao_task.number_of_channels * samples_to_write, 0x1234, dtype=numpy.int16)
 
@@ -31,9 +39,7 @@ def test___valid_array___write___returns_samples_written(
 def test___odd_sized_array___write___returns_whole_samples(
     task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
 ) -> None:
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[1].name)
-    assert task.ao_channels.all.ao_resolution == 16
+    _create_ao_channels(task, any_x_series_device, number_of_channels=2)
     task.out_stream.auto_start = True
     data = numpy.full(19, 0x1234, dtype=numpy.int16)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add component tests for `in_stream.read()`, `in_stream.readinto()`, and `out_stream.write()`.

### Why should this Pull Request be merged?

These functions have inadequate test coverage.

### What testing has been done?

Tests pass with simulated devices, using the fixes from the subsequent PRs.