### PR TITLE
tests: Fix Tox failures

### DIFF
--- a/tests/acceptance/test_multi_threading.py
+++ b/tests/acceptance/test_multi_threading.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import random
+import sys
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -46,7 +47,7 @@ def test___single_task___get_set_float_properties___no_errors(
 
     start_barrier.wait(timeout=TIMEOUT)
     time.sleep(RUN_TIME)
-    stop_semaphore.release(2)
+    _release_n(stop_semaphore, num_channels)
 
     concurrent.futures.wait(futures)
     _check_for_exceptions(futures)
@@ -88,7 +89,7 @@ def test___single_task___get_set_float_and_string_properties___no_errors(
 
     start_barrier.wait(timeout=TIMEOUT)
     time.sleep(RUN_TIME)
-    stop_semaphore.release(2)
+    _release_n(stop_semaphore, num_channels)
 
     concurrent.futures.wait(futures)
     _check_for_exceptions(futures)
@@ -135,7 +136,7 @@ def test___multiple_tasks___get_set_float_and_string_properties___no_errors(
 
     start_barrier.wait(timeout=TIMEOUT)
     time.sleep(RUN_TIME)
-    stop_semaphore.release(len(futures))
+    _release_n(stop_semaphore, num_tasks)
 
     concurrent.futures.wait(futures)
     _check_for_exceptions(futures)
@@ -158,3 +159,11 @@ def _get_set_property_thread_main(
 def _check_for_exceptions(futures: Sequence[Future]) -> None:
     for future in futures:
         _ = future.result()
+
+
+def _release_n(semaphore: Semaphore, n: int) -> None:
+    if sys.version_info < (3, 9):
+        for i in range(n):
+            semaphore.release()
+    else:
+        semaphore.release(n)

--- a/tests/component/system/storage/test_persisted_task.py
+++ b/tests/component/system/storage/test_persisted_task.py
@@ -1,4 +1,3 @@
-import grpc
 import pytest
 
 from nidaqmx import DaqError, SessionInitializationBehavior
@@ -84,6 +83,7 @@ def test___grpc_session_initializaton_behavior_auto___load_twice___returns_multi
 def test___grpc_session_initialization_behavior_initialize_server_session___load_twice___raises_duplicate_task(
     persisted_task: PersistedTask,
 ):
+    import grpc
     with persisted_task.load():
         with pytest.raises(RpcError) as exc_info:
             with persisted_task.load():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -413,6 +413,11 @@ def _get_marker_value(request, marker_name, default=None):
 
 @pytest.fixture(scope="function")
 def thread_pool_executor() -> Generator[ThreadPoolExecutor, None, None]:
-    """Creates a thread pool executor."""
+    """Creates a thread pool executor.
+
+    When the test completes, this fixture shuts down the thread pool executor. If any futures are
+    still running at this time, shutting down the thread pool executor will wait for them to
+    complete.
+    """
     with ThreadPoolExecutor() as executor:
         yield executor


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix a hang in `tests/acceptance/test_multi_threading.py` with Python 3.7 or 3.8. The ability to pass a count to `Semaphore.release()` was added in Python 3.9.

Fix an `import grpc` when testing without the `grpc` extra installed.

### Why should this Pull Request be merged?

Make tests pass in all Tox configurations.

### What testing has been done?

`poetry run tox` (still running...)