### PR TITLE
Fix - get analog powerup states without output type

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -785,11 +785,6 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_analog_power_up_states(
-            self, device_name, channel_name, channel_type):
-        raise NotImplementedError
-
-    @abc.abstractmethod
     def get_analog_power_up_states_with_output_type(
             self, channel_names, array_size):
         raise NotImplementedError

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -1669,16 +1669,6 @@ class GrpcStubInterpreter(BaseInterpreter):
                 task=task, signal_id_raw=signal_id,
                 output_terminal=output_terminal))
 
-    def get_analog_power_up_states(
-            self, device_name, channel_name, channel_type):
-        channels = []
-        for index in range(len(channel_name)):
-            channels.append(grpc_types.AnalogPowerUpChannelAndType(channel_name=channel_name[index], channel_type=channel_type[index]))
-        response = self._invoke(
-            self._client.GetAnalogPowerUpStates,
-            grpc_types.GetAnalogPowerUpStatesRequest(device_name=device_name, channels=channels))
-        return response.power_up_states
-
     def get_analog_power_up_states_with_output_type(
             self, channel_names, array_size):
         response = self._invoke(

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -2250,36 +2250,6 @@ class LibraryInterpreter(BaseInterpreter):
             task, signal_id, output_terminal)
         self.check_for_error(error_code)
 
-    def get_analog_power_up_states(
-            self, device_name, channel_name, channel_type):
-        state = []
-
-        args = [device_name]
-        argtypes: List[type] = [ctypes_byte_str]
-
-        for index in range(len(channel_name)):
-            state_element = ctypes.c_double()
-            state.append(state_element)
-
-            args.append(channel_name[index])
-            argtypes.append(ctypes_byte_str)
-            
-            args.append(ctypes.byref(state_element))
-            argtypes.append(ctypes.POINTER(ctypes.c_double))
-            
-            args.append(channel_type[index])
-            argtypes.append(ctypes.c_int32)
-            
-        args.append(None)
-        argtypes.append(ctypes.c_void_p)
-
-        cfunc = lib_importer.cdll.DAQmxGetAnalogPowerUpStates
-        with cfunc.arglock:
-            cfunc.argtypes = argtypes
-            error_code = cfunc(*args)
-        self.check_for_error(error_code)
-        return [state_element.value for state_element in state]
-
     def get_analog_power_up_states_with_output_type(
             self, channel_names, array_size):
         state_array = numpy.zeros(array_size, dtype=numpy.float64)

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -432,17 +432,10 @@ class System:
               Specifies the output type for the physical channel
               specified with the **physical_channel** input.
         """
-        channel_names = []
-        channel_types = []
-
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
+        channel_names = device.ao_physical_chans.channel_names
 
-        for ao_physical_chan in device.ao_physical_chans:
-            channel_type = ctypes.c_int()
-            channel_types.append(channel_type)
-            channel_names.append(ao_physical_chan.name)
-
-        states = self._interpreter.get_analog_power_up_states(device_name, channel_names, channel_types)
+        states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(flatten_channel_string(channel_names), len(channel_names))
 
         power_up_states = []
         for a, p, c in zip(device.ao_physical_chans, states, channel_types):
@@ -450,7 +443,7 @@ class System:
                 AOPowerUpState(
                     physical_channel=a.name,
                     power_up_state=p,
-                    channel_type=AOPowerUpOutputBehavior(c.value)))
+                    channel_type=PowerUpChannelType(c)))
 
         return power_up_states
 

--- a/generated/nidaqmx/system/system.py
+++ b/generated/nidaqmx/system/system.py
@@ -434,18 +434,9 @@ class System:
         """
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
         channel_names = device.ao_physical_chans.channel_names
-
-        states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(flatten_channel_string(channel_names), len(channel_names))
-
-        power_up_states = []
-        for a, p, c in zip(device.ao_physical_chans, states, channel_types):
-            power_up_states.append(
-                AOPowerUpState(
-                    physical_channel=a.name,
-                    power_up_state=p,
-                    channel_type=PowerUpChannelType(c)))
-
-        return power_up_states
+        
+        # Here get_analog_power_up_states is not called, since it is deprecated and passes channel_type in wrong direction
+        return self.get_analog_power_up_states_with_output_type(channel_names)
 
     def get_analog_power_up_states_with_output_type(self, physical_channels):
         """

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -374,18 +374,9 @@ ${function_template.script_function(function_object)}
         """
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
         channel_names = device.ao_physical_chans.channel_names
-
-        states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(flatten_channel_string(channel_names), len(channel_names))
-
-        power_up_states = []
-        for a, p, c in zip(device.ao_physical_chans, states, channel_types):
-            power_up_states.append(
-                AOPowerUpState(
-                    physical_channel=a.name,
-                    power_up_state=p,
-                    channel_type=PowerUpChannelType(c)))
-
-        return power_up_states
+        
+        # Here get_analog_power_up_states is not called, since it is deprecated and passes channel_type in wrong direction
+        return self.get_analog_power_up_states_with_output_type(channel_names)
 
     def get_analog_power_up_states_with_output_type(self, physical_channels):
         """

--- a/src/codegen/templates/system/system.py.mako
+++ b/src/codegen/templates/system/system.py.mako
@@ -372,17 +372,10 @@ ${function_template.script_function(function_object)}
               Specifies the output type for the physical channel
               specified with the **physical_channel** input.
         """
-        channel_names = []
-        channel_types = []
-
         device = _DeviceAlternateConstructor(device_name, self._interpreter)
+        channel_names = device.ao_physical_chans.channel_names
 
-        for ao_physical_chan in device.ao_physical_chans:
-            channel_type = ctypes.c_int()
-            channel_types.append(channel_type)
-            channel_names.append(ao_physical_chan.name)
-
-        states = self._interpreter.get_analog_power_up_states(device_name, channel_names, channel_types)
+        states, channel_types = self._interpreter.get_analog_power_up_states_with_output_type(flatten_channel_string(channel_names), len(channel_names))
 
         power_up_states = []
         for a, p, c in zip(device.ao_physical_chans, states, channel_types):
@@ -390,7 +383,7 @@ ${function_template.script_function(function_object)}
                 AOPowerUpState(
                     physical_channel=a.name,
                     power_up_state=p,
-                    channel_type=AOPowerUpOutputBehavior(c.value)))
+                    channel_type=PowerUpChannelType(c)))
 
         return power_up_states
 

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -75,6 +75,8 @@ INTERPRETER_IGNORED_FUNCTIONS = [
     "SetTimingAttributeTimestamp",
     "SetTrigAttributeTimestamp",
     "WaitForValidTimestamp",
+    # Deprecated, not working
+    "GetAnalogPowerUpStates",
 ]
 
 GRPC_INTERPRETER_IGNORED_FUNCTIONS = [

--- a/tests/component/system/test_system.py
+++ b/tests/component/system/test_system.py
@@ -56,6 +56,19 @@ def test_invalid_power_up_states___set_analog_power_up_states_with_output_type__
     assert exc_info.value.error_code == DAQmxErrors.INVALID_ATTRIBUTE_VALUE
 
 
+def test___get_analog_power_up_states___returns_power_up_states(system):
+    device_name = "aoTester"
+
+    power_up_states = system.get_analog_power_up_states(device_name)
+
+    channel_names = system.devices[device_name].ao_physical_chans.channel_names
+    assert len(power_up_states) == len(channel_names)
+    for i in range(len(channel_names)):
+        assert power_up_states[i].physical_channel == channel_names[i]
+        assert power_up_states[i].power_up_state == 0.0
+        assert power_up_states[i].channel_type == PowerUpChannelType.CHANNEL_HIGH_IMPEDANCE
+
+
 def test_valid_power_up_states___set_analog_power_up_states___sets_power_up_states_without_errors(
     system,
 ):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR reroutes the get_analog_power_up_states without output type to get_analog_power_up_states with output type since the corresponding C call is deprecated.

### Why should this Pull Request be merged?

To fix: [Bug 2400919](https://dev.azure.com/ni/DevCentral/_workitems/edit/2400919): get_analog_power_up_states() (without output type) returns errors with both LibraryInterpreter and GrpcStubInterpreter

### What testing has been done?

Test case added