### PR TITLE
handwritten: Fix AttributeError when leaking task w/alternate constructor

### DIFF
--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -73,7 +73,7 @@ class Task:
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None
         self._close_on_exit = False
-        self._saved_name = new_task_name
+        self._saved_name = new_task_name  # _initialize sets this to the name assigned by DAQmx.
         self._grpc_options = grpc_options
 
         if grpc_options and not (
@@ -1129,10 +1129,13 @@ class _TaskAlternateConstructor(Task):
             close_on_exit: Specifies whether the task's context manager closes the task.
 
         """
+        # Initialize the fields that __del__ accesses so it doesn't crash when _initialize raises an exception.
         self._handle = task_handle
-        self._interpreter = interpreter
         self._close_on_exit = close_on_exit
+        self._saved_name = ""  # _initialize sets this to the name assigned by DAQmx.
+        self._grpc_options = getattr(interpreter, "_grpc_options", None)
 
+        self._interpreter = interpreter
         self._initialize(self._handle, self._interpreter)
 
         # Use meta-programming to change the type of this object to Task,

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -73,7 +73,7 @@ class Task:
         # Initialize the fields that __del__ accesses so it doesn't crash when __init__ raises an exception.
         self._handle = None
         self._close_on_exit = False
-        self._saved_name = new_task_name
+        self._saved_name = new_task_name  # _initialize sets this to the name assigned by DAQmx.
         self._grpc_options = grpc_options
 
         if grpc_options and not (
@@ -1129,10 +1129,13 @@ class _TaskAlternateConstructor(Task):
             close_on_exit: Specifies whether the task's context manager closes the task.
 
         """
+        # Initialize the fields that __del__ accesses so it doesn't crash when _initialize raises an exception.
         self._handle = task_handle
-        self._interpreter = interpreter
         self._close_on_exit = close_on_exit
+        self._saved_name = ""  # _initialize sets this to the name assigned by DAQmx.
+        self._grpc_options = getattr(interpreter, "_grpc_options", None)
 
+        self._interpreter = interpreter
         self._initialize(self._handle, self._interpreter)
 
         # Use meta-programming to change the type of this object to Task,

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -171,3 +171,27 @@ def test___close_on_exit_with_grpc_options___leak_task___resource_warning_not_ra
 
     assert len(warnings_raised) == 0
     task.close()
+
+
+def test___close_on_exit_with_alternate_constructor___leak_task___raises_resource_warning(
+    interpreter: Mock,
+):
+    task = _TaskAlternateConstructor("MyTaskHandle", interpreter, close_on_exit=True)
+
+    with pytest.warns(ResourceWarning):
+        task.__del__()
+
+    task.close()
+
+
+def test___close_on_exit_with_alternate_constructor_and_grpc_options___leak_task___resource_warning_not_raised(
+    interpreter: Mock, mocker: MockerFixture
+):
+    interpreter._grpc_options = create_grpc_options(mocker)
+    task = _TaskAlternateConstructor("MyTaskHandle", interpreter, close_on_exit=True)
+
+    with warnings.catch_warnings(record=True) as warnings_raised:
+        task.__del__()
+
+    assert len(warnings_raised) == 0
+    task.close()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `_TaskAlternateConstructor` to set `self._saved_name` and `self._grpc_options`.

### Why should this Pull Request be merged?

I noticed this while writing a test that uses `PersistedTask.load()` that leaking a loaded task raises `AttributeError: 'Task' object has no attribute '_grpc_options'`. 

### What testing has been done?

Verified that the test fails without the fix.
Ran all tests with `poetry run pytest -v`.