### PR TITLE
Fix - powerup states with output type

### DIFF
--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -2274,6 +2274,7 @@ class LibraryInterpreter(BaseInterpreter):
             self, channel_names, array_size):
         state_array = numpy.zeros(array_size, dtype=numpy.float64)
         channel_type_array = numpy.zeros(array_size, dtype=numpy.int32)
+        array_size = ctypes.c_uint32(array_size)
 
         cfunc = lib_importer.cdll.DAQmxGetAnalogPowerUpStatesWithOutputType
         if cfunc.argtypes is None:

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -14,7 +14,7 @@ from nidaqmx.system._collections.persisted_task_collection import (
     PersistedTaskCollection)
 from nidaqmx.utils import flatten_channel_string, unflatten_channel_string
 from nidaqmx.constants import (
-    AOPowerUpOutputBehavior, LogicFamily, PowerUpStates, ResistorState,
+    AOPowerUpOutputBehavior, LogicFamily, PowerUpChannelType, PowerUpStates, ResistorState,
     SignalModifiers, WAIT_INFINITELY)
 from nidaqmx.types import (
     AOPowerUpState, CDAQSyncConnection, DOPowerUpState, DOResistorPowerUpState)
@@ -486,7 +486,7 @@ class System:
                 AOPowerUpState(
                     physical_channel=p,
                     power_up_state=float(s),
-                    channel_type=AOPowerUpOutputBehavior(c.value)))
+                    channel_type=PowerUpChannelType(c)))
 
         return power_up_states
 

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -479,6 +479,9 @@ class System:
         """
         states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(
             flatten_channel_string(physical_channels), len(physical_channels))
+        
+        assert len(states) == len(physical_channels)
+        assert len(channel_types) == len(physical_channels)
 
         power_up_states = []
         for p, s, c in zip(physical_channels, states, channel_types):

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -21,7 +21,7 @@ from nidaqmx.system._collections.persisted_task_collection import (
     PersistedTaskCollection)
 from nidaqmx.utils import flatten_channel_string, unflatten_channel_string
 from nidaqmx.constants import (
-    AOPowerUpOutputBehavior, LogicFamily, PowerUpStates, ResistorState,
+    AOPowerUpOutputBehavior, LogicFamily, PowerUpChannelType, PowerUpStates, ResistorState,
     SignalModifiers, WAIT_INFINITELY)
 from nidaqmx.types import (
     AOPowerUpState, CDAQSyncConnection, DOPowerUpState, DOResistorPowerUpState)
@@ -426,7 +426,7 @@ ${function_template.script_function(function_object)}
                 AOPowerUpState(
                     physical_channel=p,
                     power_up_state=float(s),
-                    channel_type=AOPowerUpOutputBehavior(c.value)))
+                    channel_type=PowerUpChannelType(c)))
 
         return power_up_states
 

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -419,6 +419,9 @@ ${function_template.script_function(function_object)}
         """
         states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(
             flatten_channel_string(physical_channels), len(physical_channels))
+        
+        assert len(states) == len(physical_channels)
+        assert len(channel_types) == len(physical_channels)
 
         power_up_states = []
         for p, s, c in zip(physical_channels, states, channel_types):

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -241,6 +241,12 @@ def get_instantiation_lines_for_output(func):
                 )
         else:
             instantiation_lines.append(f"{param.parameter_name} = {param.ctypes_data_type}()")
+    for param in get_interpreter_in_out_params(func):
+        if param.parameter_name == "reserved" or param.parameter_name == "callback_data":
+            continue
+        instantiation_lines.append(
+            f"{param.parameter_name} = {param.ctypes_data_type}({param.parameter_name})"
+        )
     return instantiation_lines
 
 
@@ -392,6 +398,10 @@ def get_interpreter_output_params(func):
 def get_output_params(func):
     """Gets output parameters for the function."""
     return [p for p in func.base_parameters if p.direction == "out"]
+
+
+def get_interpreter_in_out_params(func):
+    return [p for p in get_interpreter_parameters(func) if p.direction == "in" and p.is_pointer]
 
 
 def get_return_values(func):

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -401,7 +401,7 @@ def get_output_params(func):
 
 
 def get_interpreter_in_out_params(func):
-    """Gets the input parameters that are also pointers for the function"""
+    """Gets the input parameters that are also pointers for the function."""
     return [p for p in get_interpreter_parameters(func) if p.direction == "in" and p.is_pointer]
 
 

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -401,6 +401,7 @@ def get_output_params(func):
 
 
 def get_interpreter_in_out_params(func):
+    """Gets the input parameters that are also pointers for the function"""
     return [p for p in get_interpreter_parameters(func) if p.direction == "in" and p.is_pointer]
 
 

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -1,0 +1,12 @@
+from nidaqmx.constants import PowerUpChannelType
+
+
+def test___get_analog_power_up_states___returns_power_up_states(system):
+    channel_names = ["aoTester/ao0", "aoTester/ao1"]
+
+    power_up_states = system.get_analog_power_up_states_with_output_type(channel_names)
+
+    for i in range(len(channel_names)):
+        assert channel_names[i] ==  power_up_states[i].physical_channel
+        assert 0.0 == power_up_states[i].power_up_state
+        assert PowerUpChannelType.CHANNEL_HIGH_IMPEDANCE == power_up_states[i].channel_type

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -1,10 +1,12 @@
 from nidaqmx.constants import PowerUpChannelType
 
 
-def test___get_analog_power_up_states___returns_power_up_states(system):
+def test___get_analog_power_up_states_with_output_type___returns_power_up_states(system):
     channel_names = ["aoTester/ao0", "aoTester/ao1"]
 
     power_up_states = system.get_analog_power_up_states_with_output_type(channel_names)
+
+    assert len(power_up_states) == len(channel_names)
 
     for i in range(len(channel_names)):
         assert channel_names[i] == power_up_states[i].physical_channel

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -7,6 +7,6 @@ def test___get_analog_power_up_states___returns_power_up_states(system):
     power_up_states = system.get_analog_power_up_states_with_output_type(channel_names)
 
     for i in range(len(channel_names)):
-        assert channel_names[i] ==  power_up_states[i].physical_channel
+        assert channel_names[i] == power_up_states[i].physical_channel
         assert 0.0 == power_up_states[i].power_up_state
         assert PowerUpChannelType.CHANNEL_HIGH_IMPEDANCE == power_up_states[i].channel_type

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -7,7 +7,6 @@ def test___get_analog_power_up_states_with_output_type___returns_power_up_states
     power_up_states = system.get_analog_power_up_states_with_output_type(channel_names)
 
     assert len(power_up_states) == len(channel_names)
-
     for i in range(len(channel_names)):
         assert channel_names[i] == power_up_states[i].physical_channel
         assert 0.0 == power_up_states[i].power_up_state


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix get_analog_power_up_states_with_output_type call

- Add ctype cast before C call
- Replace`AOPowerUpOutputBehavior` with`PowerUpChannelType` to cast to the ChannelType enum to frame the PowerUpStates

### Why should this Pull Request be merged?

To Fix: [Bug 2400896](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400896): get_analog_power_up_states_with_output_type() returns errors with both LibraryInterpreter and GrpcStubInterpreter

### What testing has been done?

Added the testing code shared as part of the above bug as separate test case