### PR TITLE
Test Fixes | Update the failing test with xfail

### DIFF
--- a/tests/component/test_device_properties.py
+++ b/tests/component/test_device_properties.py
@@ -72,7 +72,7 @@ def test___device___list_of_float_property___returns_value(device):
 
 
 @pytest.mark.xfail(
-    reason="#2395661: The attributes are present under the wrong type in NIDAQmx proto file, hence it fails in grpc."
+    reason="AB#2395661: Attributes with bitfield enum are listed under the wrong type in DAQmx proto file."
 )
 @pytest.mark.device_name("bridgeTester")
 def test___device___list_of_enum_property___returns_value(device):

--- a/tests/component/test_device_properties.py
+++ b/tests/component/test_device_properties.py
@@ -71,6 +71,9 @@ def test___device___list_of_float_property___returns_value(device):
     assert ai_bridge_ranges == [-0.025, 0.025, -0.1, 0.1]
 
 
+@pytest.mark.xfail(
+    reason="#2395661: The attributes are present under the wrong type in NIDAQmx proto file, hence it fails in grpc."
+)
 @pytest.mark.device_name("bridgeTester")
 def test___device___list_of_enum_property___returns_value(device):
     ai_trigger_usage = device.ai_trig_usage

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -120,16 +120,25 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
     assert not ai_task.in_stream.logging_pause
 
 
+@pytest.mark.xfail(
+        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+)
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path == ""
 
 
+@pytest.mark.xfail(
+        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+)
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"
 
     assert ai_task.in_stream.logging_file_path == "TestData.tdms"
 
 
+@pytest.mark.xfail(
+        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+)
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"
 

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -121,14 +121,14 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path == ""
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"
@@ -137,7 +137,7 @@ def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task)
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: A NULL pointer is passed in the grpc device."
+        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -121,14 +121,14 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path == ""
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"
@@ -137,7 +137,7 @@ def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task)
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
 )
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -121,14 +121,14 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
 
 
 @pytest.mark.xfail(
-    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path == ""
 
 
 @pytest.mark.xfail(
-    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"
@@ -137,7 +137,7 @@ def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task)
 
 
 @pytest.mark.xfail(
-    reason="#AB2393811: When using gRPC interpreter, a NULL pointer is passed in the grpc device."
+    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -84,6 +84,9 @@ def test___ao_current_task___get_bool_property___returns_default_value(task, dev
     assert not task.out_stream.open_current_loop_chans_exist
 
 
+@pytest.mark.xfail(
+        reason= "#AB2393824: Calling IVI Dance twice returns an error in the grpc device."
+)
 @pytest.mark.device_name("aoTester")
 def test___ao_current_task___get_string_list_property___returns_default_value(task, device):
     task.ao_channels.add_ao_current_chan(device.ao_physical_chans[0].name)

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -85,7 +85,7 @@ def test___ao_current_task___get_bool_property___returns_default_value(task, dev
 
 
 @pytest.mark.xfail(
-    reason="#AB2393824: When using grpc interpreter, calling IVI Dance twice returns an error in the grpc device."
+    reason="AB#2393824: DAQmx read/write status properties return errors when called from C, Python, or grpc-device."
 )
 @pytest.mark.device_name("aoTester")
 def test___ao_current_task___get_string_list_property___returns_default_value(task, device):

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -85,7 +85,7 @@ def test___ao_current_task___get_bool_property___returns_default_value(task, dev
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393824: When using grpc interpreter, calling IVI Dance twice returns an error in the grpc device."
+    reason="#AB2393824: When using grpc interpreter, calling IVI Dance twice returns an error in the grpc device."
 )
 @pytest.mark.device_name("aoTester")
 def test___ao_current_task___get_string_list_property___returns_default_value(task, device):

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -85,7 +85,7 @@ def test___ao_current_task___get_bool_property___returns_default_value(task, dev
 
 
 @pytest.mark.xfail(
-        reason= "#AB2393824: Calling IVI Dance twice returns an error in the grpc device."
+        reason= "#AB2393824: When using grpc interpreter, calling IVI Dance twice returns an error in the grpc device."
 )
 @pytest.mark.device_name("aoTester")
 def test___ao_current_task___get_string_list_property___returns_default_value(task, device):


### PR DESCRIPTION
**What does this PR accomplish?**
1. [Bug 2393811](https://dev.azure.com/ni/DevCentral/_workitems/edit/2393811): DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when 1st IVI dance call passes value=NULL
2. [Bug 2393824](https://dev.azure.com/ni/DevCentral/_workitems/edit/2393824): DAQmx read/write status properties return errors when called from C, Python, or grpc-device
There are totally 4 test cases that are failing in DAQmx as result of the above bugs in gRPC device. This PR marks all these tests with xfail tag.

**Why should this PR be merged?**
Updated the failing tests in `read_properties` and `write_properties` with the xfail tag and linked them with the appropriate bug.