### PR TITLE
pyproject.toml: Fix `black` excludes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ tox = [
 
 [tool.black]
 line-length = 100
-extend_exclude = ".tox,docs,generated,src/codegen/metadata,src/codegen/templates"
+extend_exclude = ".tox/|docs/|generated/|src/codegen/metadata/|src/codegen/templates/|src/handwritten/"
 
 [tool.ni-python-styleguide]
 extend_exclude = ".tox,docs,generated,src/codegen/metadata,src/codegen/templates,src/handwritten"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change the `tools.black` `extend_exclude` field to use the correct format.

### Why should this Pull Request be merged?

`black` and `ni-python-styleguide` have different formats for `extend_exclude`:
- `black` uses a single regex
- `ni-python-styleguide` uses a comma-separated list of `fnmatch` patterns

See https://github.com/ni/python-styleguide/issues/134 for more info.

### What testing has been done?

`poetry run black .` no longer reformats files that it shouldn't.