### PR TITLE
Create channels.py

### DIFF
--- a/src/handwritten/channels.py
+++ b/src/handwritten/channels.py
@@ -1,0 +1,9 @@
+from nidaqmx._task_modules.channels.channel import Channel
+from nidaqmx._task_modules.channels.ai_channel import AIChannel
+from nidaqmx._task_modules.channels.ao_channel import AOChannel
+from nidaqmx._task_modules.channels.ci_channel import CIChannel
+from nidaqmx._task_modules.channels.co_channel import COChannel
+from nidaqmx._task_modules.channels.di_channel import DIChannel
+from nidaqmx._task_modules.channels.do_channel import DOChannel
+
+__all__ = ['Channel', 'AIChannel', 'AOChannel', 'CIChannel', 'COChannel', 'DIChannel', 'DOChannel']


### PR DESCRIPTION
Create the `nidaqmx/channels.py` file to import the channel types gracefully.

The file improves typing annotations. Without the file, there are warnings about accessing `_task_modules`, which is a private module, when getting the `Channel` class or its subclasses.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Expose channel classes from `nidaqmx._task_modules.channels`, primarily for typing annotations, but not limiting to it.

### Why should this Pull Request be merged?

As Python has adopted optional typing annotations, various IDEs help writing code by providing the methods available for a variable. This significantly increases the speed of the code writing, without damaging the quality. Unfortunately, without the file I propose, I can't annotate, for instance, what the `Task.ai_channels.add_ai_voltage_chan()` function returns.

### What testing has been done?

No regression testing has been done by me, for it requires a piece of hardware I'm not allowed to use for the purpose of the testing. However, I do use the code in my copy of `nidaqmx` for more than a year, and it has not caused any troubles.