### PR TITLE
tests: Update GrpcServerProcess to ignore additional output

### DIFF
--- a/tests/_grpc_utils.py
+++ b/tests/_grpc_utils.py
@@ -21,7 +21,7 @@ class GrpcServerProcess:
             self.server_port = None
             while self.server_port is None and self._proc.poll() is None:
                 line = self._proc.stdout.readline()
-                match = re.search(br"Server listening on port (\d+)", line)
+                match = re.search(rb"Server listening on port (\d+)", line)
                 if match:
                     self.server_port = int(match.group(1))
 

--- a/tests/_grpc_utils.py
+++ b/tests/_grpc_utils.py
@@ -1,6 +1,7 @@
 """Helper functions to be used in nidaqmx tests."""
 import os
 import pathlib
+import re
 import subprocess
 import threading
 
@@ -15,13 +16,17 @@ class GrpcServerProcess:
         server_exe = self._get_grpc_server_exe()
         self._proc = subprocess.Popen([str(server_exe)], stdout=subprocess.PIPE)
 
-        # Read/parse first line of output; discard the rest
+        # Read/parse output until we find the port number or the process exits; discard the rest.
         try:
-            first_line = self._proc.stdout.readline()
-            assert first_line.startswith(
-                b"Server listening on port "
-            ), f"Unrecognized output: {first_line}"
-            self.server_port = int(first_line.replace(b"Server listening on port ", b"").strip())
+            self.server_port = None
+            while self.server_port is None and self._proc.poll() is None:
+                line = self._proc.stdout.readline()
+                match = re.search(br"Server listening on port (\d+)", line)
+                if match:
+                    self.server_port = int(match.group(1))
+
+            if self._proc.poll() is not None:
+                raise RuntimeError(f"Server exited with return code {self._proc.returncode}")
 
             self._stdout_thread = threading.Thread(
                 target=self._proc.communicate, args=(), daemon=True


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update `GrpcServerProcess` to ignore additional output.

This is required to handle the additional log output added in https://github.com/ni/grpc-device/pull/989

Also see https://github.com/ni/nimi-python/pull/2006 

### Why should this Pull Request be merged?

Enable tests to pass with the next version of NI gRPC Device Server.

### What testing has been done?

Manually tested with a local build of NI gRPC Device Server.
Added a bogus argument "-asdf" to test the case where the server returns an error. 
At one point I ran the local build without the VS2017 debug CRT installed, and this also caused a hang, but I can't reproduce it because I now have the debug CRT installed.