### PR TITLE
Add Time Trigger API Support for nidaqmx-python

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -148,6 +148,10 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def cfg_time_start_trig(self, task, when, timescale):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def cfg_watchdog_ao_expir_states(
             self, task, channel_names, expir_state_array, output_type_array):
         raise NotImplementedError

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -378,6 +378,11 @@ class GrpcStubInterpreter(BaseInterpreter):
                 active_edge_raw=active_edge, sample_mode_raw=sample_mode,
                 samps_per_chan=samps_per_chan))
 
+    def cfg_time_start_trig(self, task, when, timescale):
+        response = self._invoke(
+            self._client.CfgTimeStartTrig,
+            grpc_types.CfgTimeStartTrigRequest(task=task, when=when, timescale_raw=timescale))
+
     def cfg_watchdog_ao_expir_states(
             self, task, channel_names, expir_state_array, output_type_array):
         response = self._invoke(

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -390,6 +390,18 @@ class LibraryInterpreter(BaseInterpreter):
             task, source, rate, active_edge, sample_mode, samps_per_chan)
         self.check_for_error(error_code)
 
+    def cfg_time_start_trig(self, task, when, timescale):
+        cfunc = lib_importer.windll.DAQmxCfgTimeStartTrig
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, DateTime, ctypes.c_int]
+
+        error_code = cfunc(
+            task, when, timescale)
+        self.check_for_error(error_code)
+
     def cfg_watchdog_ao_expir_states(
             self, task, channel_names, expir_state_array, output_type_array):
         cfunc = lib_importer.windll.DAQmxCfgWatchdogAOExpirStates

--- a/generated/nidaqmx/_task_modules/triggering/start_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/start_trigger.py
@@ -1037,6 +1037,20 @@ class StartTrigger:
         self._interpreter.cfg_dig_pattern_start_trig(
             self._handle, trigger_source, trigger_pattern, trigger_when.value)
 
+    def cfg_time_start_trig(self, when, timescale=Timescale.USE_HOST):
+        """
+        New Start Trigger
+
+        Args:
+            when (nidaqmx.constants.DateTime): Specifies when to
+                trigger.
+            timescale (Optional[nidaqmx.constants.Timescale]): Specifies
+                the start trigger timestamp time scale.
+        """
+
+        self._interpreter.cfg_time_start_trig(
+            self._handle, when, timescale.value)
+
     def disable_start_trig(self):
         """
         Configures the task to start acquiring or generating samples

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -1413,6 +1413,11 @@ functions = {
     },
     'CfgTimeStartTrig': {
         'calling_convention': 'StdCall',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
         'parameters': [
             {
                 'ctypes_data_type': 'ctypes.TaskHandle',
@@ -1447,7 +1452,7 @@ functions = {
                 'type': 'int32'
             }
         ],
-        'python_codegen_method': 'no',
+        'python_class_name': 'StartTrigger',
         'python_description': 'New Start Trigger',
         'returns': 'int32'
     },

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -54,7 +54,6 @@ INTERPRETER_IGNORED_FUNCTIONS = [
     "SetRealTimeAttributeUInt32",
     "WaitForNextSampleClock",
     # Time triggers
-    "CfgTimeStartTrig",
     "GetArmStartTrigTimestampVal",
     "GetArmStartTrigTrigWhen",
     "GetFirstSampClkWhen",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR adds Time Trigger API support for the following functions in nidaqmx-python:
[DAQmxCfgTimeStartTrig ](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/src/daqmx/api/nicai/source/nicai/ctrigger.cpp&version=GBmain&line=209&lineEnd=210&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents)

Remaining API yet to be added (due to functions missing in daqmxAPISharp.json): 
[DAQmxCfgAnlgMultiEdgeRefTrig](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/src/daqmx/api/nicai/source/nicai/ctrigger.cpp&version=GBmain&line=389&lineEnd=436&lineStartColumn=1&lineEndColumn=2&lineStyle=plain&_a=contents)
[DAQmxCfgAnlgMultiEdgeStartTrig](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/src/daqmx/api/nicai/source/nicai/ctrigger.cpp&version=GBmain&line=121&lineEnd=166&lineStartColumn=1&lineEndColumn=2&lineStyle=plain&_a=contents)

Work Item: [[DAQmx] Add Time Triggers API support for nidaqmx-python](https://ni.visualstudio.com/DevCentral/_workitems/edit/2610992)

### Why should this Pull Request be merged?
It provide support for Time Trigger in python.

### What testing has been done?
- Ran nidaqmx-python code generator and validated the API was generated correctly
- TODO: Regression tests for Time Trigger API to be added