### PR TITLE
handwritten: Fix interpreter sharing and add missing `name` properties

### DIFF
--- a/generated/nidaqmx/system/_collections/physical_channel_collection.py
+++ b/generated/nidaqmx/system/_collections/physical_channel_collection.py
@@ -61,7 +61,7 @@ class PhysicalChannelCollection(Sequence):
         elif isinstance(index, slice):
             return _PhysicalChannelAlternateConstructor(self.channel_names[index], self._interpreter)
         elif isinstance(index, str):
-            return PhysicalChannel(f'{self._name}/{index}')
+            return _PhysicalChannelAlternateConstructor(f'{self._name}/{index}', self._interpreter)
         else:
             raise DaqError(
                 'Invalid index type "{}" used to access collection.'
@@ -91,7 +91,7 @@ class PhysicalChannelCollection(Sequence):
             physical channel object that represents the entire list of
             physical channels on this channel collection.
         """
-        return PhysicalChannel(flatten_channel_string(self.channel_names))
+        return _PhysicalChannelAlternateConstructor(flatten_channel_string(self.channel_names), self._interpreter)
 
     @property
     def channel_names(self):

--- a/generated/nidaqmx/system/storage/persisted_channel.py
+++ b/generated/nidaqmx/system/storage/persisted_channel.py
@@ -38,6 +38,13 @@ class PersistedChannel:
         return f'PersistedChannel(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the global channel.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the global channel.

--- a/generated/nidaqmx/system/storage/persisted_scale.py
+++ b/generated/nidaqmx/system/storage/persisted_scale.py
@@ -39,6 +39,13 @@ class PersistedScale:
         return f'PersistedScale(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the custom scale.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the custom scale.

--- a/generated/nidaqmx/system/storage/persisted_task.py
+++ b/generated/nidaqmx/system/storage/persisted_task.py
@@ -39,6 +39,13 @@ class PersistedTask:
         return f'PersistedTask(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the task.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the task.

--- a/src/handwritten/system/_collections/physical_channel_collection.py
+++ b/src/handwritten/system/_collections/physical_channel_collection.py
@@ -61,7 +61,7 @@ class PhysicalChannelCollection(Sequence):
         elif isinstance(index, slice):
             return _PhysicalChannelAlternateConstructor(self.channel_names[index], self._interpreter)
         elif isinstance(index, str):
-            return PhysicalChannel(f'{self._name}/{index}')
+            return _PhysicalChannelAlternateConstructor(f'{self._name}/{index}', self._interpreter)
         else:
             raise DaqError(
                 'Invalid index type "{}" used to access collection.'
@@ -91,7 +91,7 @@ class PhysicalChannelCollection(Sequence):
             physical channel object that represents the entire list of
             physical channels on this channel collection.
         """
-        return PhysicalChannel(flatten_channel_string(self.channel_names))
+        return _PhysicalChannelAlternateConstructor(flatten_channel_string(self.channel_names), self._interpreter)
 
     @property
     def channel_names(self):

--- a/src/handwritten/system/storage/persisted_channel.py
+++ b/src/handwritten/system/storage/persisted_channel.py
@@ -38,6 +38,13 @@ class PersistedChannel:
         return f'PersistedChannel(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the global channel.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the global channel.

--- a/src/handwritten/system/storage/persisted_scale.py
+++ b/src/handwritten/system/storage/persisted_scale.py
@@ -39,6 +39,13 @@ class PersistedScale:
         return f'PersistedScale(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the custom scale.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the custom scale.

--- a/src/handwritten/system/storage/persisted_task.py
+++ b/src/handwritten/system/storage/persisted_task.py
@@ -39,6 +39,13 @@ class PersistedTask:
         return f'PersistedTask(name={self._name})'
 
     @property
+    def name(self):
+        """
+        str: Indicates the name of the task.
+        """
+        return self._name
+
+    @property
     def author(self):
         """
         str: Indicates the author of the task.

--- a/tests/component/system/_collections/__init__.py
+++ b/tests/component/system/_collections/__init__.py
@@ -1,0 +1,1 @@
+"""Component tests for nidaqmx.system.storage._collecitons.*."""

--- a/tests/component/system/_collections/test_device_collection.py
+++ b/tests/component/system/_collections/test_device_collection.py
@@ -1,0 +1,66 @@
+import pytest
+
+from nidaqmx.system import System
+
+
+def test___devices___getitem_int___forward_order(system: System):
+    devices = [system.devices[i] for i in range(len(system.devices))]
+
+    assert [dev.name for dev in devices] == system.devices.device_names
+
+
+def test___devices___getitem_int___interpreter_shared(system: System):
+    devices = [system.devices[i] for i in range(len(system.devices))]
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)
+
+
+def test___devices___getitem_slice___forward_order(system: System):
+    devices = system.devices[:]
+
+    assert [dev.name for dev in devices] == system.devices.device_names
+
+
+def test___devices___getitem_slice___interpreter_shared(system: System):
+    devices = system.devices[:]
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)
+
+
+def test___devices___getitem_str___interpreter_shared(system: System):
+    devices = [system.devices[name] for name in system.devices.device_names]
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)
+
+
+def test___devices___getitem_str_list___interpreter_shared(system: System):
+    if len(system.devices) < 2:
+        pytest.skip("This test requires two or more devices.")
+
+    devices = system.devices[",".join(system.devices.device_names)]
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)
+
+
+def test___devices___iter___forward_order(system: System):
+    devices = iter(system.devices)
+
+    assert [dev.name for dev in devices] == system.devices.device_names
+
+
+def test___devices___iter___interpreter_shared(system: System):
+    devices = iter(system.devices)
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)
+
+
+def test___devices___reversed___reverse_order(system: System):
+    devices = reversed(system.devices)
+
+    assert [dev.name for dev in devices] == list(reversed(system.devices.device_names))
+
+
+def test___devices___reversed___interpreter_shared(system: System):
+    devices = reversed(system.devices)
+
+    assert all(dev._interpreter is system._interpreter for dev in devices)

--- a/tests/component/system/_collections/test_persisted_channel_collection.py
+++ b/tests/component/system/_collections/test_persisted_channel_collection.py
@@ -1,0 +1,70 @@
+import pytest
+
+from nidaqmx.system import System
+
+
+def test___global_channels___getitem_int___forward_order(system: System):
+    channels = [system.global_channels[i] for i in range(len(system.global_channels))]
+
+    assert [chan.name for chan in channels] == system.global_channels.global_channel_names
+
+
+def test___global_channels___getitem_int___interpreter_shared(system: System):
+    channels = [system.global_channels[i] for i in range(len(system.global_channels))]
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)
+
+
+def test___global_channels___getitem_slice___forward_order(system: System):
+    channels = system.global_channels[:]
+
+    assert [chan.name for chan in channels] == system.global_channels.global_channel_names
+
+
+def test___global_channels___getitem_slice___interpreter_shared(system: System):
+    channels = system.global_channels[:]
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)
+
+
+def test___global_channels___getitem_str___interpreter_shared(system: System):
+    channels = [
+        system.global_channels[name] for name in system.global_channels.global_channel_names
+    ]
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)
+
+
+def test___global_channels___getitem_str_list___interpreter_shared(system: System):
+    if len(system.global_channels) < 2:
+        pytest.skip("This test requires two or more global channels.")
+
+    channels = system.global_channels[",".join(system.global_channels.global_channel_names)]
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)
+
+
+def test___global_channels___iter___forward_order(system: System):
+    channels = iter(system.global_channels)
+
+    assert [chan.name for chan in channels] == system.global_channels.global_channel_names
+
+
+def test___global_channels___iter___interpreter_shared(system: System):
+    channels = iter(system.global_channels)
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)
+
+
+def test___global_channels___reversed___reverse_order(system: System):
+    channels = reversed(system.global_channels)
+
+    assert [chan.name for chan in channels] == list(
+        reversed(system.global_channels.global_channel_names)
+    )
+
+
+def test___global_channels___reversed___interpreter_shared(system: System):
+    channels = reversed(system.global_channels)
+
+    assert all(chan._interpreter is system._interpreter for chan in channels)

--- a/tests/component/system/_collections/test_persisted_scale_collection.py
+++ b/tests/component/system/_collections/test_persisted_scale_collection.py
@@ -1,0 +1,66 @@
+import pytest
+
+from nidaqmx.system import System
+
+
+def test___scales___getitem_int___forward_order(system: System):
+    scales = [system.scales[i] for i in range(len(system.scales))]
+
+    assert [scale.name for scale in scales] == system.scales.scale_names
+
+
+def test___scales___getitem_int___interpreter_shared(system: System):
+    scales = [system.scales[i] for i in range(len(system.scales))]
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)
+
+
+def test___scales___getitem_slice___forward_order(system: System):
+    scales = system.scales[:]
+
+    assert [scale.name for scale in scales] == system.scales.scale_names
+
+
+def test___scales___getitem_slice___interpreter_shared(system: System):
+    scales = system.scales[:]
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)
+
+
+def test___scales___getitem_str___interpreter_shared(system: System):
+    scales = [system.scales[name] for name in system.scales.scale_names]
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)
+
+
+def test___scales___getitem_str_list___interpreter_shared(system: System):
+    if len(system.scales) < 2:
+        pytest.skip("This test requires two or more persisted scales.")
+
+    scales = system.scales[",".join(system.scales.scale_names)]
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)
+
+
+def test___scales___iter___forward_order(system: System):
+    scales = iter(system.scales)
+
+    assert [scale.name for scale in scales] == system.scales.scale_names
+
+
+def test___scales___iter___interpreter_shared(system: System):
+    scales = iter(system.scales)
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)
+
+
+def test___scales___reversed___reverse_order(system: System):
+    scales = reversed(system.scales)
+
+    assert [scale.name for scale in scales] == list(reversed(system.scales.scale_names))
+
+
+def test___scales___reversed___interpreter_shared(system: System):
+    scales = reversed(system.scales)
+
+    assert all(scale._interpreter is system._interpreter for scale in scales)

--- a/tests/component/system/_collections/test_persisted_task_collection.py
+++ b/tests/component/system/_collections/test_persisted_task_collection.py
@@ -1,0 +1,66 @@
+import pytest
+
+from nidaqmx.system import System
+
+
+def test___tasks___getitem_int___forward_order(system: System):
+    tasks = [system.tasks[i] for i in range(len(system.tasks))]
+
+    assert [task.name for task in tasks] == system.tasks.task_names
+
+
+def test___tasks___getitem_int___interpreter_shared(system: System):
+    tasks = [system.tasks[i] for i in range(len(system.tasks))]
+
+    assert all(task._interpreter is system._interpreter for task in tasks)
+
+
+def test___tasks___getitem_slice___forward_order(system: System):
+    tasks = system.tasks[:]
+
+    assert [task.name for task in tasks] == system.tasks.task_names
+
+
+def test___tasks___getitem_slice___interpreter_shared(system: System):
+    tasks = system.tasks[:]
+
+    assert all(task._interpreter is system._interpreter for task in tasks)
+
+
+def test___tasks___getitem_str___interpreter_shared(system: System):
+    tasks = [system.tasks[name] for name in system.tasks.task_names]
+
+    assert all(task._interpreter is system._interpreter for task in tasks)
+
+
+def test___tasks___getitem_str_list___interpreter_shared(system: System):
+    if len(system.tasks) < 2:
+        pytest.skip("This test requires two or more persisted tasks.")
+
+    tasks = system.tasks[",".join(system.tasks.task_names)]
+
+    assert all(task._interpreter is system._interpreter for task in tasks)
+
+
+def test___tasks___iter___forward_order(system: System):
+    tasks = iter(system.tasks)
+
+    assert [task.name for task in tasks] == system.tasks.task_names
+
+
+def test___tasks___iter___interpreter_shared(system: System):
+    tasks = iter(system.tasks)
+
+    assert all(task._interpreter is system._interpreter for task in tasks)
+
+
+def test___tasks___reversed___reverse_order(system: System):
+    tasks = reversed(system.tasks)
+
+    assert [task.name for task in tasks] == list(reversed(system.tasks.task_names))
+
+
+def test___tasks___reversed___interpreter_shared(system: System):
+    tasks = reversed(system.tasks)
+
+    assert all(task._interpreter is system._interpreter for task in tasks)

--- a/tests/component/system/_collections/test_physical_channel_collection.py
+++ b/tests/component/system/_collections/test_physical_channel_collection.py
@@ -1,0 +1,157 @@
+import pytest
+
+import nidaqmx.utils
+from nidaqmx.system import Device
+
+COLLECTION_NAMES = [
+    "ai_physical_chans",
+    "ao_physical_chans",
+    "ci_physical_chans",
+    "co_physical_chans",
+    "di_lines",
+    "di_ports",
+    "do_lines",
+    "do_ports",
+]
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_int___forward_order(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = [physical_channels[i] for i in range(len(physical_channels))]
+
+    assert [chan.name for chan in channels] == physical_channels.channel_names
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_int___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = [physical_channels[i] for i in range(len(physical_channels))]
+
+    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+
+
+@pytest.mark.xfail(reason="https://github.com/ni/nidaqmx-python/issues/392")
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_slice___forward_order(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = physical_channels[:]
+
+    assert [chan.name for chan in channels] == physical_channels.channel_names
+
+
+@pytest.mark.xfail(reason="https://github.com/ni/nidaqmx-python/issues/392")
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_slice___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = physical_channels[:]
+
+    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_str___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+    device_name = any_x_series_device.name
+    unqualified_channel_names = [
+        name.replace(device_name + "/", "") for name in physical_channels.channel_names
+    ]
+
+    channels = [physical_channels[name] for name in unqualified_channel_names]
+
+    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___getitem_str_list___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+    device_name = any_x_series_device.name
+    unqualified_channel_names = [
+        name.replace(device_name + "/", "") for name in physical_channels.channel_names
+    ]
+
+    channel = physical_channels[",".join(unqualified_channel_names)]
+
+    assert channel._interpreter == any_x_series_device._interpreter
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___iter___forward_order(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = iter(physical_channels)
+
+    assert [chan.name for chan in channels] == physical_channels.channel_names
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___iter___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = iter(physical_channels)
+
+    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___reversed___reverse_order(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = reversed(physical_channels)
+
+    assert [chan.name for chan in channels] == list(reversed(physical_channels.channel_names))
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___reversed___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channels = reversed(physical_channels)
+
+    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___all___forward_order(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channel = physical_channels.all
+
+    assert channel.name == nidaqmx.utils.flatten_channel_string(physical_channels.channel_names)
+
+
+@pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
+def test___physical_channels___all___interpreter_shared(
+    collection_name: str, any_x_series_device: Device
+):
+    physical_channels = getattr(any_x_series_device, collection_name)
+
+    channel = physical_channels.all
+
+    assert channel._interpreter is any_x_series_device._interpreter

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -2,6 +2,43 @@
 MajorVersion = 21
 MinorVersion = 8
 
+[DAQmxChannel AOTesterTask/VoltageOut_0]
+AO.OutputType = Voltage
+AO.Voltage.Units = Volts
+AO.Max = 16
+AO.Min = -16
+ChanType = Analog Output
+AO.TermCfg = Differential
+PhysicalChanName = aoTester/ao0
+
+[DAQmxChannel AOTesterTask/VoltageOut_1]
+AO.OutputType = Voltage
+AO.Voltage.Units = Volts
+AO.Max = 16
+AO.Min = -16
+ChanType = Analog Output
+AO.TermCfg = Differential
+PhysicalChanName = aoTester/ao1
+
+[DAQmxChannel AOTesterTask/VoltageOut_2]
+AO.OutputType = Voltage
+AO.Voltage.Units = Volts
+AO.Max = 16
+AO.Min = -16
+ChanType = Analog Output
+AO.TermCfg = Differential
+PhysicalChanName = aoTester/ao2
+
+[DAQmxTask AOTesterTask]
+Channels = AOTesterTask/VoltageOut_0, AOTesterTask/VoltageOut_1, AOTesterTask/VoltageOut_2
+SampQuant.SampMode = Finite Samples
+SampClk.ActiveEdge = Rising
+SampQuant.SampPerChan = 100
+SampClk.Rate = 1000
+SampTimingType = Sample Clock
+RegenMode = Allow Regeneration
+SampClk.Src =
+
 [DAQmxChannel VoltageTesterChannel]
 AI.MeasType = Voltage
 AI.Voltage.Units = Volts
@@ -12,6 +49,18 @@ ChanType = Analog Input
 PhysicalChanName = tsVoltageTester1/ai0
 Descr = 
 Author = "Test Author"
+AllowInteractiveEditing = True
+
+[DAQmxChannel VoltageTesterChannel2]
+AI.MeasType = Voltage
+AI.Voltage.Units = Volts
+AI.TermCfg = Differential
+AI.Max = 5
+AI.Min = -5
+ChanType = Analog Input
+PhysicalChanName = tsVoltageTester1/ai1
+Descr = "Another channel"
+Author = "Another Test Author"
 AllowInteractiveEditing = True
 
 [DAQmxChannel VoltageTesterTask/Voltage_0]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix interpreter sharing in `PhysicalChannelCollection`.

Add missing `name` property to `PersistedChannel`, `PersistedScale`, and `PersistedTask`.

Add tests for system storage collection classes.

### Why should this Pull Request be merged?

Tests interpreter sharing in system storage collection classes.

Fixes some bugs that I ran into while writing the tests.

### What testing has been done?

`poetry run pytest -v`
There was one failure related to the bitfield enum property change.