### PR TITLE
Address Event Callbacks Contain Unusable Parameters Issue

### DIFF
--- a/tests/_event_utils.py
+++ b/tests/_event_utils.py
@@ -69,6 +69,17 @@ class DoneEventObserver(BaseEventObserver[DoneEvent]):
             self._invoke_side_effect()
         return 0
 
+class DoneEventBasicParametersObserver(BaseEventObserver[DoneEvent]):
+    """An observer for Done events with only basic parameters in callback function."""
+
+    def handle_done_event(self, status: int) -> int:
+        """Handles a Done event."""
+        with self._lock:
+            self._events.append(DoneEvent(status))
+            self._event_semaphore.release()
+            self._invoke_side_effect()
+        return 0
+
 
 class EveryNSamplesEventObserver(BaseEventObserver[EveryNSamplesEvent]):
     """An observer for Every N Samples events."""
@@ -87,12 +98,39 @@ class EveryNSamplesEventObserver(BaseEventObserver[EveryNSamplesEvent]):
             self._invoke_side_effect()
         return 0
 
+class EveryNSamplesEventBasicParametersObserver(BaseEventObserver[EveryNSamplesEvent]):
+    """An observer for Every N Samples events with only basic parameters in callback function."""
+
+    def handle_every_n_samples_event(
+        self,
+        every_n_samples_event_type: int,
+        number_of_samples: int,
+    ) -> int:
+        """Handles an Every N Samples event."""
+        with self._lock:
+            self._events.append(EveryNSamplesEvent(every_n_samples_event_type, number_of_samples))
+            self._event_semaphore.release()
+            self._invoke_side_effect()
+        return 0
 
 class SignalEventObserver(BaseEventObserver[SignalEvent]):
     """An observer for Signal events."""
 
     def handle_signal_event(
         self, task_handle: object, signal_type: int, callback_data: object
+    ) -> int:
+        """Handles a Signal event."""
+        with self._lock:
+            self._events.append(SignalEvent(signal_type))
+            self._event_semaphore.release()
+            self._invoke_side_effect()
+        return 0
+
+class SignalEventBasicParametersObserver(BaseEventObserver[SignalEvent]):
+    """An observer for Signal events with only basic parameters in callback function."""
+
+    def handle_signal_event(
+        self, signal_type: int
     ) -> int:
         """Handles a Signal event."""
         with self._lock:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

Attempt to address the issue brought up in https://github.com/ni/nidaqmx-python/issues/143
Made a wrapper in task.py that takes in the callback_function that doesn't have task_handle or callback_data inside, and pass it to wrappers that modify the function to add in the missing functions respectively.  I guess there must be a more elegant way to approach this issue but this is what I could come up with in a short time. 

Updated functional test to test for the cases when the callback function has missing parameters.

### Why should this Pull Request be merged?

Addresses the issue brought up in https://github.com/ni/nidaqmx-python/issues/143

### What testing has been done?

Functional test coverage added and all pass
![image](https://github.com/ni/nidaqmx-python/assets/74756143/d136f261-800b-41f1-a3e5-e011d9391e15)
