### PR TITLE
tests: Move more stream reader/writer setup into arrange section

### DIFF
--- a/tests/component/test_stream_readers.py
+++ b/tests/component/test_stream_readers.py
@@ -30,9 +30,9 @@ def test___analog_single_channel_reader___read_many_sample___returns_valid_sampl
     ai_single_channel_task: nidaqmx.Task,
 ):
     reader = AnalogSingleChannelReader(ai_single_channel_task.in_stream)
-
     samples_to_read = 10
     data = numpy.full(samples_to_read, math.inf, dtype=numpy.float64)
+
     samples_read = reader.read_many_sample(data, samples_to_read)
 
     assert samples_read == samples_to_read
@@ -43,9 +43,9 @@ def test___analog_single_channel_reader___read_many_sample_with_wrong_dtype___ra
     ai_single_channel_task: nidaqmx.Task,
 ):
     reader = AnalogSingleChannelReader(ai_single_channel_task.in_stream)
-
     samples_to_read = 10
     data = numpy.full(samples_to_read, math.inf, dtype=numpy.float32)
+
     with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
         _ = reader.read_many_sample(data, samples_to_read)
 
@@ -58,8 +58,8 @@ def test___analog_multi_channel_reader___read_many_sample___returns_valid_sample
     reader = AnalogMultiChannelReader(ai_multi_channel_task.in_stream)
     num_channels = ai_multi_channel_task.number_of_channels
     samples_to_read = 10
-
     data = numpy.full((num_channels, samples_to_read), math.inf, dtype=numpy.float64)
+
     samples_read = reader.read_many_sample(data, samples_to_read)
 
     assert samples_read == samples_to_read
@@ -72,8 +72,8 @@ def test___analog_multi_channel_reader___read_many_sample_with_wrong_dtype___rai
     reader = AnalogMultiChannelReader(ai_multi_channel_task.in_stream)
     num_channels = ai_multi_channel_task.number_of_channels
     samples_to_read = 10
-
     data = numpy.full((num_channels, samples_to_read), math.inf, dtype=numpy.float32)
+
     with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
         _ = reader.read_many_sample(data, samples_to_read)
 

--- a/tests/component/test_stream_writers.py
+++ b/tests/component/test_stream_writers.py
@@ -28,9 +28,9 @@ def test___analog_single_channel_writer___write_many_sample___returns_samples_wr
     ao_single_channel_task: nidaqmx.Task,
 ):
     writer = AnalogSingleChannelWriter(ao_single_channel_task.in_stream, auto_start=True)
-
     samples_to_write = 10
     data = numpy.full(samples_to_write, 1.234, dtype=numpy.float64)
+
     samples_written = writer.write_many_sample(data)
 
     assert samples_written == samples_to_write
@@ -40,9 +40,9 @@ def test___analog_single_channel_writer___write_many_sample_with_wrong_dtype___r
     ao_single_channel_task: nidaqmx.Task,
 ):
     writer = AnalogSingleChannelWriter(ao_single_channel_task.in_stream, auto_start=True)
-
     samples_to_write = 10
     data = numpy.full(samples_to_write, 1.234, dtype=numpy.float32)
+
     with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
         _ = writer.write_many_sample(data)
 
@@ -58,8 +58,8 @@ def test___analog_multi_channel_writer___write_many_sample___returns_samples_wri
     writer = AnalogMultiChannelWriter(ao_multi_channel_task.in_stream, auto_start=True)
     num_channels = ao_multi_channel_task.number_of_channels
     samples_to_write = 10
-
     data = numpy.full((num_channels, samples_to_write), 1.234, dtype=numpy.float64)
+
     samples_written = writer.write_many_sample(data)
 
     assert samples_written == samples_to_write
@@ -74,8 +74,8 @@ def test___analog_multi_channel_writer___write_many_sample_with_wrong_dtype___ra
     writer = AnalogMultiChannelWriter(ao_multi_channel_task.in_stream, auto_start=True)
     num_channels = ao_multi_channel_task.number_of_channels
     samples_to_write = 10
-
     data = numpy.full((num_channels, samples_to_write), 1.234, dtype=numpy.float32)
+
     with pytest.raises((ctypes.ArgumentError, TypeError)) as exc_info:
         _ = writer.write_many_sample(data)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In tests_stream_readers.py and tests_stream_writers.py, move more of the setup code into the arrange section so that the act section only contains the read/write call (and pytest.raises, if necessary).

### Why should this Pull Request be merged?

Better follow testing guidelines, make consistent with in/out_stream tests.

### What testing has been done?

Ran affected tests.