### PR TITLE
codegen: Report gRPC event registration errors

### DIFF
--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -49,38 +49,41 @@ class GrpcStubInterpreter(BaseInterpreter):
         try:
             response = func(request, metadata=metadata)
         except grpc.RpcError as rpc_error:
-            error_message = rpc_error.details()
-            error_code = None
-            samps_per_chan_read = None
-            samps_per_chan_written = None
-            for entry in rpc_error.trailing_metadata() or []:
-                if entry.key == 'ni-error':
-                    try:
-                        error_code = int(typing.cast(str, entry.value))
-                    except ValueError:
-                        error_message += f'\nError status: {entry.value}'
-                elif entry.key == "ni-samps-per-chan-read":
-                    try:
-                        samps_per_chan_read = int(typing.cast(str, entry.value))
-                    except ValueError:
-                        error_message += f'\nSamples per channel read: {entry.value}'
-                elif entry.key == "ni-samps-per-chan-written":
-                    try:
-                        samps_per_chan_written = int(typing.cast(str, entry.value))
-                    except ValueError:
-                        error_message += f'\nSamples per channel written: {entry.value}'
-            grpc_error = rpc_error.code()
-            if grpc_error == grpc.StatusCode.UNAVAILABLE:
-                error_message = 'Failed to connect to server'
-            elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
-                error_message = (
-                    'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'
-                )
-            if error_code is None:
-                raise errors.RpcError(grpc_error, error_message) from None
-            else:
-                self._raise_error(error_code, error_message, samps_per_chan_written, samps_per_chan_read)
+            self._handle_rpc_error(rpc_error)
         return response
+
+    def _handle_rpc_error(self, rpc_error):
+        error_message = rpc_error.details()
+        error_code = None
+        samps_per_chan_read = None
+        samps_per_chan_written = None
+        for entry in rpc_error.trailing_metadata() or []:
+            if entry.key == 'ni-error':
+                try:
+                    error_code = int(typing.cast(str, entry.value))
+                except ValueError:
+                    error_message += f'\nError status: {entry.value}'
+            elif entry.key == "ni-samps-per-chan-read":
+                try:
+                    samps_per_chan_read = int(typing.cast(str, entry.value))
+                except ValueError:
+                    error_message += f'\nSamples per channel read: {entry.value}'
+            elif entry.key == "ni-samps-per-chan-written":
+                try:
+                    samps_per_chan_written = int(typing.cast(str, entry.value))
+                except ValueError:
+                    error_message += f'\nSamples per channel written: {entry.value}'
+        grpc_error = rpc_error.code()
+        if grpc_error == grpc.StatusCode.UNAVAILABLE:
+            error_message = 'Failed to connect to server'
+        elif grpc_error == grpc.StatusCode.UNIMPLEMENTED:
+            error_message = (
+                'This operation is not supported by the NI gRPC Device Server being used. Upgrade NI gRPC Device Server.'
+            )
+        if error_code is None:
+            raise errors.RpcError(grpc_error, error_message) from None
+        else:
+            self._raise_error(error_code, error_message, samps_per_chan_written, samps_per_chan_read)
 
     def _raise_error(self, error_code, error_message, samps_per_chan_written=None, samps_per_chan_read=None):
         if error_code < 0:
@@ -107,7 +110,23 @@ class GrpcStubInterpreter(BaseInterpreter):
         except ValueError:
             error_message = f'\nError status: {value}'
         return error_code, error_message
-    
+
+    def _check_for_event_registration_error(self, event_stream):
+        try:
+            # Wait for initial metadata to ensure that the server has received the event
+            # registration request and called the event registration function. Otherwise,
+            # there is no guarantee that the event registration function is called before
+            # the application sends the next RPC request (e.g. start_task).
+            _ = event_stream.initial_metadata()
+
+            # When the event registration function returns an error, the server should close
+            # the event stream with an error before sending initial metadata. This behavior
+            # requires NI gRPC Device Server version 2.2 or later.
+            if event_stream.done() and event_stream.exception() is not None:
+                raise event_stream.exception()
+        except grpc.RpcError as rpc_error:
+            self._handle_rpc_error(rpc_error)
+
     def _unregister_done_event_callbacks(self):
         if self._done_event_thread is not None:
             self._done_event_stream.cancel()

--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -229,9 +229,7 @@ def test___ai_task____run_multiple_finite_acquisitions_with_varying_every_n_samp
     ] == every_n_samples_event_counts
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___done_event_registered___register_done_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -247,9 +245,7 @@ def test___done_event_registered___register_done_event___already_registered_erro
     assert exc_info.value.error_code == DAQmxErrors.DONE_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___every_n_samples_acquired_into_buffer_event_registered___register_every_n_samples_acquired_into_buffer_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -272,9 +268,7 @@ def test___every_n_samples_acquired_into_buffer_event_registered___register_ever
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___every_n_samples_transferred_from_buffer_event_registered___register_every_n_samples_transferred_from_buffer_event___already_registered_error_raised(
     ao_task: nidaqmx.Task,
 ) -> None:
@@ -297,9 +291,7 @@ def test___every_n_samples_transferred_from_buffer_event_registered___register_e
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___signal_event_registered___register_signal_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -315,9 +307,7 @@ def test___signal_event_registered___register_signal_event___already_registered_
     assert exc_info.value.error_code == DAQmxErrors.SIGNAL_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -337,9 +327,7 @@ def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_dev
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2395958: GrpcStubInterpreter does not report event registration errors to caller"
-)
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___ao_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
     ao_task: nidaqmx.Task,
 ) -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `GrpcStubInterpreter` event registration codegen to check for event registration errors.

Reorder event registration function so that the event registration error reported by the server takes precedence over the double-registration error generated by the interpreter class.

### Why should this Pull Request be merged?

Fixes AB#2395958: GrpcStubInterpreter does not report event registration errors to caller

### What testing has been done?

Affected test cases now pass with a build of NI gRPC Device Server that includes this fix:
https://github.com/ni/grpc-device/pull/927