### PR TITLE
tests: Don't randomize the random seed

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,4 @@
 """This contains the helpers methods used in the DAQmx tests."""
-import random
-import sys
 
 
 # Power uses fixed-point scaling, so we have a pretty wide epsilon.
@@ -9,4 +7,7 @@ POWER_ABS_EPSILON = 1e-3
 
 def generate_random_seed():
     """Creates a random integer."""
-    return random.randint(0, sys.maxsize)
+    # Randomizing the random seed makes the GitHub test reporting action
+    # (EnricoMi/publish-unit-test-result-action) report many added/removed
+    # tests, so use the same random seed every time.
+    return 42


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Randomizing the random seed makes the GitHub test reporting action (EnricoMi/publish-unit-test-result-action) report many added/removed tests, so use the same random seed every time.

### Why should this Pull Request be merged?

Make GitHub test results report stable test deltas.

### What testing has been done?

Ran tests and verified that the seed is always 42.