### PR TITLE
handwritten: Remove a Python 2.x compatibility check

### DIFF
--- a/generated/nidaqmx/_lib.py
+++ b/generated/nidaqmx/_lib.py
@@ -57,11 +57,6 @@ def wrapped_ndpointer(*args, **kwargs):
 
     Taken from http://stackoverflow.com/questions/32120178
     """
-    if sys.version_info < (3,):
-        if 'flags' in kwargs:
-            kwargs['flags'] = tuple(
-                f.encode('ascii') for f in kwargs['flags'])
-
     base = ndpointer(*args, **kwargs)
 
     def from_param(cls, obj):

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -57,11 +57,6 @@ def wrapped_ndpointer(*args, **kwargs):
 
     Taken from http://stackoverflow.com/questions/32120178
     """
-    if sys.version_info < (3,):
-        if 'flags' in kwargs:
-            kwargs['flags'] = tuple(
-                f.encode('ascii') for f in kwargs['flags'])
-
     base = ndpointer(*args, **kwargs)
 
     def from_param(cls, obj):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove a Python 2.x compatibility check from `_lib.py`

### Why should this Pull Request be merged?

nidaqmx-python no longer supports Python 2.x.

### What testing has been done?

Ran `poetry run pytest -v`