### PR TITLE
Updated incorrect random start range of DAQmx_Pwr_Current_Setpoint property

### DIFF
--- a/tests/legacy/test_channel_creation.py
+++ b/tests/legacy/test_channel_creation.py
@@ -317,7 +317,7 @@ class TestAnalogCreateChannels:
 
         pwr_phys_chan = f"{sim_ts_power_device.name}/power"
         voltage_setpoint = random.random() * 6.0
-        current_setpoint = random.random() * 3.0
+        current_setpoint = random.uniform(0.03, 3.0)
         output_enable = random.choice([True, False])
         # CPLD is fixed-point, so values are coerced to something close.
         setpoint_tolerance = 1e-03


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
1) Fixes the test failures due to the incorrect generated random value in `test_create_ai_power_chan` test case.
2) Used `random.uniform` to add start and end range in floating point precisions.

### Why should this Pull Request be merged?
Fixes the failing test case `test_create_ai_power_chan`  in pipeline.

### What testing has been done?
Observed `random.uniform` generates desired output and ran `poetry run tox`.