### PR TITLE
Consistently return DaqNotFoundError when NI-DAQmx is not installed on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ All notable changes to this project will be documented in this file.
 * ### Merged Pull Requests
     * ...
 * ### Major Changes
-    * ...
+    * Promoted `DaqNotFoundError`, `DaqNotSupportedError`, and `DaqFunctionNotSupportedError` to `nidaqmx.errors`.
+    * Consistently return `DaqNotFoundError` on all platforms when the NI-DAQmx driver is not installed.
 * ### Known Issues
     * ...
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ All notable changes to this project will be documented in this file.
 * ### Merged Pull Requests
     * ...
 * ### Major Changes
-    * Promoted `DaqNotFoundError`, `DaqNotSupportedError`, and `DaqFunctionNotSupportedError` to `nidaqmx.errors`.
-    * Consistently return `DaqNotFoundError` on all platforms when the NI-DAQmx driver is not installed.
+    * `nidaqmx.errors.DaqNotFoundError`, `nidaqmx.errors.DaqNotSupportedError`, and
+    `nidaqmx.errors.DaqFunctionNotSupportedError` are now public exceptions.
+    * Consistently return `nidaqmx.errors.DaqNotFoundError` on all platforms when the NI-DAQmx
+    driver is not installed.
 * ### Known Issues
     * ...
 

--- a/generated/nidaqmx/_lib.py
+++ b/generated/nidaqmx/_lib.py
@@ -9,14 +9,14 @@ from typing import cast
 from nidaqmx.errors import DaqNotFoundError, DaqNotSupportedError, DaqFunctionNotSupportedError
 
 
-DAQ_NOT_FOUND_MESSAGE = "Could not find an installation of NI-DAQmx. Please ensure that NI-DAQmx " \
-                        "is installed on this machine or contact National Instruments for support."
+_DAQ_NOT_FOUND_MESSAGE = "Could not find an installation of NI-DAQmx. Please ensure that NI-DAQmx " \
+                         "is installed on this machine or contact National Instruments for support."
 
-DAQ_NOT_SUPPORTED_MESSAGE = "NI-DAQmx Python is not supported on this platform: {0}. Please " \
-                            "direct any questions or feedback to National Instruments."
+_DAQ_NOT_SUPPORTED_MESSAGE = "NI-DAQmx Python is not supported on this platform: {0}. Please " \
+                             "direct any questions or feedback to National Instruments."
 
-FUNCTION_NOT_SUPPORTED_MESSAGE = "The NI-DAQmx function \"{0}\" is not supported in this version " \
-                                 "of NI-DAQmx. Visit ni.com/downloads to upgrade."
+_FUNCTION_NOT_SUPPORTED_MESSAGE = "The NI-DAQmx function \"{0}\" is not supported in this version " \
+                                  "of NI-DAQmx. Visit ni.com/downloads to upgrade."
 
 
 class c_bool32(ctypes.c_uint):
@@ -93,7 +93,7 @@ class DaqFunctionImporter:
                         cfunc.arglock = threading.Lock()
             return cfunc
         except AttributeError:
-            raise DaqFunctionNotSupportedError(FUNCTION_NOT_SUPPORTED_MESSAGE.format(function))
+            raise DaqFunctionNotSupportedError(_FUNCTION_NOT_SUPPORTED_MESSAGE.format(function))
 
 
 class DaqLibImporter:
@@ -150,16 +150,16 @@ class DaqLibImporter:
                     windll = ctypes.windll.LoadLibrary('nicaiu')
                     cdll = ctypes.cdll.LoadLibrary('nicaiu')
             except (OSError, WindowsError) as e:
-                raise DaqNotFoundError(DAQ_NOT_FOUND_MESSAGE) from e
+                raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE) from e
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')
             if find_library('nidaqmx') is not None:
                 cdll = ctypes.cdll.LoadLibrary(find_library('nidaqmx'))
                 windll = cdll
             else:
-                raise DaqNotFoundError(DAQ_NOT_FOUND_MESSAGE)
+                raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE)
         else:
-            raise DaqNotSupportedError(DAQ_NOT_SUPPORTED_MESSAGE.format(sys.platform))
+            raise DaqNotSupportedError(_DAQ_NOT_SUPPORTED_MESSAGE.format(sys.platform))
 
         self._windll = DaqFunctionImporter(windll)
         self._cdll = DaqFunctionImporter(cdll)

--- a/generated/nidaqmx/_lib.py
+++ b/generated/nidaqmx/_lib.py
@@ -170,8 +170,8 @@ class DaqLibImporter:
                 else:
                     windll = ctypes.windll.LoadLibrary('nicaiu')
                     cdll = ctypes.cdll.LoadLibrary('nicaiu')
-            except (OSError, WindowsError):
-                raise DaqNotFoundError()
+            except (OSError, WindowsError) as e:
+                raise DaqNotFoundError() from e
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')
             if find_library('nidaqmx') is not None:

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -13,6 +13,28 @@ class Error(Exception):
     pass
 
 
+class DaqNotFoundError(Error):
+    """
+    Error raised when NI-DAQmx driver is not installed.
+    """
+    pass
+
+
+class DaqNotSupportedError(Error):
+    """
+    Error raised when DAQmx is not supported on this platform.
+    """
+    pass
+
+
+class DaqFunctionNotSupportedError(Error):
+    """
+    Error raised when a specific function isn't supported by the installed
+    version of the NI-DAQmx driver.
+    """
+    pass
+
+
 class DaqError(Error):
     """
     Error raised by any DAQmx method.

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -9,14 +9,14 @@ from typing import cast
 from nidaqmx.errors import DaqNotFoundError, DaqNotSupportedError, DaqFunctionNotSupportedError
 
 
-DAQ_NOT_FOUND_MESSAGE = "Could not find an installation of NI-DAQmx. Please ensure that NI-DAQmx " \
-                        "is installed on this machine or contact National Instruments for support."
+_DAQ_NOT_FOUND_MESSAGE = "Could not find an installation of NI-DAQmx. Please ensure that NI-DAQmx " \
+                         "is installed on this machine or contact National Instruments for support."
 
-DAQ_NOT_SUPPORTED_MESSAGE = "NI-DAQmx Python is not supported on this platform: {0}. Please " \
-                            "direct any questions or feedback to National Instruments."
+_DAQ_NOT_SUPPORTED_MESSAGE = "NI-DAQmx Python is not supported on this platform: {0}. Please " \
+                             "direct any questions or feedback to National Instruments."
 
-FUNCTION_NOT_SUPPORTED_MESSAGE = "The NI-DAQmx function \"{0}\" is not supported in this version " \
-                                 "of NI-DAQmx. Visit ni.com/downloads to upgrade."
+_FUNCTION_NOT_SUPPORTED_MESSAGE = "The NI-DAQmx function \"{0}\" is not supported in this version " \
+                                  "of NI-DAQmx. Visit ni.com/downloads to upgrade."
 
 
 class c_bool32(ctypes.c_uint):
@@ -93,7 +93,7 @@ class DaqFunctionImporter:
                         cfunc.arglock = threading.Lock()
             return cfunc
         except AttributeError:
-            raise DaqFunctionNotSupportedError(FUNCTION_NOT_SUPPORTED_MESSAGE.format(function))
+            raise DaqFunctionNotSupportedError(_FUNCTION_NOT_SUPPORTED_MESSAGE.format(function))
 
 
 class DaqLibImporter:
@@ -150,16 +150,16 @@ class DaqLibImporter:
                     windll = ctypes.windll.LoadLibrary('nicaiu')
                     cdll = ctypes.cdll.LoadLibrary('nicaiu')
             except (OSError, WindowsError) as e:
-                raise DaqNotFoundError(DAQ_NOT_FOUND_MESSAGE) from e
+                raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE) from e
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')
             if find_library('nidaqmx') is not None:
                 cdll = ctypes.cdll.LoadLibrary(find_library('nidaqmx'))
                 windll = cdll
             else:
-                raise DaqNotFoundError(DAQ_NOT_FOUND_MESSAGE)
+                raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE)
         else:
-            raise DaqNotSupportedError(DAQ_NOT_SUPPORTED_MESSAGE.format(sys.platform))
+            raise DaqNotSupportedError(_DAQ_NOT_SUPPORTED_MESSAGE.format(sys.platform))
 
         self._windll = DaqFunctionImporter(windll)
         self._cdll = DaqFunctionImporter(cdll)

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -170,8 +170,8 @@ class DaqLibImporter:
                 else:
                     windll = ctypes.windll.LoadLibrary('nicaiu')
                     cdll = ctypes.cdll.LoadLibrary('nicaiu')
-            except (OSError, WindowsError):
-                raise DaqNotFoundError()
+            except (OSError, WindowsError) as e:
+                raise DaqNotFoundError() from e
         elif sys.platform.startswith('linux'):
             # On linux you can use the command find_library('nidaqmx')
             if find_library('nidaqmx') is not None:

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -13,6 +13,28 @@ class Error(Exception):
     pass
 
 
+class DaqNotFoundError(Error):
+    """
+    Error raised when NI-DAQmx driver is not installed.
+    """
+    pass
+
+
+class DaqNotSupportedError(Error):
+    """
+    Error raised when DAQmx is not supported on this platform.
+    """
+    pass
+
+
+class DaqFunctionNotSupportedError(Error):
+    """
+    Error raised when a specific function isn't supported by the installed
+    version of the NI-DAQmx driver.
+    """
+    pass
+
+
 class DaqError(Error):
     """
     Error raised by any DAQmx method.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Ensures `nidaqmx` consistently uses `DaqNotFoundError` on Windows. Previously, it would leak ctypes' `OSError` or `WindowsError`. Note: `WindowsError` is now an alias for `OSError`, but they were separate before Python 3.3. IronPython 3.4 seems to indicate its ctypes implementation still uses `WindowsError`, so I am catching both. To be honest, I'm not sure if we care about IronPython, but whatever.

Other small improvement:
* Single source common error strings

### Why should this Pull Request be merged?

Improves UX when using `nidaqmx` without the `NI-DAQmx` driver installed.

### What testing has been done?

Validated error reporting using `system_properties.py` example on a system without NI-DAQmx installed:

```
(.venv) C:\Users\User>python system_properties.py
Traceback (most recent call last):
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\_lib.py", line 150, in _import_lib
    windll = ctypes.windll.LoadLibrary('nicaiu')
  File "C:\Users\User\.pyenv\pyenv-win\versions\3.7.9\lib\ctypes\__init__.py", line 442, in LoadLibrary
    return self._dlltype(name)
  File "C:\Users\User\.pyenv\pyenv-win\versions\3.7.9\lib\ctypes\__init__.py", line 364, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: [WinError 126] The specified module could not be found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "system_properties.py", line 5, in <module>
    driver_version = local_system.driver_version
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\system\system.py", line 89, in driver_version
    return System.DriverVersion(self._major_version, self._minor_version,
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\system\system.py", line 122, in _major_version
    val = self._interpreter.get_system_info_attribute_uint32(0x1272)
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\_library_interpreter.py", line 3272, in get_system_info_attribute_uint32
    cfunc = lib_importer.cdll.DAQmxGetSystemInfoAttribute
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\_lib.py", line 119, in cdll
    self._import_lib()
  File "C:\Users\User\.venv\lib\site-packages\nidaqmx\_lib.py", line 153, in _import_lib
    raise DaqNotFoundError(DAQ_NOT_FOUND_MESSAGE) from e
nidaqmx.errors.DaqNotFoundError: Could not find an installation of NI-DAQmx. Please ensure that NI-DAQmx is installed on this machine or contact National Instruments for support.
```

Ran `pytest` on a system that has NI-DAQmx installed:

```
...
=============== 973 passed, 114 skipped, 54 xfailed in 100.67s (0:01:40) =============== 
```
