### PR TITLE
test: update test to verify data returned after partial read

### DIFF
--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -219,7 +219,7 @@ class TestReadExceptions:
         number_of_samples_read = timeout_exception.value.samps_per_chan_read
         assert number_of_samples_read == number_of_samples_expected
 
-        # DAQmx overwrites first channel array slices with other channel data as mentioned in #2420742
+        # DAQmx overwrites first channel array slices with other channel data as in AB#2420742
         # Hence resize of the data is needed to extract each data correctly
         resized_data = numpy.resize(data, (number_of_channels, number_of_samples_read))
         for i in range(number_of_channels):

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -147,8 +147,10 @@ class TestReadExceptions:
             pytest.skip("Requires a plugin device.")
 
         if real_x_series_device.ai_simultaneous_sampling_supported:
-            pytest.skip("Requires device that do not have simultaneous sampling, since AO loopback have to be programmed differently.")
-        
+            pytest.skip(
+                "Requires device that do not have simultaneous sampling, since AO loopback have to be programmed differently."
+            )
+
         number_of_channels = len(real_x_series_device.ao_physical_chans)
 
         if not number_of_channels:
@@ -215,7 +217,7 @@ class TestReadExceptions:
         assert not any(element == 0 for element in data.reshape(data.size))
 
         for i in range(number_of_channels):
-            assert all(element == pytest.approx(data_to_write[i], abs=1e-2)  for element in data[i])
+            assert all(element == pytest.approx(data_to_write[i], abs=1e-2) for element in data[i])
 
         # Now read more data than is available.
         data = numpy.zeros((number_of_channels, samples_to_read), dtype=numpy.float64)
@@ -234,5 +236,6 @@ class TestReadExceptions:
         # Hence resize of the data is needed to extract each data correctly
         resized_data = numpy.resize(data, (number_of_channels, number_of_samples_read))
         for i in range(number_of_channels):
-            assert all(element == pytest.approx(data_to_write[i], abs=1e-2) for element in resized_data[i])
-
+            assert all(
+                element == pytest.approx(data_to_write[i], abs=1e-2) for element in resized_data[i]
+            )


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the test_timeout_stream test case to verify the partial read data on timeout exception
- Removed sentinal_value since grpc call is not passed by reference and hence cannot retain the sentinal_value
- Updated the test case to setup and verify multiple channels, so as to showcase the way to extract multiple channel data and verify (we have to extract properly from the partial read data, since DAQmx overwrites first channel's data with other channel's data in a partial read)

### Why should this Pull Request be merged?

To verify the read partial data by properly extracting from the returned data of various channels and validate - as discussed here [Bug 2420742](https://dev.azure.com/ni/DevCentral/_workitems/edit/2420742): nidaqmx-python read timeout test interprets partial read data incorrectly

### What testing has been done?

Test passed in the remote PC with hardware