### PR TITLE
import MAX config when running system tests

### DIFF
--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
-      - name: Import DAQmx Config
+      - name: Import DAQmx config
         run: C:\nidaqmxconfig\targets\win64U\x64\msvc-14.0\release\nidaqmxconfig.exe --eraseconfig --import tests\max_config\nidaqmxMaxConfig.ini
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+      - name: Import DAQmx Config
+        run: C:\nidaqmxconfig\targets\win64U\x64\msvc-14.0\release\nidaqmxconfig.exe --eraseconfig --import tests\max_config\nidaqmxMaxConfig.ini
       - name: Install dependencies
         run: poetry install
       - name: Run system tests


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Attempting to dynamically import the MAX configuration required for system tests rather than rely on the system image to have done that.

### Why should this Pull Request be merged?

Less maintenance cost of the system image.

### What testing has been done?

PR build ran the new test_ai_channel.py tests:
* Reported 50 more tests than before (1200 vs 1150)
* Downloaded the XML and confirmed those tests ran
* Log of import step looks correct

```
Run C:\nidaqmxconfig\targets\win64U\x64\msvc-14.0\release\nidaqmxconfig.exe --eraseconfig --import tests\max_config\nidaqmxMaxConfig.ini
Processed:
   Deleting nidaqmxMultithreadingTester2
   Deleting nidaqmxMultithreadingTester3
   Deleting nidaqmxMultithreadingTester1
   Deleting nidaqmxMultithreadingTester4
   Deleting aoTester
   Deleting bridgeTester
   Deleting tsChassisTester
   Deleting cdaqChassisTester
   aoTester
   AOTesterTask
   AOTesterTask/VoltageOut_0
   AOTesterTask/VoltageOut_1
   AOTesterTask/VoltageOut_2
   bridgeTester
   cdaqChassisTester
   chargeTester
   dmmTester
   double_gain_scale
   dsaTester
   nidaqmxMultithreadingTester1
   nidaqmxMultithreadingTester2
   nidaqmxMultithreadingTester3
   nidaqmxMultithreadingTester4
   no_scaling_scale
   polynomial_scale
   positionTester
   RM-24999_A/bridgeTester/0
   tempTester
   tsChassisTester
   tsPowerTester1
   tsPowerTester2
   tsVoltageTester1
   VoltageTesterChannel
   VoltageTesterChannel2
   VoltageTesterTask
   VoltageTesterTask/Voltage_0
Success
```