### PR TITLE
codegen: Fix `TypeError` in `in_stream` and `out_stream` samples per channel calculations

### DIFF
--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -1190,7 +1190,7 @@ class InStream:
 
         number_of_samples_per_channel, _ = divmod(
             numpy_array.nbytes, (
-                number_of_channels * channels_to_read.ai_raw_samp_size / 8))
+                number_of_channels * channels_to_read.ai_raw_samp_size // 8))
 
         _, samples_read, _ = self._interpreter.read_raw(
             self._handle, number_of_samples_per_channel,

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -558,8 +558,8 @@ class OutStream:
 
         number_of_samples_per_channel, _ = divmod(
             numpy_array.nbytes, (
-                number_of_channels * channels_to_write.ao_resolution / 8))
+                number_of_channels * int(channels_to_write.ao_resolution) // 8))
 
         return self._interpreter.write_raw(
-            self._handle, number_of_samples_per_channel, 
+            self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -311,7 +311,7 @@ ${property_template.script_property(attribute)}\
 
         number_of_samples_per_channel, _ = divmod(
             numpy_array.nbytes, (
-                number_of_channels * channels_to_read.ai_raw_samp_size / 8))
+                number_of_channels * channels_to_read.ai_raw_samp_size // 8))
 
         _, samples_read, _ = self._interpreter.read_raw(
             self._handle, number_of_samples_per_channel,

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -160,8 +160,8 @@ ${property_template.script_property(attribute)}\
 
         number_of_samples_per_channel, _ = divmod(
             numpy_array.nbytes, (
-                number_of_channels * channels_to_write.ao_resolution / 8))
+                number_of_channels * int(channels_to_write.ao_resolution) // 8))
 
         return self._interpreter.write_raw(
-            self._handle, number_of_samples_per_channel, 
+            self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The samples per channel calculations in `in_stream.readinto()` and `out_stream.write()` result in a floating point number, and passing it to ctypes or gRPC raises a `TypeError`. The solution is to use integer division and cast to `int` when needed.

### Why should this Pull Request be merged?

Fixes #356 

### What testing has been done?

Ran new tests.