### PR TITLE
tests: mark tests that require an updated gRPC device with xfail

### DIFF
--- a/tests/acceptance/test_multi_threading.py
+++ b/tests/acceptance/test_multi_threading.py
@@ -200,6 +200,7 @@ def test___shared_interpreter___run_multiple_acquisitions_with_events___callback
         assert all(status == 0 for status in done_statuses)
 
 
+@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___shared_interpreter___unregister_events_during_other_acquisitions_with_events___callbacks_invoked(
     init_kwargs,
     multi_threading_test_devices: Sequence[Device],

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -15,6 +15,7 @@ class TestReadExceptions:
     loopback routes on the device.
     """
 
+    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
     def test_timeout(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
@@ -71,6 +72,7 @@ class TestReadExceptions:
         number_of_samples_expected = clocks_to_give - samples_to_read
         assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
+    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
     def test_timeout_raw(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -5,6 +5,7 @@ import pytest
 import nidaqmx
 from nidaqmx.constants import AcquisitionType, BusType, Level, TaskMode
 from nidaqmx.error_codes import DAQmxErrors
+from nidaqmx.errors import RpcError
 
 
 class TestReadExceptions:
@@ -15,7 +16,9 @@ class TestReadExceptions:
     loopback routes on the device.
     """
 
-    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
+    @pytest.mark.grpc_xfail(
+        reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
+    )
     def test_timeout(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
@@ -72,7 +75,9 @@ class TestReadExceptions:
         number_of_samples_expected = clocks_to_give - samples_to_read
         assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
+    @pytest.mark.grpc_xfail(
+        reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
+    )
     def test_timeout_raw(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.


### PR DESCRIPTION
### What does this Pull Request accomplish?
This PR adds grpc_xfail tag to the test methods that requires an updated version of gRPC device driver in `test_read_exceptions` An issue in event registration/unregistration has been fixed in the latest gRPC device driver which is required by one of the test cases in `test_multi_threading` and this has also been marked with `xfail` tag.

### Why should this Pull Request be merged?
This fixes the test cases failing as it requires an updated gRPC device driver version.
