### PR TITLE
Fix -  set power up states with output type

### DIFF
--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -407,7 +407,7 @@ class System:
         channel_type = numpy.int32(
             [p.channel_type.value for p in power_up_states])
 
-        self._interpreter.set_analog_power_up_states_with_output_type(physical_channel, state, channel_type, len(power_up_states))
+        self._interpreter.set_analog_power_up_states_with_output_type(physical_channel, state, channel_type)
 
     def get_analog_power_up_states(self, device_name):
         """

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -347,7 +347,7 @@ ${function_template.script_function(function_object)}
         channel_type = numpy.int32(
             [p.channel_type.value for p in power_up_states])
 
-        self._interpreter.set_analog_power_up_states_with_output_type(physical_channel, state, channel_type, len(power_up_states))
+        self._interpreter.set_analog_power_up_states_with_output_type(physical_channel, state, channel_type)
 
     def get_analog_power_up_states(self, device_name):
         """

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -31,22 +31,23 @@ def test_valid_power_up_states___set_analog_power_up_states_with_output_type___s
         for channel_name in channel_names
     ]
 
-    result = system.set_analog_power_up_states_with_output_type(power_up_states)
-
-    assert result == None
+    system.set_analog_power_up_states_with_output_type(power_up_states)
 
 
 def test_invalid_power_up_states___set_analog_power_up_states_with_output_type___throws_invalid_attribute_value_error(
     system,
 ):
-    channel_names = ["aoTester/ao0", "aoTester/ao1"]
     power_up_states = [
         AOPowerUpState(
-            physical_channel=channel_name,
+            physical_channel="aoTester/ao0",
+            power_up_state=1,
+            channel_type=PowerUpChannelType.CHANNEL_VOLTAGE,
+        ),
+        AOPowerUpState(
+            physical_channel="aoTester/ao1",
             power_up_state=20,
             channel_type=PowerUpChannelType.CHANNEL_VOLTAGE,
-        )
-        for channel_name in channel_names
+        ),
     ]
 
     with pytest.raises(nidaqmx.DaqError) as exc_info:

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -1,4 +1,9 @@
+import pytest
+
+import nidaqmx
 from nidaqmx.constants import PowerUpChannelType
+from nidaqmx.error_codes import DAQmxErrors
+from nidaqmx.types import AOPowerUpState
 
 
 def test___get_analog_power_up_states_with_output_type___returns_power_up_states(system):
@@ -11,3 +16,40 @@ def test___get_analog_power_up_states_with_output_type___returns_power_up_states
         assert channel_names[i] == power_up_states[i].physical_channel
         assert 0.0 == power_up_states[i].power_up_state
         assert PowerUpChannelType.CHANNEL_HIGH_IMPEDANCE == power_up_states[i].channel_type
+
+
+def test_valid_power_up_states___set_analog_power_up_states_with_output_type___sets_power_up_states_without_errors(
+    system,
+):
+    channel_names = ["aoTester/ao0", "aoTester/ao1"]
+    power_up_states = [
+        AOPowerUpState(
+            physical_channel=channel_name,
+            power_up_state=-1.0,
+            channel_type=PowerUpChannelType.CHANNEL_HIGH_IMPEDANCE,
+        )
+        for channel_name in channel_names
+    ]
+
+    result = system.set_analog_power_up_states_with_output_type(power_up_states)
+
+    assert result == None
+
+
+def test_invalid_power_up_states___set_analog_power_up_states_with_output_type___throws_invalid_attribute_value_error(
+    system,
+):
+    channel_names = ["aoTester/ao0", "aoTester/ao1"]
+    power_up_states = [
+        AOPowerUpState(
+            physical_channel=channel_name,
+            power_up_state=20,
+            channel_type=PowerUpChannelType.CHANNEL_VOLTAGE,
+        )
+        for channel_name in channel_names
+    ]
+
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
+        system.set_analog_power_up_states_with_output_type(power_up_states)
+
+    assert exc_info.value.error_code == DAQmxErrors.INVALID_ATTRIBUTE_VALUE


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes the `get_analog_power_up_states_with_output_type` call

### Why should this Pull Request be merged?

To fix: [Bug 2409371](https://dev.azure.com/ni/DevCentral/_workitems/edit/2409371): set_analog_power_up_states_with_output_type() returns errors with both LibraryInterpreter and GrpcStubInterpreter

### What testing has been done?

New test cases added