### PR TITLE
tests: Add library_skip, library_xfail, grpc_skip, and grpc_xfail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,12 @@ filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
 markers = [
   # Defines custom markers used by nidaqmx tests. Prevents PytestUnknownMarkWarning.
-  "library_only: tests only the library interpreter implementation.",
-  "grpc_only: tests only the grpc interpreter implementation.",
+  "library_only: run the test with only the library interpreter implementation.",
+  "library_skip(reason=None): skip the given test function with the library interpreter implementation.",
+  "library_xfail(condition, ..., *, reason=..., run=True, raises=None, strict=xfail_strict): mark the test function as an expected failure with the library interpreter implementation.",
+  "grpc_only: run the test with only the gRPC interpreter implementation.",
+  "grpc_skip(reason=None): skip the given test function with the gRPC interpreter implementation.",
+  "grpc_xfail(condition, ..., *, reason=..., run=True, raises=None, strict=xfail_strict): mark the test function as an expected failure with the gRPC interpreter implementation.",
   "new_task_name: name of the new task to be created.",
   "device_name: name of the device used for testing.",
   "task_name: the existing task name to be used for testing.",

--- a/tests/component/test_device_properties.py
+++ b/tests/component/test_device_properties.py
@@ -71,7 +71,7 @@ def test___device___list_of_float_property___returns_value(device):
     assert ai_bridge_ranges == [-0.025, 0.025, -0.1, 0.1]
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395661: Attributes with bitfield enum are listed under the wrong type in DAQmx proto file."
 )
 @pytest.mark.device_name("bridgeTester")

--- a/tests/component/test_read_properties.py
+++ b/tests/component/test_read_properties.py
@@ -120,14 +120,14 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
     assert not ai_task.in_stream.logging_pause
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path == ""
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
@@ -136,7 +136,7 @@ def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task)
     assert ai_task.in_stream.logging_file_path == "TestData.tdms"
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device."
 )
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):

--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -194,8 +194,9 @@ def test___done_and_every_n_samples_events_registered___run_multiple_finite_acqu
     assert len(every_n_samples_event_observer.events) == num_acquisitions * every_n_event_count
 
 
-@pytest.mark.xfail(reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx")
-@pytest.mark.library_only  # Test hangs with gRPC
+@pytest.mark.grpc_xfail(
+    reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx", run=False
+)
 def test___ai_task____run_multiple_finite_acquisitions_with_varying_every_n_samples_event_interval___callbacks_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -228,7 +229,7 @@ def test___ai_task____run_multiple_finite_acquisitions_with_varying_every_n_samp
     ] == every_n_samples_event_counts
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___done_event_registered___register_done_event___already_registered_error_raised(
@@ -246,7 +247,7 @@ def test___done_event_registered___register_done_event___already_registered_erro
     assert exc_info.value.error_code == DAQmxErrors.DONE_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___every_n_samples_acquired_into_buffer_event_registered___register_every_n_samples_acquired_into_buffer_event___already_registered_error_raised(
@@ -271,7 +272,7 @@ def test___every_n_samples_acquired_into_buffer_event_registered___register_ever
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___every_n_samples_transferred_from_buffer_event_registered___register_every_n_samples_transferred_from_buffer_event___already_registered_error_raised(
@@ -296,7 +297,7 @@ def test___every_n_samples_transferred_from_buffer_event_registered___register_e
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___signal_event_registered___register_signal_event___already_registered_error_raised(
@@ -314,7 +315,7 @@ def test___signal_event_registered___register_signal_event___already_registered_
     assert exc_info.value.error_code == DAQmxErrors.SIGNAL_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
@@ -336,7 +337,7 @@ def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_dev
     )
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
 )
 def test___ao_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
@@ -358,7 +359,9 @@ def test___ao_task___register_wrong_every_n_samples_event___not_supported_by_dev
     )
 
 
-@pytest.mark.xfail(reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx")
+@pytest.mark.grpc_xfail(
+    reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx"
+)
 def test___task___register_unregister_done_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -371,7 +374,9 @@ def test___task___register_unregister_done_event___callback_not_invoked(
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.xfail(reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx")
+@pytest.mark.grpc_xfail(
+    reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx"
+)
 def test___task___register_unregister_every_n_samples_acquired_into_buffer_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -386,7 +391,9 @@ def test___task___register_unregister_every_n_samples_acquired_into_buffer_event
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.xfail(reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx")
+@pytest.mark.grpc_xfail(
+    reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx"
+)
 def test___task___register_unregister_every_n_samples_transferred_from_buffer_event___callback_not_invoked(
     ao_task: nidaqmx.Task,
 ) -> None:
@@ -401,7 +408,9 @@ def test___task___register_unregister_every_n_samples_transferred_from_buffer_ev
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.xfail(reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx")
+@pytest.mark.grpc_xfail(
+    reason="AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx"
+)
 def test___task___register_unregister_signal_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:

--- a/tests/component/test_write_properties.py
+++ b/tests/component/test_write_properties.py
@@ -84,7 +84,7 @@ def test___ao_current_task___get_bool_property___returns_default_value(task, dev
     assert not task.out_stream.open_current_loop_chans_exist
 
 
-@pytest.mark.xfail(
+@pytest.mark.grpc_xfail(
     reason="AB#2393824: DAQmx read/write status properties return errors when called from C, Python, or grpc-device."
 )
 @pytest.mark.device_name("aoTester")


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add custom markers `library_skip`, `library_xfail`, `grpc_skip`, and `grpc_xfail`. This allows us to skip or xfail a test when using the gRPC interpreter without affecting its behavior when using the library interpreter, and vice versa.

Update tests to use the new markers as appropriate.

### Why should this Pull Request be merged?

More accurately describe the state of the tests.

Reduce number of XPASS results.

### What testing has been done?

Ran `poetry run pytest -v` and verified that there were no XPASS results.