### PR TITLE
Fix readthedocs with Python 3.9

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,11 +2,15 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.9
   install:
     - method: pip
       path: .


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updating readthedocs to Python 3.9 produced this error: https://readthedocs.org/projects/nidaqmx-python/builds/20936049/

> Problem in your project's configuration. Invalid "python.version": expected one of (2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, pypy3.5), got 3.9

The legacy build specification only supports Python versions up to 3.8, according to https://docs.readthedocs.io/en/stable/config-file/v2.html#legacy-build-specification

### Why should this Pull Request be merged?

Fix readthedocs web site generation.

### What testing has been done?

None