### PR TITLE
docs: Upgrade readthedocs workflow to Python 3.9

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -6,14 +6,12 @@ on:
       - master
 jobs:
   build:
-
     runs-on: 
       - ubuntu-latest
     strategy:
       matrix:
         # The codegen scripts require Python 3.8 or later.
         python-version: ["3.8"]
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +35,47 @@ jobs:
           poetry run python src/codegen --dest generated/nidaqmx
       - name: Check for files dirtied by codegen
         run: git diff --exit-code
+  run-unit-tests:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.4.0"
+      - run: poetry --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          poetry install
       - name: Run unit tests
         run: poetry run pytest -v --cov=generated/nidaqmx tests/unit
+  generate-docs:
+    runs-on:
+      - ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.4.0"
+      - run: poetry --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          poetry install
       - name: Generate docs
         run: poetry run tox -e docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
 
 [testenv:docs]
 # base_python should match the version specified in .readthedocs.yml
-base_python = python3.7
+base_python = python3.9
 commands =
    poetry install -v --only main --extras docs
    # Use -W to treat warnings as errors.

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands =
    poetry run coverage report
 
 [testenv:docs]
-# base_python should match the version specified in .readthedocs.yml
+# base_python should match the version specified in .readthedocs.yml and the PR workflow.
 base_python = python3.9
 commands =
    poetry run python --version

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ setenv =
    base: PYTEST_OPTS=-k "not grpc"
    grpc: PYTEST_OPTS=
 commands =
+   poetry run python --version
    poetry install -v {env:INSTALL_OPTS}
    poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=pytests-{envname}.xml {env:PYTEST_OPTS} {posargs}
 
@@ -31,6 +32,7 @@ commands =
 # base_python should match the version specified in .readthedocs.yml
 base_python = python3.9
 commands =
+   poetry run python --version
    poetry install -v --only main --extras docs
    # Use -W to treat warnings as errors.
    poetry run sphinx-build -b html -W docs docs/_build


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Upgrade `.readthedocs.yml` and `docs` tox environment to use Python 3.9.

Split P4 workflow into separate jobs for unit tests and docs so that we can run them with the right Python versions.

### Why should this Pull Request be merged?

Python 3.7 is not long for this world.

Run unit tests on more Python versions.

### What testing has been done?

Ran `poetry run tox -e docs`