### PR TITLE
pyproject.toml: Exclude .tox when running lint tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,10 @@ tox = "^3.24"
 
 [tool.black]
 line-length = 100
-extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates"
+extend_exclude = ".tox,docs,generated,src/codegen/metadata,src/codegen/templates"
 
 [tool.ni-python-styleguide]
-extend_exclude = "docs,generated,src/codegen/metadata,src/codegen/templates,src/handwritten"
+extend_exclude = ".tox,docs,generated,src/codegen/metadata,src/codegen/templates,src/handwritten"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --strict-markers"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `.tox` to the exclude list for `black` and `ni-python-styleguide`

### Why should this Pull Request be merged?

Running `ni-python-styleguide` on multiple Tox virtualenvs takes a long time.

### What testing has been done?

Ran `poetry run tox` and `poetry run ni-python-styleguide fix`