### PR TITLE
tests: Update a gRPC specific test case so that `pytest -k "not grpc"` skips it

### DIFF
--- a/tests/component/test_interpreter.py
+++ b/tests/component/test_interpreter.py
@@ -37,12 +37,12 @@ def test___grpc_channel_with_errors___get_error_string___returns_failed_to_retri
 
 
 @pytest.mark.parametrize("error_code", list(_ERROR_MESSAGES))
-def test___known_error_codes___get_error_string_with_error_code___returns_matching_error_message(
+def test___grpc_interpreter_with_known_error_message___get_error_string___returns_matching_error_message(
     grpc_init_kwargs, error_code: int
-):
+) -> None:
     interpreter = GrpcStubInterpreter(**grpc_init_kwargs)
     expected_error_message = _ERROR_MESSAGES[error_code]
 
-    actual_error_message = interpreter.get_error_string(error_code=error_code)
+    actual_error_message = interpreter.get_error_string(error_code)
 
     assert expected_error_message == actual_error_message

--- a/tests/component/test_interpreter.py
+++ b/tests/component/test_interpreter.py
@@ -4,7 +4,6 @@ from nidaqmx._base_interpreter import BaseInterpreter
 from nidaqmx.error_codes import DAQmxErrors
 
 try:
-    from nidaqmx._grpc_interpreter import GrpcStubInterpreter
     from nidaqmx._grpc_interpreter import _ERROR_MESSAGES
 except ImportError:
     _ERROR_MESSAGES = {}
@@ -36,13 +35,11 @@ def test___grpc_channel_with_errors___get_error_string___returns_failed_to_retri
     assert error_message.startswith("Failed to retrieve error description.")
 
 
+@pytest.mark.grpc_only(reason="Tests gRPC-specific error message lookup")
 @pytest.mark.parametrize("error_code", list(_ERROR_MESSAGES))
-def test___grpc_interpreter_with_known_error_message___get_error_string___returns_matching_error_message(
-    grpc_init_kwargs, error_code: int
+def test___error_code_with_hardcoded_error_message___get_error_string___returns_hardcoded_error_message(
+    interpreter: BaseInterpreter, error_code: int
 ) -> None:
-    interpreter = GrpcStubInterpreter(**grpc_init_kwargs)
-    expected_error_message = _ERROR_MESSAGES[error_code]
+    error_message = interpreter.get_error_string(error_code)
 
-    actual_error_message = interpreter.get_error_string(error_code)
-
-    assert expected_error_message == actual_error_message
+    assert error_message == _ERROR_MESSAGES[error_code]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update a gRPC specific test case to use `@pytest.mark.grpc_only` and `init_kwargs` so `pytest -k "not grpc"` skips it. 

This works because the `init_kwargs` parameterization appends `[grpc_init_kwargs]` to the test case name.

### Why should this Pull Request be merged?

Remove a skipped test from pyXX-base runs.

### What testing has been done?

Ran `pytest -vvv tests/component/test_interpreter.py` with and without `-k "not grpc"`.