### PR TITLE
tests: Add reason= to grpc_only and library_only marks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,11 @@ filterwarnings = ["always::ImportWarning", "always::ResourceWarning"]
 testpaths = ["tests"]
 markers = [
   # Defines custom markers used by nidaqmx tests. Prevents PytestUnknownMarkWarning.
-  "library_only: run the test with only the library interpreter implementation.",
-  "library_skip(reason=None): skip the given test function with the library interpreter implementation.",
+  "library_only(reason=...): run the test with only the library interpreter implementation.",
+  "library_skip(reason=...): skip the given test function with the library interpreter implementation.",
   "library_xfail(condition, ..., *, reason=..., run=True, raises=None, strict=xfail_strict): mark the test function as an expected failure with the library interpreter implementation.",
-  "grpc_only: run the test with only the gRPC interpreter implementation.",
-  "grpc_skip(reason=None): skip the given test function with the gRPC interpreter implementation.",
+  "grpc_only(reason=...): run the test with only the gRPC interpreter implementation.",
+  "grpc_skip(reason=...): skip the given test function with the gRPC interpreter implementation.",
   "grpc_xfail(condition, ..., *, reason=..., run=True, raises=None, strict=xfail_strict): mark the test function as an expected failure with the gRPC interpreter implementation.",
   "new_task_name: name of the new task to be created.",
   "device_name: name of the device used for testing.",

--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -15,10 +15,8 @@ EXAMPLE_PATHS = [p for p in EXAMPLES_DIRECTORY.glob("**/*.py") if p.name != "__i
 
 
 @pytest.mark.parametrize("example_path", EXAMPLE_PATHS)
-@pytest.mark.library_only
+@pytest.mark.library_only(reason="The examples don't support gRPC.")
 def test___shipping_example___run___no_errors(example_path: Path, system):
-    # This test runs the example programs, which do not support gRPC.
-    # Hence this test is marked library_only.
     example_source = example_path.read_text()
     for device_name in _find_device_names(example_source):
         if device_name not in system.devices:

--- a/tests/component/system/storage/test_persisted_task.py
+++ b/tests/component/system/storage/test_persisted_task.py
@@ -49,7 +49,7 @@ def test___persisted_task___load_and_read___returns_persisted_sample_count(
 
 
 @pytest.mark.task_name("VoltageTesterTask")
-@pytest.mark.library_only
+@pytest.mark.library_only(reason="Default gRPC initialization behavior is auto (create or attach)")
 def test___persisted_task___load_twice___raises_duplicate_task(persisted_task: PersistedTask):
     with persisted_task.load():
         with pytest.raises(DaqError) as exc_info:
@@ -60,7 +60,7 @@ def test___persisted_task___load_twice___raises_duplicate_task(persisted_task: P
 
 
 @pytest.mark.task_name("VoltageTesterTask")
-@pytest.mark.grpc_only
+@pytest.mark.grpc_only(reason="Default gRPC initialization behavior is auto (create or attach)")
 @pytest.mark.grpc_session_initialization_behavior(SessionInitializationBehavior.AUTO)
 def test___grpc_session_initializaton_behavior_auto___load_twice___returns_multiple_task_proxies(
     persisted_task: PersistedTask,
@@ -76,7 +76,7 @@ def test___grpc_session_initializaton_behavior_auto___load_twice___returns_multi
 
 
 @pytest.mark.task_name("VoltageTesterTask")
-@pytest.mark.grpc_only
+@pytest.mark.grpc_only(reason="Default gRPC initialization behavior is auto (create or attach)")
 @pytest.mark.grpc_session_initialization_behavior(
     SessionInitializationBehavior.INITIALIZE_SERVER_SESSION
 )

--- a/tests/component/test_interpreter.py
+++ b/tests/component/test_interpreter.py
@@ -20,7 +20,7 @@ def test___unknown_error_code___get_error_string___returns_unable_to_locate_erro
     assert error_message.startswith("Error code could not be found.")
 
 
-@pytest.mark.grpc_only
+@pytest.mark.grpc_only(reason="Tests gRPC-specific error case")
 def test___grpc_interpreter_with_errors___get_error_string___returns_failed_to_retrieve_error_description(
     grpc_interpreter_with_errors: BaseInterpreter,
 ) -> None:

--- a/tests/component/test_task.py
+++ b/tests/component/test_task.py
@@ -4,7 +4,7 @@ import nidaqmx
 from nidaqmx.error_codes import DAQmxErrors
 
 
-@pytest.mark.library_only
+@pytest.mark.library_only(reason="Default gRPC initialization behavior is auto (create or attach)")
 def test___task___create_task_with_same_name___raises_duplicate_task(init_kwargs):
     task1 = nidaqmx.Task("MyTask1", **init_kwargs)
 

--- a/tests/component/test_task_resource_warnings.py
+++ b/tests/component/test_task_resource_warnings.py
@@ -6,7 +6,7 @@ import nidaqmx
 from nidaqmx.errors import DaqResourceWarning
 
 
-@pytest.mark.library_only
+@pytest.mark.library_only(reason="gRPC task allows detaching from task on server")
 def test___unclosed_task___leak_task___resource_warning_raised(task):
     # Since __del__ is not guaranteed to be called, for the purposes of
     # consistent test results call __del__ manually.
@@ -14,7 +14,7 @@ def test___unclosed_task___leak_task___resource_warning_raised(task):
         task.__del__()
 
 
-@pytest.mark.grpc_only
+@pytest.mark.grpc_only(reason="gRPC task allows detaching from task on server")
 def test___grpc_task___leak_task___resource_warning_not_raised(task):
     with warnings.catch_warnings(record=True) as warnings_raised:
         task.__del__()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a `reason=` keyword argument to the `grpc_only` and `library_only` marks.

### Why should this Pull Request be merged?

Encourage developers to document the reason why a test is gRPC-only or library-only.

### What testing has been done?

`poetry run ni-python-styleguide lint`
`poetry run pytest -v`