### PR TITLE
Add support for WaitForValidTimestamp to nidaqmx-python

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -1662,6 +1662,10 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def wait_for_valid_timestamp(self, task, timestamp_event, timeout):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def wait_until_task_done(self, task, time_to_wait):
         raise NotImplementedError
 

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3260,7 +3260,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.WaitForValidTimestampRequest(
                 task=task, timestamp_event_raw=timestamp_event,
                 timeout=timeout))
-        return response.timestamp
+        return convert_timestamp_to_time(response.timestamp)
 
     def wait_until_task_done(self, task, time_to_wait):
         response = self._invoke(

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3254,6 +3254,14 @@ class GrpcStubInterpreter(BaseInterpreter):
             self._client.UnreserveNetworkDevice,
             grpc_types.UnreserveNetworkDeviceRequest(device_name=device_name))
 
+    def wait_for_valid_timestamp(self, task, timestamp_event, timeout):
+        response = self._invoke(
+            self._client.WaitForValidTimestamp,
+            grpc_types.WaitForValidTimestampRequest(
+                task=task, timestamp_event_raw=timestamp_event,
+                timeout=timeout))
+        return response.timestamp
+
     def wait_until_task_done(self, task, time_to_wait):
         response = self._invoke(
             self._client.WaitUntilTaskDone,

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -5636,6 +5636,23 @@ class LibraryInterpreter(BaseInterpreter):
             device_name)
         self.check_for_error(error_code)
 
+    def wait_for_valid_timestamp(self, task, timestamp_event, timeout):
+        timestamp = _lib_time.AbsoluteTime()
+
+        cfunc = lib_importer.windll.DAQmxWaitForValidTimestamp
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes.c_int32,
+                        ctypes.c_double,
+                        ctypes.POINTER(_lib_time.AbsoluteTime)]
+
+        error_code = cfunc(
+            task, timestamp_event, timeout, ctypes.byref(timestamp))
+        self.check_for_error(error_code)
+        return timestamp.value
+
     def wait_until_task_done(self, task, time_to_wait):
         cfunc = lib_importer.windll.DAQmxWaitUntilTaskDone
         if cfunc.argtypes is None:

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -3684,7 +3684,7 @@ class LibraryInterpreter(BaseInterpreter):
         error_code = cfunc(
             task, attribute, ctypes.byref(value))
         self.check_for_error(error_code)
-        return value
+        return value.to_datetime()
 
     def get_trig_attribute_uint32(self, task, attribute):
         value = ctypes.c_uint32()
@@ -5637,7 +5637,7 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
 
     def wait_for_valid_timestamp(self, task, timestamp_event, timeout):
-        timestamp = _lib_time.AbsoluteTime()
+        timestamp = AbsoluteTime()
 
         cfunc = lib_importer.windll.DAQmxWaitForValidTimestamp
         if cfunc.argtypes is None:
@@ -5645,13 +5645,12 @@ class LibraryInterpreter(BaseInterpreter):
                 if cfunc.argtypes is None:
                     cfunc.argtypes = [
                         lib_importer.task_handle, ctypes.c_int32,
-                        ctypes.c_double,
-                        ctypes.POINTER(_lib_time.AbsoluteTime)]
+                        ctypes.c_double, ctypes.POINTER(AbsoluteTime)]
 
         error_code = cfunc(
             task, timestamp_event, timeout, ctypes.byref(timestamp))
         self.check_for_error(error_code)
-        return timestamp.value
+        return timestamp.to_datetime()
 
     def wait_until_task_done(self, task, time_to_wait):
         cfunc = lib_importer.windll.DAQmxWaitUntilTaskDone

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -1023,19 +1023,17 @@ class Task:
         """
         Wait until the specified timestamp has a value.
 
-        Use this VI to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
+        Use this method to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
 
         Args:
             timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 
-            timeout (Optional[float]): Specifies the maximum amount of time in
-                seconds to wait for the measurement or generation to complete.
+            timeout (float): Specifies the maximum amount of time in
+                seconds to wait for a valid timestamp.
                 This method returns an error if the time elapses. The
                 default is 10. If you set timeout (sec) to
-                nidaqmx.WAIT_INFINITELY, the method waits indefinitely. If you
-                set timeout (sec) to 0, the method checks once and returns
-                an error if the measurement or generation is not done.
+                nidaqmx.WAIT_INFINITELY, the method waits indefinitely.
         """
-        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event, timeout)
+        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event.value, timeout)
 
     def wait_until_done(self, timeout=10.0):
         """

--- a/generated/nidaqmx/task.py
+++ b/generated/nidaqmx/task.py
@@ -1019,6 +1019,24 @@ class Task:
         """
         self._interpreter.stop_task(self._handle)
 
+    def wait_for_valid_timestamp(self, timestamp_event, timeout=10.0):
+        """
+        Wait until the specified timestamp has a value.
+
+        Use this VI to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
+
+        Args:
+            timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 
+            timeout (Optional[float]): Specifies the maximum amount of time in
+                seconds to wait for the measurement or generation to complete.
+                This method returns an error if the time elapses. The
+                default is 10. If you set timeout (sec) to
+                nidaqmx.WAIT_INFINITELY, the method waits indefinitely. If you
+                set timeout (sec) to 0, the method checks once and returns
+                an error if the measurement or generation is not done.
+        """
+        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event, timeout)
+
     def wait_until_done(self, timeout=10.0):
         """
         Waits for the measurement or generation to complete.

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -23606,6 +23606,11 @@ functions = {
     },
     'WaitForValidTimestamp': {
         'calling_convention': 'StdCall',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
         'parameters': [
             {
                 'ctypes_data_type': 'ctypes.TaskHandle',
@@ -23644,13 +23649,14 @@ functions = {
                 'direction': 'out',
                 'is_optional_in_python': False,
                 'name': 'timestamp',
-                'python_data_type': 'DateTime',
+                'python_data_type': 'datetime',
                 'python_description': 'Specifies the timestamp type to wait on.',
-                'python_type_annotation': 'nidaqmx.constants.DateTime',
+                'python_type_annotation': 'datetime',
                 'type': 'CVIAbsoluteTime'
             }
         ],
-        'python_codegen_method': 'no',
+        'python_class_name': 'Task',
+        'python_codegen_method': 'CustomCode',
         'python_description': 'DAQmx Wait for Valid Timestamp',
         'returns': 'int32'
     },

--- a/src/codegen/utilities/function_helpers.py
+++ b/src/codegen/utilities/function_helpers.py
@@ -197,7 +197,10 @@ def to_param_argtype(parameter):
         if parameter.ctypes_data_type == "ctypes.TaskHandle":
             return "lib_importer.task_handle"
         elif parameter.python_data_type == "datetime":
-            return "AbsoluteTime"
+            if parameter.direction == "in":
+                return "AbsoluteTime"
+            else:
+                return f"ctypes.POINTER(AbsoluteTime)"
         elif parameter.direction == "in":
             # If is string input parameter, use separate custom
             # argtype to convert from unicode to bytes.

--- a/src/codegen/utilities/function_helpers.py
+++ b/src/codegen/utilities/function_helpers.py
@@ -203,8 +203,6 @@ def to_param_argtype(parameter):
             # argtype to convert from unicode to bytes.
             if parameter.ctypes_data_type == "ctypes.c_char_p":
                 return "ctypes_byte_str"
-            elif parameter.python_data_type == "datetime":
-                return "_lib_time.AbsoluteTime"
             elif parameter.python_data_type == "timestampEvent":
                 return "ctypes.c_int32"
             else:
@@ -212,8 +210,6 @@ def to_param_argtype(parameter):
         else:
             if parameter.ctypes_data_type == "ctypes.c_char_p":
                 return parameter.ctypes_data_type
-            elif parameter.python_data_type == "datetime":
-                return "ctypes.POINTER(_lib_time.AbsoluteTime)"
             else:
                 return f"ctypes.POINTER({parameter.ctypes_data_type})"
 

--- a/src/codegen/utilities/function_helpers.py
+++ b/src/codegen/utilities/function_helpers.py
@@ -203,11 +203,17 @@ def to_param_argtype(parameter):
             # argtype to convert from unicode to bytes.
             if parameter.ctypes_data_type == "ctypes.c_char_p":
                 return "ctypes_byte_str"
+            elif parameter.python_data_type == "datetime":
+                return "_lib_time.AbsoluteTime"
+            elif parameter.python_data_type == "timestampEvent":
+                return "ctypes.c_int32"
             else:
                 return parameter.ctypes_data_type or parameter.python_data_type
         else:
             if parameter.ctypes_data_type == "ctypes.c_char_p":
                 return parameter.ctypes_data_type
+            elif parameter.python_data_type == "datetime":
+                return "ctypes.POINTER(_lib_time.AbsoluteTime)"
             else:
                 return f"ctypes.POINTER({parameter.ctypes_data_type})"
 

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -70,7 +70,6 @@ INTERPRETER_IGNORED_FUNCTIONS = [
     "SetSyncPulseTimeWhen",
     "SetTimingAttributeExTimestamp",
     "SetTimingAttributeTimestamp",
-    "SetTrigAttributeTimestamp",
     # Deprecated, not working
     "GetAnalogPowerUpStates",
 ]

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -70,7 +70,7 @@ INTERPRETER_IGNORED_FUNCTIONS = [
     "SetSyncPulseTimeWhen",
     "SetTimingAttributeExTimestamp",
     "SetTimingAttributeTimestamp",
-    "WaitForValidTimestamp",
+    "SetTrigAttributeTimestamp",
     # Deprecated, not working
     "GetAnalogPowerUpStates",
 ]

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -446,8 +446,10 @@ def get_return_values(func):
                 return_values.append(param.parameter_name)
             else:
                 return_values.append(f"{param.parameter_name}.tolist()")
-        elif param.type == "TaskHandle" or param.type == "CVIAbsoluteTime":
+        elif param.type == "TaskHandle":
             return_values.append(param.parameter_name)
+        elif param.type == "CVIAbsoluteTime":
+            return_values.append(f"{param.parameter_name}.to_datetime()")
         else:
             return_values.append(f"{param.parameter_name}.value")
     if func.is_init_method:

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1027,13 +1027,13 @@ class Task:
 
         Args:
             timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 
-            timeout (Optional[float]): Specifies the maximum amount of time in
+            timeout (float): Specifies the maximum amount of time in
                 seconds to wait for a valid timestamp.
                 This method returns an error if the time elapses. The
                 default is 10. If you set timeout (sec) to
                 nidaqmx.WAIT_INFINITELY, the method waits indefinitely.
         """
-        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event, timeout)
+        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event.value, timeout)
 
     def wait_until_done(self, timeout=10.0):
         """

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1023,7 +1023,7 @@ class Task:
         """
         Wait until the specified timestamp has a value.
 
-        Use this VI to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
+        Use this method to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
 
         Args:
             timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1019,6 +1019,24 @@ class Task:
         """
         self._interpreter.stop_task(self._handle)
 
+    def wait_for_valid_timestamp(self, timestamp_event, timeout=10.0):
+        """
+        Wait until the specified timestamp has a value.
+
+        Use this VI to ensure the timestamp has a valid value to prevent an error when querying a timestamp value.
+
+        Args:
+            timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 
+            timeout (Optional[float]): Specifies the maximum amount of time in
+                seconds to wait for the measurement or generation to complete.
+                This method returns an error if the time elapses. The
+                default is 10. If you set timeout (sec) to
+                nidaqmx.WAIT_INFINITELY, the method waits indefinitely. If you
+                set timeout (sec) to 0, the method checks once and returns
+                an error if the measurement or generation is not done.
+        """
+        self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event, timeout)
+
     def wait_until_done(self, timeout=10.0):
         """
         Waits for the measurement or generation to complete.

--- a/src/handwritten/task.py
+++ b/src/handwritten/task.py
@@ -1028,12 +1028,10 @@ class Task:
         Args:
             timestamp_event(nidaqmx.constants.TimestampEvent): Specifies the timestamp type to wait on. 
             timeout (Optional[float]): Specifies the maximum amount of time in
-                seconds to wait for the measurement or generation to complete.
+                seconds to wait for a valid timestamp.
                 This method returns an error if the time elapses. The
                 default is 10. If you set timeout (sec) to
-                nidaqmx.WAIT_INFINITELY, the method waits indefinitely. If you
-                set timeout (sec) to 0, the method checks once and returns
-                an error if the measurement or generation is not done.
+                nidaqmx.WAIT_INFINITELY, the method waits indefinitely.
         """
         self._interpreter.wait_for_valid_timestamp(self._handle, timestamp_event, timeout)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds Time Trigger API support for the following functions in nidaqmx-python:
[DAQmxWaitForValidTimestamp](https://dev.azure.com/ni/DevCentral/_git/ni-central?path=/src/daqmx/api/nicai/source/nicai/ctask.cpp&version=GC83afeb252672d4420622e056eb9aab8930cae7d6&line=1252&lineEnd=1252&lineStartColumn=23&lineEndColumn=49&lineStyle=plain&_a=contents)

### Why should this Pull Request be merged?

It provides support for WaitForValidTimestamp in python.

### What testing has been done?

Ran nidaqmx-python code generator and validated the API was generated correctly
All existing functional test passed.
![image](https://github.com/ni/nidaqmx-python/assets/74756143/1941ccb0-bb52-4181-91f4-749e68a67331)
Increasing functional test coverage to cover this function will be done in another PR.







