### PR TITLE
codegen: Delete an unused GrpcStubInterpreter method

### DIFF
--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -95,16 +95,6 @@ class GrpcStubInterpreter(BaseInterpreter):
                     error_message = 'Failed to retrieve error description.'
             warnings.warn(errors.DaqWarning(error_message, error_code))
 
-    def _get_integer_value_from_grpc_string(self, entry_value):
-        value = entry_value if isinstance(entry_value, str) else entry_value.decode('utf-8')
-        error_code = None
-        error_message = None
-        try:
-            error_code = int(value)
-        except ValueError:
-            error_message = f'\nError status: {value}'
-        return error_code, error_message
-
     def _check_for_event_registration_error(self, event_stream):
         try:
             # Wait for initial metadata to ensure that the server has received the event

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -109,16 +109,6 @@ class GrpcStubInterpreter(BaseInterpreter):
                     error_message = 'Failed to retrieve error description.'
             warnings.warn(errors.DaqWarning(error_message, error_code))
 
-    def _get_integer_value_from_grpc_string(self, entry_value):
-        value = entry_value if isinstance(entry_value, str) else entry_value.decode('utf-8')
-        error_code = None
-        error_message = None
-        try:
-            error_code = int(value)
-        except ValueError:
-            error_message = f'\nError status: {value}'
-        return error_code, error_message
-
     def _check_for_event_registration_error(self, event_stream):
         try:
             # Wait for initial metadata to ensure that the server has received the event


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Delete `GrpcStubInterpreter._get_integer_value_from_grpc_string()`.

### Why should this Pull Request be merged?

It's never called. The code was inlined into `_handle_rpc_error()`.

I found this by viewing the HTML report of coverage data.

### What testing has been done?

`poetry run pytest -v -k grpc`