### PR TITLE
tests: Add component tests for load_task() and markers to specify grpc_options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ markers = [
   "task_name: the existing task name to be used for testing.",
   "channel_name: the existing channel name to be used for testing.",
   "scale_name: the existing scale name to be used for testing.",
-  "timeout: the timeout in seconds."
+  "timeout: the timeout in seconds.",
+  "grpc_session_name: specifies GrpcSessionOptions.session_name.",
+  "grpc_session_initialization_behavior: specifies GrpcSessionOptions.initialization_behavior."
 ]
 
 [build-system]

--- a/tests/component/system/storage/test_persisted_task_properties.py
+++ b/tests/component/system/storage/test_persisted_task_properties.py
@@ -1,6 +1,11 @@
 import pytest
 
 from nidaqmx import DaqError
+from nidaqmx.constants import (
+    AcquisitionType,
+    TerminalConfiguration,
+    UsageTypeAI,
+)
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system.storage import PersistedTask
 
@@ -23,10 +28,54 @@ def test___nonexistent_persisted_task___get_property___raises_task_not_in_data_n
 
 
 @pytest.mark.task_name("VoltageTesterTask")
-def test___persisted_task___get_bool_property___returns_persisted_value(persisted_task):
+def test___persisted_task___get_bool_property___returns_persisted_value(
+    persisted_task: PersistedTask,
+):
     assert persisted_task.allow_interactive_editing
 
 
 @pytest.mark.task_name("VoltageTesterTask")
-def test___persisted_scale___get_string_property___returns_persisted_value(persisted_task):
+def test___persisted_task___get_string_property___returns_persisted_value(
+    persisted_task: PersistedTask,
+):
     assert persisted_task.author == "Test Author"
+
+
+@pytest.mark.task_name("VoltageTesterTask")
+def test___persisted_task___load_and_get_channel_properties___returns_persisted_values(
+    persisted_task: PersistedTask,
+):
+    with persisted_task.load() as task:
+        ai_meas_type = task.ai_channels[0].ai_meas_type
+        ai_term_cfg = task.ai_channels[0].ai_term_cfg
+        ai_max = task.ai_channels[0].ai_max
+
+    assert ai_meas_type == UsageTypeAI.VOLTAGE
+    assert ai_term_cfg == TerminalConfiguration.DIFF
+    assert ai_max == 10.0
+
+
+@pytest.mark.task_name("VoltageTesterTask")
+def test___persisted_task___load_and_get_task_properties___returns_persisted_values(
+    persisted_task: PersistedTask,
+):
+    with persisted_task.load() as task:
+        channel_names = task.channel_names
+
+    assert channel_names == ["Voltage_0"]
+
+
+# Don't test samp_clk_src because it requires reserving the task and returns a coerced value,
+# not the persisted value.
+@pytest.mark.task_name("VoltageTesterTask")
+def test___persisted_task___load_and_get_timing_properties___returns_persisted_values(
+    persisted_task: PersistedTask,
+):
+    with persisted_task.load() as task:
+        samp_clk_rate = task.timing.samp_clk_rate
+        samp_quant_samp_mode = task.timing.samp_quant_samp_mode
+        samp_quant_samp_per_chan = task.timing.samp_quant_samp_per_chan
+
+    assert samp_clk_rate == 1000.0
+    assert samp_quant_samp_mode == AcquisitionType.FINITE
+    assert samp_quant_samp_per_chan == 100


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add component tests for `PersistedTask.load()` (a.k.a. `load_task()`).

Add markers to specify grpc_options:
- `grpc_session_name`
- `grpc_session_initialization_behavior`

Set scope=function for init_kwargs and everything that depends on it in order to allow test functions to control grpc_options.

### Why should this Pull Request be merged?

The interpreter's `load_task` method has no test coverage, and I wanted to understand how it behaves with respect to gRPC session initialization behavior.

### What testing has been done?

Ran `poetry run pytest -v`.