### PR TITLE
Add CI workflow, refactor/rename jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  workflow_call:
+  workflow_dispatch:
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'releases/**'
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+  run_unit_tests:
+    uses: ./.github/workflows/run_unit_tests.yml
+    needs: [build]
+  generate_docs:
+    uses: ./.github/workflows/generate_docs.yml
+    needs: [build]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,10 +9,13 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    name: Build
     uses: ./.github/workflows/build.yml
   run_unit_tests:
+    name: Run unit tests
     uses: ./.github/workflows/run_unit_tests.yml
     needs: [build]
   generate_docs:
+    name: Generate docs
     uses: ./.github/workflows/generate_docs.yml
     needs: [build]

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -9,4 +9,5 @@ on:
   workflow_dispatch:
 jobs:
   run_ci:
+    name: Run CI
     uses: ./.github/workflows/CI.yml

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -4,78 +4,9 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
+  workflow_call:
+  workflow_dispatch:
 jobs:
-  build:
-    runs-on: 
-      - ubuntu-latest
-    strategy:
-      matrix:
-        # The codegen scripts require Python 3.8 or later.
-        python-version: ["3.8"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: "1.4.0"
-      - run: poetry --version
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          poetry install
-      - name: Run linters
-        run: |
-          poetry run ni-python-styleguide lint
-      - name: Generate ni-daqmx files
-        run: |
-          rm -fr generated/nidaqmx
-          poetry run python src/codegen --dest generated/nidaqmx
-      - name: Check for files dirtied by codegen
-        run: git diff --exit-code
-  run-unit-tests:
-    runs-on:
-      - ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: "1.4.0"
-      - run: poetry --version
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          poetry install
-      - name: Run unit tests
-        run: poetry run pytest -v --cov=generated/nidaqmx tests/unit
-  generate-docs:
-    runs-on:
-      - ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v8
-        with:
-          poetry-version: "1.4.0"
-      - run: poetry --version
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          poetry install
-      - name: Generate docs
-        run: poetry run tox -e docs
+  run_ci:
+    uses: ./.github/workflows/CI.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: 
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          # The codegen scripts require Python 3.8 or later.
+          python-version: "3.8"
+      - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.4.0"
+      - run: poetry --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          poetry install
+      - name: Run linters
+        run: |
+          poetry run ni-python-styleguide lint
+      - name: Generate ni-daqmx files
+        run: |
+          rm -fr generated/nidaqmx
+          poetry run python src/codegen --dest generated/nidaqmx
+      - name: Check for files dirtied by codegen
+        run: git diff --exit-code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,27 @@
-name: build
+name: Build
 
 on:
   workflow_call:
   workflow_dispatch:
 jobs:
   build:
+    name: Build
     runs-on: 
       - ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           # The codegen scripts require Python 3.8 or later.
           python-version: "3.8"
-      - uses: Gr1N/setup-poetry@v8
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.4.0"
-      - run: poetry --version
+      - name: Check Poetry version
+        run: poetry --version
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,22 +1,26 @@
-name: generate_docs
+name: Generate docs
 
 on:
   workflow_call:
   workflow_dispatch:
 jobs:
   generate_docs:
+    name: Generate docs
     runs-on:
       - ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - uses: Gr1N/setup-poetry@v8
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.4.0"
-      - run: poetry --version
+      - name: Check Poetry version
+        run: poetry --version
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,0 +1,25 @@
+name: generate_docs
+
+on:
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  generate_docs:
+    runs-on:
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.4.0"
+      - run: poetry --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          poetry install
+      - name: Generate docs
+        run: poetry run tox -e docs

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,0 +1,29 @@
+name: run_unit_tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  run_unit_tests:
+    runs-on:
+      - ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "1.4.0"
+      - run: poetry --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          poetry install
+      - name: Run unit tests
+        run: poetry run pytest -v --cov=generated/nidaqmx tests/unit

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,10 +1,11 @@
-name: run_unit_tests
+name: Run unit tests
 
 on:
   workflow_call:
   workflow_dispatch:
 jobs:
   run_unit_tests:
+    name: Run unit tests
     runs-on:
       - ${{ matrix.os }}
     strategy:
@@ -12,15 +13,18 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repo
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: Gr1N/setup-poetry@v8
+      - name: Set up Poetry
+        uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: "1.4.0"
-      - run: poetry --version
+      - name: Check Poetry version
+        run: poetry --version
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `CI.yml` that runs on push to main/release branches.

Update `PR.yml` to delegate to `CI.yml` for now.

Split up `PR.yml`'s jobs into separate actions. Rename jobs & action filenames to use imperative tense and snake_case.

Avoid running tests or generating docs when `build`.

Remove unnecessary matrices from `build` and `generate_docs`.

Add `on: workflow_dispatch:` to all workflows to allow running them manually.

Run unit tests on Windows too.

### Why should this Pull Request be merged?

Sometimes a PR merge succeeds with no conflicts but breaks the trunk due to incompatibility with another recent PR. The grpc-device repo's CI job runs on push to main and I've seen it catch this situation.

Skipping tests when checks fail causes the PR workflow to fail faster and use less resources.

### What testing has been done?

None, will run PR build