### PR TITLE
fix: update write teds array grpc call to pass bytes

### DIFF
--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3335,7 +3335,8 @@ class GrpcStubInterpreter(BaseInterpreter):
         response = self._invoke(
             self._client.WriteToTEDSFromArray,
             grpc_types.WriteToTEDSFromArrayRequest(
-                physical_channel=physical_channel, bit_stream=bit_stream,
+                physical_channel=physical_channel,
+                bit_stream=bit_stream.tobytes(),
                 basic_teds_options_raw=basic_teds_options))
 
     def write_to_teds_from_file(

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -326,13 +326,14 @@ def get_grpc_interpreter_call_params(func, params):
             elif param.is_grpc_enum or (param.is_enum and not param.is_list):
                 grpc_params.append(f"{name}_raw={param.parameter_name}")
             else:
-                if is_write_function:
-                    if is_write_bytes_param(param):
-                        grpc_params.append(f"{name}={param.parameter_name}.tobytes()")
-                    else:
-                        grpc_params.append(get_write_array_param(param))
+                if is_write_bytes_param(param):
+                    grpc_params.append(f"{name}={param.parameter_name}.tobytes()")
                 else:
-                    grpc_params.append(f"{name}={param.parameter_name}")
+                    if is_write_function:
+                        grpc_params.append(get_write_array_param(param))
+                    else:
+                        grpc_params.append(f"{name}={param.parameter_name}")
+
     if func.is_init_method:
         grpc_params.append("initialization_behavior=self._grpc_options.initialization_behavior")
     return ", ".join(grpc_params)

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -328,11 +328,10 @@ def get_grpc_interpreter_call_params(func, params):
             else:
                 if is_write_bytes_param(param):
                     grpc_params.append(f"{name}={param.parameter_name}.tobytes()")
+                elif is_write_function:
+                    grpc_params.append(get_write_array_param(param))
                 else:
-                    if is_write_function:
-                        grpc_params.append(get_write_array_param(param))
-                    else:
-                        grpc_params.append(f"{name}={param.parameter_name}")
+                    grpc_params.append(f"{name}={param.parameter_name}")
 
     if func.is_init_method:
         grpc_params.append("initialization_behavior=self._grpc_options.initialization_behavior")

--- a/tests/component/system/test_physical_channel.py
+++ b/tests/component/system/test_physical_channel.py
@@ -1,4 +1,9 @@
+import nidaqmx
+from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import PhysicalChannel
+import pytest
+
+from tests.component.system.test_physical_channel_properties import VALUES_IN_TED
 
 
 def test___physical_channels_with_same_name___compare___equal(init_kwargs):
@@ -37,3 +42,53 @@ def test___physical_channels_with_different_names___hash___not_equal(
 
     assert hash(phys_chan1) != hash(phys_chan2)
     assert hash(phys_chan1) != hash(phys_chan3)
+
+
+def test__physical_channel__write_to_teds_from_array_with_invalid_stream__throws_data_error(
+    any_x_series_device,
+):
+    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+
+    with pytest.raises(nidaqmx.DaqError) as exception:
+        phys_chan.write_to_teds_from_array([1, 2, 3, 4])
+
+    assert exception.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
+
+
+def test__physical_channel__write_to_teds_from_array_with_valid_stream__throws_config_or_detection_error(
+    any_x_series_device,
+):
+    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+
+    with pytest.raises(nidaqmx.DaqError) as exception:
+        phys_chan.write_to_teds_from_array(VALUES_IN_TED)
+
+    assert exception.value.error_code in [
+        DAQmxErrors.CANT_CONFIGURE_TEDS_FOR_CHAN,
+        DAQmxErrors.TEDS_SENSOR_NOT_DETECTED,
+    ]
+
+
+def test__physical_channel__write_to_teds_from_file_with_invalid_file_path__throws_data_error(
+    any_x_series_device,
+):
+    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+
+    with pytest.raises(nidaqmx.DaqError) as exception:
+        phys_chan.write_to_teds_from_file()
+
+    assert exception.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
+
+
+def test__physical_channel__write_to_teds_from_file_with_valid_stream__throws_config_or_detection_error(
+    any_x_series_device, teds_file_path
+):
+    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+
+    with pytest.raises(nidaqmx.DaqError) as exception:
+        phys_chan.write_to_teds_from_file(teds_file_path)
+
+    assert exception.value.error_code in [
+        DAQmxErrors.CANT_CONFIGURE_TEDS_FOR_CHAN,
+        DAQmxErrors.TEDS_SENSOR_NOT_DETECTED,
+    ]

--- a/tests/component/system/test_physical_channel.py
+++ b/tests/component/system/test_physical_channel.py
@@ -44,51 +44,51 @@ def test___physical_channels_with_different_names___hash___not_equal(
     assert hash(phys_chan1) != hash(phys_chan3)
 
 
-def test__physical_channel__write_to_teds_from_array_with_invalid_stream__throws_data_error(
+def test___invalid_bitstream___write_to_teds_from_array___throws_data_error(
     any_x_series_device,
 ):
     phys_chan = any_x_series_device.ai_physical_chans["ai0"]
 
-    with pytest.raises(nidaqmx.DaqError) as exception:
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_array([1, 2, 3, 4])
 
-    assert exception.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
+    assert exc_info.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
 
 
-def test__physical_channel__write_to_teds_from_array_with_valid_stream__throws_config_or_detection_error(
+def test___valid_bitstream___write_to_teds_from_array___throws_config_or_detection_error(
     any_x_series_device,
 ):
     phys_chan = any_x_series_device.ai_physical_chans["ai0"]
 
-    with pytest.raises(nidaqmx.DaqError) as exception:
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_array(VALUES_IN_TED)
 
-    assert exception.value.error_code in [
+    assert exc_info.value.error_code in [
         DAQmxErrors.CANT_CONFIGURE_TEDS_FOR_CHAN,
         DAQmxErrors.TEDS_SENSOR_NOT_DETECTED,
     ]
 
 
-def test__physical_channel__write_to_teds_from_file_with_invalid_file_path__throws_data_error(
+def test___invalid_file_path___write_to_teds_from_file___throws_data_error(
     any_x_series_device,
 ):
     phys_chan = any_x_series_device.ai_physical_chans["ai0"]
 
-    with pytest.raises(nidaqmx.DaqError) as exception:
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_file()
 
-    assert exception.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
+    assert exc_info.value.error_code == DAQmxErrors.TEDS_SENSOR_DATA_ERROR
 
 
-def test__physical_channel__write_to_teds_from_file_with_valid_stream__throws_config_or_detection_error(
+def test___valid_file_path___write_to_teds_from_array___throws_config_or_detection_error(
     any_x_series_device, teds_file_path
 ):
     phys_chan = any_x_series_device.ai_physical_chans["ai0"]
 
-    with pytest.raises(nidaqmx.DaqError) as exception:
-        phys_chan.write_to_teds_from_file(teds_file_path)
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
+        phys_chan.write_to_teds_from_file(str(teds_file_path))
 
-    assert exception.value.error_code in [
+    assert exc_info.value.error_code in [
         DAQmxErrors.CANT_CONFIGURE_TEDS_FOR_CHAN,
         DAQmxErrors.TEDS_SENSOR_NOT_DETECTED,
     ]

--- a/tests/component/system/test_physical_channel.py
+++ b/tests/component/system/test_physical_channel.py
@@ -1,7 +1,8 @@
+import pytest
+
 import nidaqmx
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import PhysicalChannel
-import pytest
 
 from tests.component.system.test_physical_channel_properties import VALUES_IN_TED
 

--- a/tests/component/system/test_physical_channel.py
+++ b/tests/component/system/test_physical_channel.py
@@ -3,7 +3,6 @@ import pytest
 import nidaqmx
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import PhysicalChannel
-
 from tests.component.system.test_physical_channel_properties import VALUES_IN_TED
 
 

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -36,7 +36,7 @@ def test___physical_channel_with_teds___get_bit_stream___returns_configured_valu
     phys_chans = any_x_series_device.ai_physical_chans
     expected_value = numpy.array(VALUES_IN_TED, dtype=numpy.uint8)
 
-    phys_chans["ai0"].configure_teds(teds_file_path)
+    phys_chans["ai0"].configure_teds(str(teds_file_path))
 
     assert (phys_chans["ai0"].teds_bit_stream == expected_value).all()
 
@@ -59,7 +59,7 @@ def test___physical_channel_with_teds___get_string_property___returns_configured
     any_x_series_device, teds_file_path
 ):
     phys_chans = any_x_series_device.ai_physical_chans
-    phys_chans["ai0"].configure_teds(teds_file_path)
+    phys_chans["ai0"].configure_teds(str(teds_file_path))
 
     assert phys_chans["ai0"].teds_version_letter == "A"
 
@@ -68,7 +68,7 @@ def test___physical_channel_with_teds___get_uint32_array_property___returns_conf
     any_x_series_device, teds_file_path
 ):
     phys_chans = any_x_series_device.ai_physical_chans
-    phys_chans["ai0"].configure_teds(teds_file_path)
+    phys_chans["ai0"].configure_teds(str(teds_file_path))
 
     assert phys_chans["ai0"].teds_template_ids == [30]
 
@@ -77,7 +77,7 @@ def test___physical_channel_with_teds___get_uint32_property___returns_configured
     any_x_series_device, teds_file_path
 ):
     phys_chans = any_x_series_device.ai_physical_chans
-    phys_chans["ai0"].configure_teds(teds_file_path)
+    phys_chans["ai0"].configure_teds(str(teds_file_path))
 
     assert phys_chans["ai0"].teds_mfg_id == 17
 

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -82,12 +82,6 @@ def test___physical_channel_with_teds___get_uint32_property___returns_configured
     assert phys_chans["ai0"].teds_mfg_id == 17
 
 
-@pytest.fixture
-def teds_file_path(test_assets_directory):
-    """Returns the ted file path."""
-    return str(test_assets_directory / "teds" / "Voltage.ted")
-
-
 VALUES_IN_TED = [
     17,
     64,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,5 +450,5 @@ def grpc_interpreter_with_errors(grpc_channel_with_errors: grpc.Channel) -> Grpc
 
 @pytest.fixture
 def teds_file_path(test_assets_directory):
-    """Returns the ted file path."""
-    return str(test_assets_directory / "teds" / "Voltage.ted")
+    """Returns a TEDS file path."""
+    return pathlib.Path(test_assets_directory, "teds", "Voltage.ted")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -446,3 +446,9 @@ def grpc_interpreter_with_errors(grpc_channel_with_errors: grpc.Channel) -> Grpc
     """Gets a GrpcStubInterpreter that returns errors for all RPCs."""
     grpc_options = nidaqmx.GrpcSessionOptions(grpc_channel_with_errors, "")
     return GrpcStubInterpreter(grpc_options)
+
+
+@pytest.fixture
+def teds_file_path(test_assets_directory):
+    """Returns the ted file path."""
+    return str(test_assets_directory / "teds" / "Voltage.ted")

--- a/tests/legacy/test_teds.py
+++ b/tests/legacy/test_teds.py
@@ -14,9 +14,7 @@ class TestTEDS:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_teds_ai_voltage_chan(
-        self, task, any_x_series_device, seed, teds_file_path
-    ):
+    def test_create_teds_ai_voltage_chan(self, task, any_x_series_device, seed, teds_file_path):
         """Test to validate TEDS functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)

--- a/tests/legacy/test_teds.py
+++ b/tests/legacy/test_teds.py
@@ -15,7 +15,7 @@ class TestTEDS:
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_create_teds_ai_voltage_chan(
-        self, task, any_x_series_device, seed, test_assets_directory
+        self, task, any_x_series_device, seed, teds_file_path
     ):
         """Test to validate TEDS functionality."""
         # Reset the pseudorandom number generator with seed.
@@ -23,10 +23,7 @@ class TestTEDS:
 
         ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans)
 
-        # Generate path to a virtual TEDS file.
-        teds_file_path = str(test_assets_directory / "teds" / "Voltage.ted")
-
-        ai_phys_chan.configure_teds(teds_file_path)
+        ai_phys_chan.configure_teds(str(teds_file_path))
 
         assert ai_phys_chan.teds_mfg_id == 17
         assert ai_phys_chan.teds_model_num == 1


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix the write_to_teds_array grpc call to pass bytes as expected

### Why should this Pull Request be merged?

To fix - [Bug 2400963](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400963): write_to_teds_with_array() errors with GrpcStubInterpreter

### What testing has been done?

The testing code snippet in the above bug item is run and grpc call throws meaningful error if TEDS is not configured.