### PR TITLE
fix: update tests to also run with grpc options

### DIFF
--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3541,7 +3541,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         response = self._invoke(
             self._client.WriteToTEDSFromArray,
             grpc_types.WriteToTEDSFromArrayRequest(
-                physical_channel=physical_channel, bit_stream=bit_stream.tobytes(),
+                physical_channel=physical_channel, bit_stream=bit_stream,
                 basic_teds_options_raw=basic_teds_options))
 
     def write_to_teds_from_file(

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3541,7 +3541,7 @@ class GrpcStubInterpreter(BaseInterpreter):
         response = self._invoke(
             self._client.WriteToTEDSFromArray,
             grpc_types.WriteToTEDSFromArrayRequest(
-                physical_channel=physical_channel, bit_stream=bit_stream,
+                physical_channel=physical_channel, bit_stream=bit_stream.tobytes(),
                 basic_teds_options_raw=basic_teds_options))
 
     def write_to_teds_from_file(

--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -15,7 +15,9 @@ EXAMPLE_PATHS = [p for p in EXAMPLES_DIRECTORY.glob("**/*.py") if p.name != "__i
 
 
 @pytest.mark.parametrize("example_path", EXAMPLE_PATHS)
+@pytest.mark.library_only
 def test___shipping_example___run___no_errors(example_path: Path, system):
+    # This test runs the example programs, which do not support gRPC. Hence this test is marked library_only
     example_source = example_path.read_text()
     for device_name in _find_device_names(example_source):
         if device_name not in system.devices:

--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -15,13 +15,12 @@ EXAMPLE_PATHS = [p for p in EXAMPLES_DIRECTORY.glob("**/*.py") if p.name != "__i
 
 
 @pytest.mark.parametrize("example_path", EXAMPLE_PATHS)
-def test___shipping_example___run___no_errors(example_path: Path):
-    local_system = nidaqmx.system.System.local()
+def test___shipping_example___run___no_errors(example_path: Path, system):
     example_source = example_path.read_text()
     for device_name in _find_device_names(example_source):
-        if device_name not in local_system.devices:
+        if device_name not in system.devices:
             pytest.skip(f"Cannot find device {device_name}.")
-        device = local_system.devices[device_name]
+        device = system.devices[device_name]
         for physical_channel_name in _find_physical_channel_names(example_source, device_name):
             if not _has_physical_channel(device, physical_channel_name):
                 pytest.skip(

--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -17,7 +17,8 @@ EXAMPLE_PATHS = [p for p in EXAMPLES_DIRECTORY.glob("**/*.py") if p.name != "__i
 @pytest.mark.parametrize("example_path", EXAMPLE_PATHS)
 @pytest.mark.library_only
 def test___shipping_example___run___no_errors(example_path: Path, system):
-    # This test runs the example programs, which do not support gRPC. Hence this test is marked library_only
+    # This test runs the example programs, which do not support gRPC.
+    # Hence this test is marked library_only.
     example_source = example_path.read_text()
     for device_name in _find_device_names(example_source):
         if device_name not in system.devices:

--- a/tests/legacy/test_multi_threading.py
+++ b/tests/legacy/test_multi_threading.py
@@ -43,7 +43,7 @@ class TestMultiThreadedReads:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_multi_threaded_analog_read(self, multi_threading_test_devices, seed):
+    def test_multi_threaded_analog_read(self, multi_threading_test_devices, seed, init_kwargs):
         """Test for validating multi-thread read operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -63,7 +63,7 @@ class TestMultiThreadedReads:
             for channel_to_test in channels_to_test:
                 task = None
                 try:
-                    task = nidaqmx.Task()
+                    task = nidaqmx.Task(**init_kwargs)
                     task.ai_channels.add_ai_voltage_chan(
                         channel_to_test.name, max_val=10, min_val=-10
                     )

--- a/tests/legacy/test_power_up_states.py
+++ b/tests/legacy/test_power_up_states.py
@@ -1,6 +1,4 @@
 """Tests for validating power up states functions."""
-import nidaqmx
-import nidaqmx.system
 from nidaqmx.constants import PowerUpStates
 from nidaqmx.system.system import DOPowerUpState
 

--- a/tests/legacy/test_power_up_states.py
+++ b/tests/legacy/test_power_up_states.py
@@ -11,13 +11,11 @@ class TestPowerUpStates:
     This validate the power up states functions in the Python NI-DAQmx API.
     """
 
-    def test_digital_power_up_states(self, real_x_series_device):
+    def test_digital_power_up_states(self, real_x_series_device, system):
         """Test for validating digital power up states."""
         # The power up state for digital lines for an X Series device has to
         # be set for the whole port.
         do_port = real_x_series_device.do_ports[0].name
-
-        system = nidaqmx.system.System.local()
 
         # Set power up state for whole port.
         state_to_set = DOPowerUpState(physical_channel=do_port, power_up_state=PowerUpStates.LOW)

--- a/tests/legacy/test_watchdog.py
+++ b/tests/legacy/test_watchdog.py
@@ -18,57 +18,59 @@ class TestWatchdog:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_watchdog_task(self, real_x_series_device, seed):
+    def test_watchdog_task(self, real_x_series_device, seed, generate_watchdog_task):
         """Test to validate watchdog task."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_line = random.choice(real_x_series_device.do_lines)
 
-        with nidaqmx.system.WatchdogTask(real_x_series_device.name, timeout=0.5) as task:
-            expir_states = [
-                DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
-            ]
+        task = generate_watchdog_task(device_name=real_x_series_device.name)
 
-            task.cfg_watchdog_do_expir_states(expir_states)
-            task.start()
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
 
-            # First, assert that watchdog expires after timeout.
+        task.cfg_watchdog_do_expir_states(expir_states)
+        task.start()
+
+        # First, assert that watchdog expires after timeout.
+        assert not task.expired
+        time.sleep(1)
+        assert task.expired
+
+        task.clear_expiration()
+        assert not task.expired
+        task.stop()
+
+        # Continually reset the watchdog timer using an interval less
+        # than the timeout and assert that it never expires.
+        task.start()
+        for _ in range(5):
+            task.reset_timer()
+            time.sleep(0.2)
             assert not task.expired
-            time.sleep(1)
-            assert task.expired
 
-            task.clear_expiration()
-            assert not task.expired
-            task.stop()
-
-            # Continually reset the watchdog timer using an interval less
-            # than the timeout and assert that it never expires.
-            task.start()
-            for _ in range(5):
-                task.reset_timer()
-                time.sleep(0.2)
-                assert not task.expired
-
-            task.stop()
+        task.stop()
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_watchdog_expir_state(self, real_x_series_device, seed):
+    def test_watchdog_expir_state(self, real_x_series_device, seed, generate_watchdog_task):
         """Test to validate watchdog expiration state."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         do_line = random.choice(real_x_series_device.do_lines)
 
-        with nidaqmx.system.WatchdogTask(real_x_series_device.name, timeout=0.1) as task:
-            expir_states = [
-                DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
-            ]
+        task = generate_watchdog_task(device_name=real_x_series_device.name, timeout=0.1)
 
-            task.cfg_watchdog_do_expir_states(expir_states)
+        expir_states = [
+            DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
+        ]
 
-            expir_state_obj = task.expiration_states[do_line.name]
-            assert expir_state_obj.do_state == Level.TRISTATE
+        task.cfg_watchdog_do_expir_states(expir_states)
 
-            expir_state_obj.do_state = Level.LOW
-            assert expir_state_obj.do_state == Level.LOW
+        expir_state_obj = task.expiration_states[do_line.name]
+        assert expir_state_obj.do_state == Level.TRISTATE
+
+        expir_state_obj.do_state = Level.LOW
+        assert expir_state_obj.do_state == Level.LOW

--- a/tests/legacy/test_watchdog.py
+++ b/tests/legacy/test_watchdog.py
@@ -4,8 +4,6 @@ import time
 
 import pytest
 
-import nidaqmx
-import nidaqmx.system
 from nidaqmx.constants import Level
 from nidaqmx.system.watchdog import DOExpirationState
 from tests.helpers import generate_random_seed


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the test cases using to use fixtures that passes grpc options as well to cover grpc calls and fixes in those calls. 

### Why should this Pull Request be merged?

To fix the following
- [Bug 2400882](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400882): tests/legacy/test_watchdog.py and tests/legacy/test_power_up_states.py do not test gRPC
- [Bug 2400884](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400884): tests/legacy/test_multi_threading.py does not test gRPC

### What testing has been done?

Test case updates are tested in remote PC.