### PR TITLE
fix: physical-channel-collection: use grpc interpreter instance in all & __getitem

### DIFF
--- a/generated/nidaqmx/system/_collections/physical_channel_collection.py
+++ b/generated/nidaqmx/system/_collections/physical_channel_collection.py
@@ -61,7 +61,7 @@ class PhysicalChannelCollection(Sequence):
         elif isinstance(index, slice):
             return _PhysicalChannelAlternateConstructor(self.channel_names[index], self._interpreter)
         elif isinstance(index, str):
-            return PhysicalChannel(f'{self._name}/{index}')
+            return _PhysicalChannelAlternateConstructor(f'{self._name}/{index}', self._interpreter)
         else:
             raise DaqError(
                 'Invalid index type "{}" used to access collection.'
@@ -91,7 +91,7 @@ class PhysicalChannelCollection(Sequence):
             physical channel object that represents the entire list of
             physical channels on this channel collection.
         """
-        return PhysicalChannel(flatten_channel_string(self.channel_names))
+        return _PhysicalChannelAlternateConstructor(flatten_channel_string(self.channel_names), self._interpreter)
 
     @property
     def channel_names(self):

--- a/src/handwritten/system/_collections/physical_channel_collection.py
+++ b/src/handwritten/system/_collections/physical_channel_collection.py
@@ -61,7 +61,7 @@ class PhysicalChannelCollection(Sequence):
         elif isinstance(index, slice):
             return _PhysicalChannelAlternateConstructor(self.channel_names[index], self._interpreter)
         elif isinstance(index, str):
-            return PhysicalChannel(f'{self._name}/{index}')
+            return _PhysicalChannelAlternateConstructor(f'{self._name}/{index}', self._interpreter)
         else:
             raise DaqError(
                 'Invalid index type "{}" used to access collection.'
@@ -91,7 +91,7 @@ class PhysicalChannelCollection(Sequence):
             physical channel object that represents the entire list of
             physical channels on this channel collection.
         """
-        return PhysicalChannel(flatten_channel_string(self.channel_names))
+        return _PhysicalChannelAlternateConstructor(flatten_channel_string(self.channel_names), self._interpreter)
 
     @property
     def channel_names(self):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replaces PhysicalChannel init with AlternatePhysicalChannel constructor in appropriate places

### Why should this Pull Request be merged?

To fix: [Bug 2400971](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400971): PhysicalChannelCollection.all and PhysicalChannelCollection.__getitem__(str) always use LibraryInterpreter

### What testing has been done?

Automated tests passing