### PR TITLE
Disabled Resource warning for explicit detach of grpc task

### DIFF
--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -74,6 +74,7 @@ class Task:
         self._handle = None
         self._close_on_exit = False
         self._saved_name = new_task_name
+        self._grpc_options = grpc_options
 
         if grpc_options and not (
             grpc_options.session_name == "" or grpc_options.session_name == new_task_name
@@ -89,7 +90,7 @@ class Task:
         self._initialize(self._handle, self._interpreter)
 
     def __del__(self):
-        if self._handle is not None and self._close_on_exit:
+        if self._handle is not None and self._close_on_exit and self._grpc_options is None:
             warnings.warn(
                 'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -74,6 +74,7 @@ class Task:
         self._handle = None
         self._close_on_exit = False
         self._saved_name = new_task_name
+        self._grpc_options = grpc_options
 
         if grpc_options and not (
             grpc_options.session_name == "" or grpc_options.session_name == new_task_name
@@ -89,7 +90,7 @@ class Task:
         self._initialize(self._handle, self._interpreter)
 
     def __del__(self):
-        if self._handle is not None and self._close_on_exit:
+        if self._handle is not None and self._close_on_exit and self._grpc_options is None:
             warnings.warn(
                 'Task of name "{}" was not explicitly closed before it was '
                 'destructed. Resources on the task device may still be '

--- a/tests/component/test_task_resource_warnings.py
+++ b/tests/component/test_task_resource_warnings.py
@@ -7,35 +7,23 @@ from nidaqmx.errors import DaqResourceWarning
 
 
 @pytest.mark.library_only
-def test__unclosed_task__leak_task__resource_warning_raised(task):
-    """Test to validate unclosed tasks."""
-    interpreter = task._interpreter
-    task_handle = task._handle
-
+def test___unclosed_task___leak_task___resource_warning_raised(task):
     # Since __del__ is not guaranteed to be called, for the purposes of
     # consistent test results call __del__ manually.
     with pytest.warns(DaqResourceWarning):
         task.__del__()
 
-    interpreter.clear_task(task_handle)
-
 
 @pytest.mark.grpc_only
-def test__grpc_task__leak_task__resource_warning_not_raised(task):
-    """Test to validate grpc leak tasks."""
-    interpreter = task._interpreter
-    task_handle = task._handle
+def test___grpc_task___leak_task___resource_warning_not_raised(task):
 
     with warnings.catch_warnings(record=True) as warnings_raised:
         task.__del__()
 
     assert len(warnings_raised) == 0
-    
-    interpreter.clear_task(task_handle)
 
 
-def test__closed_task__del_task__resource_warning_not_raised(init_kwargs):
-    """Test to validate __del__ of closed tasks."""
+def test___closed_task___del_task___resource_warning_not_raised(init_kwargs):
     task = nidaqmx.Task(**init_kwargs)
     task.close()
 

--- a/tests/component/test_task_resource_warnings.py
+++ b/tests/component/test_task_resource_warnings.py
@@ -1,8 +1,8 @@
 import warnings
-import nidaqmx
 
 import pytest
 
+import nidaqmx
 from nidaqmx.errors import DaqResourceWarning
 
 
@@ -16,7 +16,6 @@ def test___unclosed_task___leak_task___resource_warning_raised(task):
 
 @pytest.mark.grpc_only
 def test___grpc_task___leak_task___resource_warning_not_raised(task):
-
     with warnings.catch_warnings(record=True) as warnings_raised:
         task.__del__()
 

--- a/tests/component/test_task_resource_warnings.py
+++ b/tests/component/test_task_resource_warnings.py
@@ -7,7 +7,7 @@ from nidaqmx.errors import DaqResourceWarning
 
 
 @pytest.mark.library_only
-def test__unclosed_task__delete_task__resource_warning_raised(task):
+def test__unclosed_task__leak_task__resource_warning_raised(task):
     """Test to validate unclosed tasks."""
     interpreter = task._interpreter
     task_handle = task._handle

--- a/tests/component/test_task_resource_warnings.py
+++ b/tests/component/test_task_resource_warnings.py
@@ -1,0 +1,45 @@
+import warnings
+import nidaqmx
+
+import pytest
+
+from nidaqmx.errors import DaqResourceWarning
+
+
+@pytest.mark.library_only
+def test__unclosed_task__delete_task__resource_warning_raised(task):
+    """Test to validate unclosed tasks."""
+    interpreter = task._interpreter
+    task_handle = task._handle
+
+    # Since __del__ is not guaranteed to be called, for the purposes of
+    # consistent test results call __del__ manually.
+    with pytest.warns(DaqResourceWarning):
+        task.__del__()
+
+    interpreter.clear_task(task_handle)
+
+
+@pytest.mark.grpc_only
+def test__grpc_task__leak_task__resource_warning_not_raised(task):
+    """Test to validate grpc leak tasks."""
+    interpreter = task._interpreter
+    task_handle = task._handle
+
+    with warnings.catch_warnings(record=True) as warnings_raised:
+        task.__del__()
+
+    assert len(warnings_raised) == 0
+    
+    interpreter.clear_task(task_handle)
+
+
+def test__closed_task__del_task__resource_warning_not_raised(init_kwargs):
+    """Test to validate __del__ of closed tasks."""
+    task = nidaqmx.Task(**init_kwargs)
+    task.close()
+
+    with warnings.catch_warnings(record=True) as warnings_raised:
+        task.__del__()
+
+    assert len(warnings_raised) == 0

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -1,6 +1,4 @@
 """Tests for validating resource warning behavior."""
-import warnings
-
 import pytest
 
 import nidaqmx
@@ -18,22 +16,3 @@ class TestResourceWarnings:
         with pytest.warns(DaqResourceWarning):
             with nidaqmx.Task(**init_kwargs) as task:
                 task.close()
-
-    @pytest.mark.library_only
-    def test_unclosed_task(self, init_kwargs):
-        """Test to validate unclosed tasks."""
-        task = nidaqmx.Task(**init_kwargs)
-        # Since __del__ is not guaranteed to be called, for the purposes of
-        # consistent test results call __del__ manually.
-        with pytest.warns(DaqResourceWarning):
-            task.__del__()
-
-    @pytest.mark.grpc_only
-    def test_explicit_detach_grpc_task(self, init_kwargs):
-        """Test to validate grpc leak tasks."""
-        task = nidaqmx.Task(**init_kwargs)
-
-        with warnings.catch_warnings(record=True) as warnings_raised:
-            task.__del__()
-            if warnings_raised:
-                pytest.fail()

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -1,5 +1,6 @@
 """Tests for validating resource warning behavior."""
 import warnings
+
 import pytest
 
 import nidaqmx

--- a/tests/legacy/test_resource_warnings.py
+++ b/tests/legacy/test_resource_warnings.py
@@ -1,4 +1,5 @@
 """Tests for validating resource warning behavior."""
+import warnings
 import pytest
 
 import nidaqmx
@@ -17,6 +18,7 @@ class TestResourceWarnings:
             with nidaqmx.Task(**init_kwargs) as task:
                 task.close()
 
+    @pytest.mark.library_only
     def test_unclosed_task(self, init_kwargs):
         """Test to validate unclosed tasks."""
         task = nidaqmx.Task(**init_kwargs)
@@ -24,3 +26,13 @@ class TestResourceWarnings:
         # consistent test results call __del__ manually.
         with pytest.warns(DaqResourceWarning):
             task.__del__()
+
+    @pytest.mark.grpc_only
+    def test_explicit_detach_grpc_task(self, init_kwargs):
+        """Test to validate grpc leak tasks."""
+        task = nidaqmx.Task(**init_kwargs)
+
+        with warnings.catch_warnings(record=True) as warnings_raised:
+            task.__del__()
+            if warnings_raised:
+                pytest.fail()

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -1,6 +1,5 @@
-import gc
-from unittest.mock import Mock
 import warnings
+from unittest.mock import Mock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -166,9 +165,9 @@ def test___close_on_exit_with_grpc_options___leak_task___resource_warning_not_ra
     expect_get_task_name(interpreter, "GrpcTask")
     grpc_options = create_grpc_options(mocker)
     task = Task("GrpcTask", grpc_options=grpc_options)
-    
+
     with warnings.catch_warnings(record=True) as warnings_raised:
         task.__del__()
-    
+
     assert len(warnings_raised) == 0
     task.close()

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -165,12 +165,10 @@ def test___close_on_exit_with_grpc_options___leak_task___resource_warning_not_ra
     expect_create_task(interpreter, "GrpcTaskHandle")
     expect_get_task_name(interpreter, "GrpcTask")
     grpc_options = create_grpc_options(mocker)
-
     task = Task("GrpcTask", grpc_options=grpc_options)
-
+    
     with warnings.catch_warnings(record=True) as warnings_raised:
         task.__del__()
     
     assert len(warnings_raised) == 0
-
     task.close()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Added a condition in `__del__` method in `task.py` to not to throw Resource warning for grpc task.
- Updated `test_resource_warnings.py` to test the no warning case for grpc.

### Why should this Pull Request be merged?
This PR fixes [Bug 2383312](https://dev.azure.com/ni/DevCentral/_workitems/edit/2383312): nidaqmx-python reports ResourceWarning when detaching from a newly created gRPC task

### What testing has been done?
Ran `poetry run pytest` for `test_resource_warnings.py`