### PR TITLE
Add Digital and Counter create channel tests

### DIFF
--- a/tests/component/_task_modules/channels/test_ai_channel.py
+++ b/tests/component/_task_modules/channels/test_ai_channel.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from nidaqmx import Task
@@ -53,13 +55,13 @@ from tests.helpers import configure_teds
 def test___task___add_ai_voltage_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-    desired_term_config,
-    expected_term_cfg,
-    min_val,
-    max_val,
-    units,
-    custom_scale_name,
-):
+    desired_term_config: TerminalConfiguration,
+    expected_term_cfg: TerminalConfiguration,
+    min_val: float,
+    max_val: float,
+    units: VoltageUnits,
+    custom_scale_name: str,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_voltage_chan(
         sim_6363_device.ai_physical_chans[0].name,
         terminal_config=desired_term_config,
@@ -80,8 +82,8 @@ def test___task___add_ai_voltage_chan___sets_channel_attributes(
 def test___task___add_teds_ai_voltage_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-    voltage_teds_file_path,
-):
+    voltage_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(sim_6363_device.ai_physical_chans[0], voltage_teds_file_path) as phys_chan:
         chan: AIChannel = task.ai_channels.add_teds_ai_voltage_chan(
             phys_chan.name,
@@ -102,8 +104,12 @@ def test___task___add_teds_ai_voltage_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_accel_4_wire_dc_voltage_chan___sets_channel_attributes(
-    task: Task, sim_charge_device: Device, units, sensitivity, sensitivity_units
-):
+    task: Task,
+    sim_charge_device: Device,
+    units: AccelUnits,
+    sensitivity: float,
+    sensitivity_units: AccelSensitivityUnits,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_accel_4_wire_dc_voltage_chan(
         sim_charge_device.ai_physical_chans[0].name,
         units=units,
@@ -125,8 +131,12 @@ def test___task___add_ai_accel_4_wire_dc_voltage_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_accel_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, units, sensitivity, sensitivity_units
-):
+    task: Task,
+    sim_dsa_device: Device,
+    units: AccelUnits,
+    sensitivity: float,
+    sensitivity_units: AccelSensitivityUnits,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_accel_chan(
         sim_dsa_device.ai_physical_chans[0].name,
         units=units,
@@ -148,8 +158,11 @@ def test___task___add_ai_accel_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_accel_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device, accelerometer_teds_file_path, units
-):
+    task: Task,
+    sim_dsa_device: Device,
+    accelerometer_teds_file_path: pathlib.Path,
+    units: AccelUnits,
+) -> None:
     with configure_teds(
         sim_dsa_device.ai_physical_chans[0], accelerometer_teds_file_path
     ) as phys_chan:
@@ -177,8 +190,12 @@ def test___task___add_teds_ai_accel_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_accel_charge_chan___sets_channel_attributes(
-    task: Task, sim_charge_device: Device, units, sensitivity, sensitivity_units
-):
+    task: Task,
+    sim_charge_device: Device,
+    units: AccelUnits,
+    sensitivity: float,
+    sensitivity_units: AccelChargeSensitivityUnits,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_accel_charge_chan(
         sim_charge_device.ai_physical_chans[0].name,
         units=units,
@@ -200,8 +217,12 @@ def test___task___add_ai_accel_charge_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_bridge_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, units, bridge_config, nominal_bridge_resistance
-):
+    task: Task,
+    sim_bridge_device: Device,
+    units: BridgeUnits,
+    bridge_config: BridgeConfiguration,
+    nominal_bridge_resistance: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_bridge_chan(
         sim_bridge_device.ai_physical_chans[0].name,
         units=units,
@@ -223,8 +244,11 @@ def test___task___add_ai_bridge_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_bridge_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, bridge_teds_file_path, voltage_excit_val
-):
+    task: Task,
+    sim_bridge_device: Device,
+    bridge_teds_file_path: pathlib.Path,
+    voltage_excit_val: float,
+) -> None:
     with configure_teds(sim_bridge_device.ai_physical_chans[0], bridge_teds_file_path) as phys_chan:
         chan: AIChannel = task.ai_channels.add_teds_ai_bridge_chan(
             phys_chan.name, voltage_excit_val=voltage_excit_val
@@ -242,8 +266,10 @@ def test___task___add_teds_ai_bridge_chan___sets_channel_attributes(
 
 @pytest.mark.parametrize("units", [ChargeUnits.COULOMBS, ChargeUnits.PICO_COULOMBS])
 def test___task___add_ai_charge_chan___sets_channel_attributes(
-    task: Task, sim_charge_device: Device, units
-):
+    task: Task,
+    sim_charge_device: Device,
+    units: ChargeUnits,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_charge_chan(
         sim_charge_device.ai_physical_chans[0].name, units=units
     )
@@ -266,10 +292,10 @@ def test___task___add_ai_charge_chan___sets_channel_attributes(
 def test___task___add_ai_current_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-    shunt_resistor_loc,
-    expected_shunt_resistor_loc,
-    ext_shunt_resistor_val,
-):
+    shunt_resistor_loc: CurrentShuntResistorLocation,
+    expected_shunt_resistor_loc: CurrentShuntResistorLocation,
+    ext_shunt_resistor_val: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_current_chan(
         sim_6363_device.ai_physical_chans[0].name,
         shunt_resistor_loc=shunt_resistor_loc,
@@ -295,11 +321,11 @@ def test___task___add_ai_current_chan___sets_channel_attributes(
 def test___task___add_teds_ai_current_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-    current_teds_file_path,
-    shunt_resistor_loc,
-    expected_shunt_resistor_loc,
-    ext_shunt_resistor_val,
-):
+    current_teds_file_path: pathlib.Path,
+    shunt_resistor_loc: CurrentShuntResistorLocation,
+    expected_shunt_resistor_loc: CurrentShuntResistorLocation,
+    ext_shunt_resistor_val: float,
+) -> None:
     with configure_teds(sim_6363_device.ai_physical_chans[0], current_teds_file_path) as phys_chan:
         chan: AIChannel = task.ai_channels.add_teds_ai_current_chan(
             phys_chan.name,
@@ -324,8 +350,11 @@ def test___task___add_teds_ai_current_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_current_rms_chan___sets_channel_attributes(
-    task: Task, sim_dmm_device: Device, shunt_resistor_loc, expected_shunt_resistor_loc
-):
+    task: Task,
+    sim_dmm_device: Device,
+    shunt_resistor_loc: CurrentShuntResistorLocation,
+    expected_shunt_resistor_loc: CurrentShuntResistorLocation,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_current_rms_chan(
         f"{sim_dmm_device.name}/dmm",
         # dmm is unipolar, defaults don't work
@@ -348,11 +377,11 @@ def test___task___add_ai_current_rms_chan___sets_channel_attributes(
 def test___task___add_ai_force_bridge_polynomial_chan___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
-    bridge_config,
-    nominal_bridge_resistance,
-    forward_coeffs,
-    reverse_coeffs,
-):
+    bridge_config: BridgeConfiguration,
+    nominal_bridge_resistance: float,
+    forward_coeffs: [float],
+    reverse_coeffs: [float],
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_force_bridge_polynomial_chan(
         sim_bridge_device.ai_physical_chans[0].name,
         bridge_config=bridge_config,
@@ -378,11 +407,11 @@ def test___task___add_ai_force_bridge_polynomial_chan___sets_channel_attributes(
 def test___task___add_ai_force_bridge_table_chan___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
-    bridge_config,
-    nominal_bridge_resistance,
-    electrical_vals,
-    physical_vals,
-):
+    bridge_config: BridgeConfiguration,
+    nominal_bridge_resistance: float,
+    electrical_vals: [float],
+    physical_vals: [float],
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_force_bridge_table_chan(
         sim_bridge_device.ai_physical_chans[0].name,
         bridge_config=bridge_config,
@@ -408,13 +437,13 @@ def test___task___add_ai_force_bridge_table_chan___sets_channel_attributes(
 def test___task___add_ai_force_bridge_two_point_lin_chan___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
-    bridge_config,
-    nominal_bridge_resistance,
-    first_electrical_val,
-    second_electrical_val,
-    first_physical_val,
-    second_physical_val,
-):
+    bridge_config: BridgeConfiguration,
+    nominal_bridge_resistance: float,
+    first_electrical_val: float,
+    second_electrical_val: float,
+    first_physical_val: float,
+    second_physical_val: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_force_bridge_two_point_lin_chan(
         sim_bridge_device.ai_physical_chans[0].name,
         bridge_config=bridge_config,
@@ -435,8 +464,10 @@ def test___task___add_ai_force_bridge_two_point_lin_chan___sets_channel_attribut
 
 
 def test___task___add_teds_ai_force_bridge_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, force_bridge_teds_file_path
-):
+    task: Task,
+    sim_bridge_device: Device,
+    force_bridge_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(
         sim_bridge_device.ai_physical_chans[0], force_bridge_teds_file_path
     ) as phys_chan:
@@ -459,8 +490,12 @@ def test___task___add_teds_ai_force_bridge_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_force_iepe_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, units, sensitivity, sensitivity_units
-):
+    task: Task,
+    sim_dsa_device: Device,
+    units: ForceUnits,
+    sensitivity: float,
+    sensitivity_units: ForceIEPESensorSensitivityUnits,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_force_iepe_chan(
         sim_dsa_device.ai_physical_chans[0].name,
         units=units,
@@ -482,8 +517,11 @@ def test___task___add_ai_force_iepe_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_force_iepe_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, force_iepe_teds_file_path, units
-):
+    task: Task,
+    sim_dsa_device: Device,
+    force_iepe_teds_file_path: pathlib.Path,
+    units: ForceUnits,
+) -> None:
     with configure_teds(
         sim_dsa_device.ai_physical_chans[0], force_iepe_teds_file_path
     ) as phys_chan:
@@ -514,8 +552,11 @@ def test___task___add_teds_ai_force_iepe_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_microphone_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, mic_sensitivity, max_snd_press_level
-):
+    task: Task,
+    sim_dsa_device: Device,
+    mic_sensitivity: float,
+    max_snd_press_level: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_microphone_chan(
         sim_dsa_device.ai_physical_chans[0].name,
         mic_sensitivity=mic_sensitivity,
@@ -535,8 +576,11 @@ def test___task___add_ai_microphone_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_microphone_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, microphone_teds_file_path, max_snd_press_level
-):
+    task: Task,
+    sim_dsa_device: Device,
+    microphone_teds_file_path: pathlib.Path,
+    max_snd_press_level: float,
+) -> None:
     with configure_teds(
         sim_dsa_device.ai_physical_chans[0], microphone_teds_file_path
     ) as phys_chan:
@@ -560,8 +604,11 @@ def test___task___add_teds_ai_microphone_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_pos_eddy_curr_prox_probe_chan___sets_channel_attributes(
-    task: Task, sim_dsa_device: Device, sensitivity_units, sensitivity
-):
+    task: Task,
+    sim_dsa_device: Device,
+    sensitivity_units: EddyCurrentProxProbeSensitivityUnits,
+    sensitivity: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_pos_eddy_curr_prox_probe_chan(
         sim_dsa_device.ai_physical_chans[0].name,
         sensitivity_units=sensitivity_units,
@@ -595,12 +642,12 @@ def test___task___add_ai_pos_eddy_curr_prox_probe_chan___sets_channel_attributes
 def test___task___add_ai_pos_lvdt_chan___sets_channel_attributes(
     task: Task,
     sim_position_device: Device,
-    sensitivity_units,
-    sensitivity,
-    ac_excit_wire_mode,
-    voltage_excit_val,
-    voltage_excit_freq,
-):
+    sensitivity_units: LVDTSensitivityUnits,
+    sensitivity: float,
+    ac_excit_wire_mode: ACExcitWireMode,
+    voltage_excit_val: float,
+    voltage_excit_freq: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_pos_lvdt_chan(
         sim_position_device.ai_physical_chans[0].name,
         sensitivity_units=sensitivity_units,
@@ -621,8 +668,7 @@ def test___task___add_ai_pos_lvdt_chan___sets_channel_attributes(
 def test___task___add_teds_ai_pos_lvdt_chan___sets_channel_attributes(
     task: Task,
     sim_position_device: Device,
-    lvdt_teds_file_path,
-):
+) -> None:
     # A bug in the driver prevents us from testing the full functionality of this method.
     # AB#2647979: Devices that don't support Voltage, Custom Voltage with Excitation, Resistance, or
     # RTD inadvertently don't support TEDS (e.g. PXIe-4340)
@@ -635,7 +681,10 @@ def test___task___add_teds_ai_pos_lvdt_chan___sets_channel_attributes(
 
 
 # Nothing novel here vs. lvdt channels.
-def test___task___add_ai_pos_rvdt_chan___sets_channel_attributes(task: Task, sim_position_device):
+def test___task___add_ai_pos_rvdt_chan___sets_channel_attributes(
+    task: Task,
+    sim_position_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_pos_rvdt_chan(
         sim_position_device.ai_physical_chans[0].name
     )
@@ -646,8 +695,7 @@ def test___task___add_ai_pos_rvdt_chan___sets_channel_attributes(task: Task, sim
 def test___task___add_teds_ai_pos_rvdt_chan___sets_channel_attributes(
     task: Task,
     sim_position_device: Device,
-    rvdt_teds_file_path,
-):
+) -> None:
     # A bug in the driver prevents us from testing the full functionality of this method.
     # AB#2647979: Devices that don't support Voltage, Custom Voltage with Excitation, Resistance, or
     # RTD inadvertently don't support TEDS (e.g. PXIe-4340)
@@ -667,8 +715,12 @@ def test___task___add_teds_ai_pos_rvdt_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_power_chan___sets_channel_attributes(
-    task: Task, sim_ts_power_device: Device, voltage_setpoint, current_setpoint, output_enable
-):
+    task: Task,
+    sim_ts_power_device: Device,
+    voltage_setpoint: float,
+    current_setpoint: float,
+    output_enable: bool,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_power_chan(
         f"{sim_ts_power_device.name}/power",
         voltage_setpoint=voltage_setpoint,
@@ -684,8 +736,9 @@ def test___task___add_ai_power_chan___sets_channel_attributes(
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_pressure_bridge_polynomial_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_pressure_bridge_polynomial_chan(
         sim_bridge_device.ai_physical_chans[0].name,
@@ -698,8 +751,9 @@ def test___task___add_ai_pressure_bridge_polynomial_chan___sets_channel_attribut
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_pressure_bridge_table_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_pressure_bridge_table_chan(
         sim_bridge_device.ai_physical_chans[0].name,
@@ -712,8 +766,9 @@ def test___task___add_ai_pressure_bridge_table_chan___sets_channel_attributes(
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_pressure_bridge_two_point_lin_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_pressure_bridge_two_point_lin_chan(
         sim_bridge_device.ai_physical_chans[0].name
     )
@@ -722,8 +777,10 @@ def test___task___add_ai_pressure_bridge_two_point_lin_chan___sets_channel_attri
 
 
 def test___task___add_teds_ai_pressure_bridge_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, pressure_bridge_teds_file_path
-):
+    task: Task,
+    sim_bridge_device: Device,
+    pressure_bridge_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(
         sim_bridge_device.ai_physical_chans[0], pressure_bridge_teds_file_path
     ) as phys_chan:
@@ -746,8 +803,10 @@ def test___task___add_teds_ai_pressure_bridge_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_resistance_chan___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_resistance_chan(
         sim_6363_device.ai_physical_chans[0].name, resistance_config=resistance_config
     )
@@ -764,8 +823,11 @@ def test___task___add_ai_resistance_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_resistance_chan___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, resistance_teds_file_path, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    resistance_teds_file_path: pathlib.Path,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     with configure_teds(
         sim_6363_device.ai_physical_chans[0], resistance_teds_file_path
     ) as phys_chan:
@@ -780,8 +842,9 @@ def test___task___add_teds_ai_resistance_chan___sets_channel_attributes(
 
 # Rosette is very complicated, so I'm not parametrizing this test.
 def test___task___add_ai_rosette_strain_gage_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     # #483: add_ai_rosette_strain_gage_chan parameter rosette_meas_types has the wrong type
     task.ai_channels.add_ai_rosette_strain_gage_chan(
         ",".join(sim_bridge_device.ai_physical_chans.channel_names[0:2]),
@@ -801,8 +864,11 @@ def test___task___add_ai_rosette_strain_gage_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_rtd_chan___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, rtd_type, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    rtd_type: RTDType,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_rtd_chan(
         sim_6363_device.ai_physical_chans[0].name,
         rtd_type=rtd_type,
@@ -822,8 +888,11 @@ def test___task___add_ai_rtd_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_rtd_chan___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, rtd_teds_file_path, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    rtd_teds_file_path: pathlib.Path,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     with configure_teds(sim_6363_device.ai_physical_chans[0], rtd_teds_file_path) as phys_chan:
         chan: AIChannel = task.ai_channels.add_teds_ai_rtd_chan(
             phys_chan.name, resistance_config=resistance_config
@@ -847,8 +916,12 @@ def test___task___add_teds_ai_rtd_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_strain_gage_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, strain_config, gage_factor, nominal_gage_resistance
-):
+    task: Task,
+    sim_bridge_device: Device,
+    strain_config: StrainGageBridgeType,
+    gage_factor: float,
+    nominal_gage_resistance: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_strain_gage_chan(
         sim_bridge_device.ai_physical_chans[0].name,
         strain_config=strain_config,
@@ -863,8 +936,10 @@ def test___task___add_ai_strain_gage_chan___sets_channel_attributes(
 
 
 def test___task___add_ai_teds_strain_gage_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, strain_gage_teds_file_path
-):
+    task: Task,
+    sim_bridge_device: Device,
+    strain_gage_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(
         sim_bridge_device.ai_physical_chans[0], strain_gage_teds_file_path
     ) as phys_chan:
@@ -881,8 +956,9 @@ def test___task___add_ai_teds_strain_gage_chan___sets_channel_attributes(
 
 
 def test___task___add_ai_temp_built_in_sensor_chan___sets_channel_attributes(
-    task: Task, sim_6363_device
-):
+    task: Task,
+    sim_6363_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_temp_built_in_sensor_chan(
         f"{sim_6363_device.name}/_boardTempSensor_vs_aignd"
     )
@@ -898,8 +974,12 @@ def test___task___add_ai_temp_built_in_sensor_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_thrmcpl_chan___sets_channel_attributes(
-    task: Task, sim_temperature_device: Device, thermocouple_type, cjc_source, cjc_val
-):
+    task: Task,
+    sim_temperature_device: Device,
+    thermocouple_type: ThermocoupleType,
+    cjc_source: CJCSource,
+    cjc_val: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_thrmcpl_chan(
         sim_temperature_device.ai_physical_chans[0].name,
         thermocouple_type=thermocouple_type,
@@ -921,8 +1001,12 @@ def test___task___add_ai_thrmcpl_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_thrmcpl_chan___sets_channel_attributes(
-    task: Task, sim_temperature_device: Device, thermocouple_teds_file_path, cjc_source, cjc_val
-):
+    task: Task,
+    sim_temperature_device: Device,
+    thermocouple_teds_file_path: pathlib.Path,
+    cjc_source: CJCSource,
+    cjc_val: float,
+) -> None:
     with configure_teds(
         sim_temperature_device.ai_physical_chans[0], thermocouple_teds_file_path
     ) as phys_chan:
@@ -948,8 +1032,13 @@ def test___task___add_teds_ai_thrmcpl_chan___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_thrmstr_chan_iex___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, resistance_config, a, b, c
-):
+    task: Task,
+    sim_6363_device: Device,
+    resistance_config: ResistanceConfiguration,
+    a: float,
+    b: float,
+    c: float,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_thrmstr_chan_iex(
         sim_6363_device.ai_physical_chans[0].name,
         resistance_config=resistance_config,
@@ -973,8 +1062,11 @@ def test___task___add_ai_thrmstr_chan_iex___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_thrmstr_chan_iex___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, thermistor_iex_teds_file_path, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    thermistor_iex_teds_file_path: pathlib.Path,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     with configure_teds(
         sim_6363_device.ai_physical_chans[0], thermistor_iex_teds_file_path
     ) as phys_chan:
@@ -1000,8 +1092,11 @@ def test___task___add_teds_ai_thrmstr_chan_iex___sets_channel_attributes(
     ],
 )
 def test___task___add_ai_thrmstr_chan_vex___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, units, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    units: TemperatureUnits,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_thrmstr_chan_vex(
         sim_6363_device.ai_physical_chans[0].name, units=units, resistance_config=resistance_config
     )
@@ -1019,8 +1114,12 @@ def test___task___add_ai_thrmstr_chan_vex___sets_channel_attributes(
     ],
 )
 def test___task___add_teds_ai_thrmstr_chan_vex___sets_channel_attributes(
-    task: Task, sim_6363_device: Device, thermistor_vex_teds_file_path, units, resistance_config
-):
+    task: Task,
+    sim_6363_device: Device,
+    thermistor_vex_teds_file_path: pathlib.Path,
+    units: TemperatureUnits,
+    resistance_config: ResistanceConfiguration,
+) -> None:
     with configure_teds(
         sim_6363_device.ai_physical_chans[0], thermistor_vex_teds_file_path
     ) as phys_chan:
@@ -1042,8 +1141,9 @@ def test___task___add_teds_ai_thrmstr_chan_vex___sets_channel_attributes(
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_torque_bridge_polynomial_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_torque_bridge_polynomial_chan(
         sim_bridge_device.ai_physical_chans[0].name,
@@ -1056,8 +1156,9 @@ def test___task___add_ai_torque_bridge_polynomial_chan___sets_channel_attributes
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_torque_bridge_table_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_torque_bridge_table_chan(
         sim_bridge_device.ai_physical_chans[0].name,
@@ -1070,8 +1171,9 @@ def test___task___add_ai_torque_bridge_table_chan___sets_channel_attributes(
 
 # Nothing novel here vs. other bridge-based channels.
 def test___task___add_ai_torque_bridge_two_point_lin_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device
-):
+    task: Task,
+    sim_bridge_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_torque_bridge_two_point_lin_chan(
         sim_bridge_device.ai_physical_chans[0].name
     )
@@ -1080,8 +1182,10 @@ def test___task___add_ai_torque_bridge_two_point_lin_chan___sets_channel_attribu
 
 
 def test___task___add_teds_ai_torque_bridge_chan___sets_channel_attributes(
-    task: Task, sim_bridge_device: Device, torque_bridge_teds_file_path
-):
+    task: Task,
+    sim_bridge_device: Device,
+    torque_bridge_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(
         sim_bridge_device.ai_physical_chans[0], torque_bridge_teds_file_path
     ) as phys_chan:
@@ -1097,7 +1201,10 @@ def test___task___add_teds_ai_torque_bridge_chan___sets_channel_attributes(
 
 
 # Nothing novel here vs. other iepe channels.
-def test___task___add_ai_velocity_iepe_chan___sets_channel_attributes(task: Task, sim_dsa_device):
+def test___task___add_ai_velocity_iepe_chan___sets_channel_attributes(
+    task: Task,
+    sim_dsa_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_velocity_iepe_chan(
         sim_dsa_device.ai_physical_chans[0].name
     )
@@ -1115,13 +1222,13 @@ def test___task___add_ai_velocity_iepe_chan___sets_channel_attributes(task: Task
 def test___task___add_ai_voltage_chan_with_excit___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-    min_val,
-    max_val,
-    bridge_config,
-    voltage_excit_source,
-    voltage_excit_val,
-    use_excit_for_scaling,
-):
+    min_val: float,
+    max_val: float,
+    bridge_config: BridgeConfiguration,
+    voltage_excit_source: ExcitationSource,
+    voltage_excit_val: float,
+    use_excit_for_scaling: bool,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_voltage_chan_with_excit(
         sim_6363_device.ai_physical_chans[0].name,
         min_val=min_val,
@@ -1144,8 +1251,8 @@ def test___task___add_ai_voltage_chan_with_excit___sets_channel_attributes(
 def test___task___add_teds_ai_voltage_chan_with_excit___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
-    bridge_teds_file_path,
-):
+    bridge_teds_file_path: pathlib.Path,
+) -> None:
     with configure_teds(sim_bridge_device.ai_physical_chans[0], bridge_teds_file_path) as phys_chan:
         chan: AIChannel = task.ai_channels.add_teds_ai_voltage_chan_with_excit(
             phys_chan.name,
@@ -1164,7 +1271,10 @@ def test___task___add_teds_ai_voltage_chan_with_excit___sets_channel_attributes(
         assert chan.ai_excit_use_for_scaling
 
 
-def test___task___add_ai_voltage_rms_chan___sets_channel_attributes(task: Task, sim_dmm_device):
+def test___task___add_ai_voltage_rms_chan___sets_channel_attributes(
+    task: Task,
+    sim_dmm_device: Device,
+) -> None:
     chan: AIChannel = task.ai_channels.add_ai_voltage_rms_chan(
         f"{sim_dmm_device.name}/dmm", min_val=0.0, max_val=1.0
     )

--- a/tests/component/_task_modules/channels/test_ci_channel.py
+++ b/tests/component/_task_modules/channels/test_ci_channel.py
@@ -1,0 +1,385 @@
+import pytest
+
+from nidaqmx import Task
+from nidaqmx._task_modules.channels import CIChannel
+from nidaqmx.constants import (
+    AngleUnits,
+    CountDirection,
+    CounterFrequencyMethod,
+    Edge,
+    EncoderType,
+    EncoderZIndexPhase,
+    UsageTypeCI,
+)
+from nidaqmx.system import Device
+
+
+# Note: Tests for other channel types will be less complete given that the underlying Python
+# implementation is code-generated and the underlying C API implementation is well unit-tested.
+@pytest.mark.parametrize(
+    "decoding_type, zidx_enable, zidx_val, zidx_phase, units, pulses_per_rev, initial_angle, custom_scale_name",
+    [
+        (
+            EncoderType.TWO_PULSE_COUNTING,
+            True,
+            30.0,
+            EncoderZIndexPhase.AHIGH_BHIGH,
+            AngleUnits.DEGREES,
+            24,
+            15.0,
+            "",
+        ),
+        (
+            EncoderType.X_2,
+            False,
+            0.0,
+            EncoderZIndexPhase.AHIGH_BLOW,
+            AngleUnits.RADIANS,
+            12,
+            0.0,
+            "",
+        ),
+        (
+            EncoderType.X_4,
+            False,
+            0.0,
+            EncoderZIndexPhase.AHIGH_BLOW,
+            AngleUnits.FROM_CUSTOM_SCALE,
+            8,
+            0.0,
+            "degrees_scale",
+        ),
+    ],
+)
+def test___task___add_ci_ang_encoder_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    decoding_type: EncoderType,
+    zidx_enable: bool,
+    zidx_val: float,
+    zidx_phase: EncoderZIndexPhase,
+    units: AngleUnits,
+    pulses_per_rev: int,
+    initial_angle: float,
+    custom_scale_name: str,
+):
+    chan: CIChannel = task.ci_channels.add_ci_ang_encoder_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        decoding_type=decoding_type,
+        zidx_enable=zidx_enable,
+        zidx_val=zidx_val,
+        zidx_phase=zidx_phase,
+        units=units,
+        pulses_per_rev=pulses_per_rev,
+        initial_angle=initial_angle,
+        custom_scale_name=custom_scale_name,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.POSITION_ANGULAR_ENCODER
+    assert chan.ci_encoder_decoding_type == decoding_type
+    assert chan.ci_encoder_z_index_enable == zidx_enable
+    assert chan.ci_encoder_z_index_val == zidx_val
+    assert chan.ci_encoder_z_index_phase == zidx_phase
+    assert chan.ci_ang_encoder_units == units
+    assert chan.ci_ang_encoder_pulses_per_rev == pulses_per_rev
+    assert chan.ci_ang_encoder_initial_angle == initial_angle
+    assert chan.ci_custom_scale.name == custom_scale_name
+
+
+@pytest.mark.parametrize(
+    "decoding_type, pulses_per_rev",
+    [
+        (EncoderType.TWO_PULSE_COUNTING, 24),
+        (EncoderType.X_2, 12),
+        (EncoderType.X_4, 8),
+    ],
+)
+def test___task___add_ci_ang_velocity_chan___sets_channel_attributes(
+    task: Task,
+    sim_velocity_device: Device,
+    decoding_type: EncoderType,
+    pulses_per_rev: int,
+):
+    chan: CIChannel = task.ci_channels.add_ci_ang_velocity_chan(
+        sim_velocity_device.ci_physical_chans[0].name,
+        decoding_type=decoding_type,
+        pulses_per_rev=pulses_per_rev,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.VELOCITY_ANGULAR_ENCODER
+    assert chan.ci_velocity_encoder_decoding_type == decoding_type
+    assert chan.ci_velocity_ang_encoder_pulses_per_rev == pulses_per_rev
+
+
+@pytest.mark.parametrize(
+    "edge, initial_count, count_direction",
+    [
+        (Edge.RISING, 0, CountDirection.COUNT_UP),
+        (Edge.FALLING, 1, CountDirection.COUNT_DOWN),
+    ],
+)
+def test___task___add_ci_count_edges_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    edge: Edge,
+    initial_count: int,
+    count_direction: CountDirection,
+):
+    chan: CIChannel = task.ci_channels.add_ci_count_edges_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        edge=edge,
+        initial_count=initial_count,
+        count_direction=count_direction,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.COUNT_EDGES
+    assert chan.ci_count_edges_active_edge
+    assert chan.ci_count_edges_initial_cnt == initial_count
+    assert chan.ci_count_edges_dir == count_direction
+
+
+@pytest.mark.parametrize(
+    "edge",
+    [Edge.RISING, Edge.FALLING],
+)
+def test___task___add_ci_duty_cycle_chan___sets_channel_attributes(
+    task: Task,
+    sim_velocity_device: Device,
+    edge: Edge,
+):
+    chan: CIChannel = task.ci_channels.add_ci_duty_cycle_chan(
+        sim_velocity_device.ci_physical_chans[0].name,
+        edge=edge,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.DUTY_CYCLE
+    assert chan.ci_duty_cycle_starting_edge == edge
+
+
+@pytest.mark.parametrize(
+    "edge, meas_method, meas_time, divisor",
+    [
+        (Edge.RISING, CounterFrequencyMethod.LOW_FREQUENCY_1_COUNTER, 0.001, 4),
+        (Edge.FALLING, CounterFrequencyMethod.HIGH_FREQUENCY_2_COUNTERS, 0.002, 4),
+        (Edge.RISING, CounterFrequencyMethod.LARGE_RANGE_2_COUNTERS, 0.001, 8),
+    ],
+)
+def test___task___add_ci_freq_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    edge: Edge,
+    meas_method: CounterFrequencyMethod,
+    meas_time: float,
+    divisor: int,
+):
+    chan: CIChannel = task.ci_channels.add_ci_freq_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        edge=edge,
+        meas_method=meas_method,
+        meas_time=meas_time,
+        divisor=divisor,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.FREQUENCY
+    assert chan.ci_freq_starting_edge == edge
+    assert chan.ci_freq_meas_meth == meas_method
+    # these properties are only relevant for certain measurement methods, and
+    # otherwise the coercion behavior is hard to rationalize
+    if meas_method == CounterFrequencyMethod.HIGH_FREQUENCY_2_COUNTERS:
+        assert chan.ci_freq_meas_time == meas_time
+    elif meas_method == CounterFrequencyMethod.LARGE_RANGE_2_COUNTERS:
+        assert chan.ci_freq_div == divisor
+
+
+# No active devices support the GPS Timestamp channel.
+@pytest.mark.parametrize(
+    "decoding_type, dist_per_pulse, initial_pos",
+    [
+        (
+            EncoderType.TWO_PULSE_COUNTING,
+            0.001,
+            0.0,
+        ),
+        (
+            EncoderType.X_2,
+            0.002,
+            0.002,
+        ),
+        (
+            EncoderType.X_4,
+            0.004,
+            0.0,
+        ),
+    ],
+)
+def test___task___add_ci_lin_encoder_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    decoding_type: EncoderType,
+    dist_per_pulse: float,
+    initial_pos: float,
+):
+    chan: CIChannel = task.ci_channels.add_ci_lin_encoder_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        decoding_type=decoding_type,
+        dist_per_pulse=dist_per_pulse,
+        initial_pos=initial_pos,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.POSITION_LINEAR_ENCODER
+    assert chan.ci_encoder_decoding_type == decoding_type
+    assert chan.ci_lin_encoder_dist_per_pulse == dist_per_pulse
+    assert chan.ci_lin_encoder_initial_pos == initial_pos
+
+
+@pytest.mark.parametrize(
+    "decoding_type, dist_per_pulse",
+    [
+        (EncoderType.TWO_PULSE_COUNTING, 0.001),
+        (EncoderType.X_2, 0.002),
+        (EncoderType.X_4, 0.004),
+    ],
+)
+def test___task___add_ci_lin_velocity_chan___sets_channel_attributes(
+    task: Task,
+    sim_velocity_device: Device,
+    decoding_type: EncoderType,
+    dist_per_pulse: float,
+):
+    chan: CIChannel = task.ci_channels.add_ci_lin_velocity_chan(
+        sim_velocity_device.ci_physical_chans[0].name,
+        decoding_type=decoding_type,
+        dist_per_pulse=dist_per_pulse,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.VELOCITY_LINEAR_ENCODER
+    assert chan.ci_velocity_encoder_decoding_type == decoding_type
+    assert chan.ci_velocity_lin_encoder_dist_per_pulse == dist_per_pulse
+
+
+@pytest.mark.parametrize(
+    "edge, meas_method, meas_time, divisor",
+    [
+        (Edge.RISING, CounterFrequencyMethod.LOW_FREQUENCY_1_COUNTER, 0.001, 4),
+        (Edge.FALLING, CounterFrequencyMethod.HIGH_FREQUENCY_2_COUNTERS, 0.002, 4),
+        (Edge.RISING, CounterFrequencyMethod.LARGE_RANGE_2_COUNTERS, 0.001, 8),
+    ],
+)
+def test___task___add_ci_period_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    edge: Edge,
+    meas_method: CounterFrequencyMethod,
+    meas_time: float,
+    divisor: int,
+):
+    chan: CIChannel = task.ci_channels.add_ci_period_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        edge=edge,
+        meas_method=meas_method,
+        meas_time=meas_time,
+        divisor=divisor,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PERIOD
+    assert chan.ci_period_starting_edge == edge
+    assert chan.ci_period_meas_meth == meas_method
+    # these properties are only relevant for certain measurement methods, and
+    # otherwise the coercion behavior is hard to rationalize
+    if meas_method == CounterFrequencyMethod.HIGH_FREQUENCY_2_COUNTERS:
+        assert chan.ci_period_meas_time == meas_time
+    elif meas_method == CounterFrequencyMethod.LARGE_RANGE_2_COUNTERS:
+        assert chan.ci_period_div == divisor
+
+
+@pytest.mark.parametrize(
+    "source_terminal",
+    ["PFI0", "PFI1"],
+)
+def test___task___add_ci_pulse_chan_ticks___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    source_terminal: str,
+):
+    chan: CIChannel = task.ci_channels.add_ci_pulse_chan_ticks(
+        sim_6363_device.ci_physical_chans[0].name,
+        source_terminal=source_terminal,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_TICKS
+    # terminal will be fully qualified
+    assert source_terminal in chan.ci_ctr_timebase_src
+
+
+# Nothing novel here vs. ticks
+def test___task___add_ci_pulse_chan_time___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+):
+    chan: CIChannel = task.ci_channels.add_ci_pulse_chan_time(
+        sim_6363_device.ci_physical_chans[0].name,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_TIME
+
+
+# Nothing novel here vs. ticks
+def test___task___add_ci_pulse_chan_freq___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+):
+    chan: CIChannel = task.ci_channels.add_ci_pulse_chan_freq(
+        sim_6363_device.ci_physical_chans[0].name,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_FREQ
+
+
+@pytest.mark.parametrize(
+    "starting_edge",
+    [Edge.RISING, Edge.FALLING],
+)
+def test___task___add_ci_pulse_width_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    starting_edge: Edge,
+):
+    chan: CIChannel = task.ci_channels.add_ci_pulse_width_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        starting_edge=starting_edge,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_WIDTH_DIGITAL
+    assert chan.ci_pulse_width_starting_edge == starting_edge
+
+
+def test___task___add_ci_semi_period_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+):
+    chan: CIChannel = task.ci_channels.add_ci_semi_period_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_WIDTH_DIGITAL_SEMI_PERIOD
+
+
+@pytest.mark.parametrize(
+    "first_edge, second_edge",
+    [(Edge.RISING, Edge.FALLING), (Edge.FALLING, Edge.RISING)],
+)
+def test___task___add_ci_two_edge_sep_chan___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    first_edge: Edge,
+    second_edge: Edge,
+):
+    chan: CIChannel = task.ci_channels.add_ci_two_edge_sep_chan(
+        sim_6363_device.ci_physical_chans[0].name,
+        first_edge=first_edge,
+        second_edge=second_edge,
+    )
+
+    assert chan.ci_meas_type == UsageTypeCI.PULSE_WIDTH_DIGITAL_TWO_EDGE_SEPARATION
+    assert chan.ci_two_edge_sep_first_edge == first_edge
+    assert chan.ci_two_edge_sep_second_edge == second_edge

--- a/tests/component/_task_modules/channels/test_ci_channel.py
+++ b/tests/component/_task_modules/channels/test_ci_channel.py
@@ -62,7 +62,7 @@ def test___task___add_ci_ang_encoder_chan___sets_channel_attributes(
     pulses_per_rev: int,
     initial_angle: float,
     custom_scale_name: str,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_ang_encoder_chan(
         sim_6363_device.ci_physical_chans[0].name,
         decoding_type=decoding_type,
@@ -99,7 +99,7 @@ def test___task___add_ci_ang_velocity_chan___sets_channel_attributes(
     sim_velocity_device: Device,
     decoding_type: EncoderType,
     pulses_per_rev: int,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_ang_velocity_chan(
         sim_velocity_device.ci_physical_chans[0].name,
         decoding_type=decoding_type,
@@ -124,7 +124,7 @@ def test___task___add_ci_count_edges_chan___sets_channel_attributes(
     edge: Edge,
     initial_count: int,
     count_direction: CountDirection,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_count_edges_chan(
         sim_6363_device.ci_physical_chans[0].name,
         edge=edge,
@@ -146,7 +146,7 @@ def test___task___add_ci_duty_cycle_chan___sets_channel_attributes(
     task: Task,
     sim_velocity_device: Device,
     edge: Edge,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_duty_cycle_chan(
         sim_velocity_device.ci_physical_chans[0].name,
         edge=edge,
@@ -171,7 +171,7 @@ def test___task___add_ci_freq_chan___sets_channel_attributes(
     meas_method: CounterFrequencyMethod,
     meas_time: float,
     divisor: int,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_freq_chan(
         sim_6363_device.ci_physical_chans[0].name,
         edge=edge,
@@ -218,7 +218,7 @@ def test___task___add_ci_lin_encoder_chan___sets_channel_attributes(
     decoding_type: EncoderType,
     dist_per_pulse: float,
     initial_pos: float,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_lin_encoder_chan(
         sim_6363_device.ci_physical_chans[0].name,
         decoding_type=decoding_type,
@@ -245,7 +245,7 @@ def test___task___add_ci_lin_velocity_chan___sets_channel_attributes(
     sim_velocity_device: Device,
     decoding_type: EncoderType,
     dist_per_pulse: float,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_lin_velocity_chan(
         sim_velocity_device.ci_physical_chans[0].name,
         decoding_type=decoding_type,
@@ -272,7 +272,7 @@ def test___task___add_ci_period_chan___sets_channel_attributes(
     meas_method: CounterFrequencyMethod,
     meas_time: float,
     divisor: int,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_period_chan(
         sim_6363_device.ci_physical_chans[0].name,
         edge=edge,
@@ -300,7 +300,7 @@ def test___task___add_ci_pulse_chan_ticks___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     source_terminal: str,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_pulse_chan_ticks(
         sim_6363_device.ci_physical_chans[0].name,
         source_terminal=source_terminal,
@@ -315,7 +315,7 @@ def test___task___add_ci_pulse_chan_ticks___sets_channel_attributes(
 def test___task___add_ci_pulse_chan_time___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_pulse_chan_time(
         sim_6363_device.ci_physical_chans[0].name,
     )
@@ -327,7 +327,7 @@ def test___task___add_ci_pulse_chan_time___sets_channel_attributes(
 def test___task___add_ci_pulse_chan_freq___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_pulse_chan_freq(
         sim_6363_device.ci_physical_chans[0].name,
     )
@@ -343,7 +343,7 @@ def test___task___add_ci_pulse_width_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     starting_edge: Edge,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_pulse_width_chan(
         sim_6363_device.ci_physical_chans[0].name,
         starting_edge=starting_edge,
@@ -356,7 +356,7 @@ def test___task___add_ci_pulse_width_chan___sets_channel_attributes(
 def test___task___add_ci_semi_period_chan___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_semi_period_chan(
         sim_6363_device.ci_physical_chans[0].name,
     )
@@ -373,7 +373,7 @@ def test___task___add_ci_two_edge_sep_chan___sets_channel_attributes(
     sim_6363_device: Device,
     first_edge: Edge,
     second_edge: Edge,
-):
+) -> None:
     chan: CIChannel = task.ci_channels.add_ci_two_edge_sep_chan(
         sim_6363_device.ci_physical_chans[0].name,
         first_edge=first_edge,

--- a/tests/component/_task_modules/channels/test_co_channel.py
+++ b/tests/component/_task_modules/channels/test_co_channel.py
@@ -20,7 +20,7 @@ def test___task___add_co_pulse_chan_freq___sets_channel_attributes(
     initial_delay: float,
     freq: float,
     duty_cycle: float,
-):
+) -> None:
     chan: COChannel = task.co_channels.add_co_pulse_chan_freq(
         sim_6363_device.ci_physical_chans[0].name,
         idle_state=idle_state,
@@ -51,7 +51,7 @@ def test___task___add_co_pulse_chan_ticks___sets_channel_attributes(
     initial_delay: float,
     low_ticks: int,
     high_ticks: int,
-):
+) -> None:
     chan: COChannel = task.co_channels.add_co_pulse_chan_ticks(
         sim_6363_device.ci_physical_chans[0].name,
         source_terminal=source_terminal,
@@ -84,7 +84,7 @@ def test___task___add_co_pulse_chan_time___sets_channel_attributes(
     initial_delay: float,
     low_time: float,
     high_time: float,
-):
+) -> None:
     chan: COChannel = task.co_channels.add_co_pulse_chan_time(
         sim_6363_device.ci_physical_chans[0].name,
         idle_state=idle_state,

--- a/tests/component/_task_modules/channels/test_co_channel.py
+++ b/tests/component/_task_modules/channels/test_co_channel.py
@@ -1,0 +1,100 @@
+import pytest
+
+from nidaqmx import Task
+from nidaqmx._task_modules.channels import COChannel
+from nidaqmx.constants import Level, UsageTypeCO
+from nidaqmx.system import Device
+
+
+@pytest.mark.parametrize(
+    "idle_state, initial_delay, freq, duty_cycle",
+    [
+        (Level.LOW, 0.001, 1.0, 0.25),
+        (Level.HIGH, 0.002, 100.0, 0.75),
+    ],
+)
+def test___task___add_co_pulse_chan_freq___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    idle_state: Level,
+    initial_delay: float,
+    freq: float,
+    duty_cycle: float,
+):
+    chan: COChannel = task.co_channels.add_co_pulse_chan_freq(
+        sim_6363_device.ci_physical_chans[0].name,
+        idle_state=idle_state,
+        initial_delay=initial_delay,
+        freq=freq,
+        duty_cycle=duty_cycle,
+    )
+
+    assert chan.co_output_type == UsageTypeCO.PULSE_FREQUENCY
+    assert chan.co_pulse_idle_state == idle_state
+    assert chan.co_pulse_freq_initial_delay == initial_delay
+    assert chan.co_pulse_freq == freq
+    assert chan.co_pulse_duty_cyc == duty_cycle
+
+
+@pytest.mark.parametrize(
+    "source_terminal, idle_state, initial_delay, low_ticks, high_ticks",
+    [
+        ("PFI0", Level.LOW, 2, 75, 25),
+        ("100khzTimebase", Level.HIGH, 4, 250, 750),
+    ],
+)
+def test___task___add_co_pulse_chan_ticks___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    source_terminal: str,
+    idle_state: Level,
+    initial_delay: float,
+    low_ticks: int,
+    high_ticks: int,
+):
+    chan: COChannel = task.co_channels.add_co_pulse_chan_ticks(
+        sim_6363_device.ci_physical_chans[0].name,
+        source_terminal=source_terminal,
+        idle_state=idle_state,
+        initial_delay=initial_delay,
+        low_ticks=low_ticks,
+        high_ticks=high_ticks,
+    )
+
+    assert chan.co_output_type == UsageTypeCO.PULSE_TICKS
+    # terminal will be fully qualified
+    assert source_terminal in chan.co_ctr_timebase_src
+    assert chan.co_pulse_idle_state == idle_state
+    assert chan.co_pulse_ticks_initial_delay == initial_delay
+    assert chan.co_pulse_low_ticks == low_ticks
+    assert chan.co_pulse_high_ticks == high_ticks
+
+
+@pytest.mark.parametrize(
+    "idle_state, initial_delay, low_time, high_time",
+    [
+        (Level.LOW, 0.001, 0.75, 0.25),
+        (Level.HIGH, 0.002, 0.0025, 0.0075),
+    ],
+)
+def test___task___add_co_pulse_chan_time___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    idle_state: Level,
+    initial_delay: float,
+    low_time: float,
+    high_time: float,
+):
+    chan: COChannel = task.co_channels.add_co_pulse_chan_time(
+        sim_6363_device.ci_physical_chans[0].name,
+        idle_state=idle_state,
+        initial_delay=initial_delay,
+        low_time=low_time,
+        high_time=high_time,
+    )
+
+    assert chan.co_output_type == UsageTypeCO.PULSE_TIME
+    assert chan.co_pulse_idle_state == idle_state
+    assert chan.co_pulse_time_initial_delay == initial_delay
+    assert chan.co_pulse_low_time == low_time
+    assert chan.co_pulse_high_time == high_time

--- a/tests/component/_task_modules/channels/test_di_channel.py
+++ b/tests/component/_task_modules/channels/test_di_channel.py
@@ -15,7 +15,7 @@ def test___task___add_di_chan_chan_for_all_lines___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     num_lines: int,
-):
+) -> None:
     chan: DIChannel = task.di_channels.add_di_chan(
         flatten_channel_string(sim_6363_device.di_lines[:num_lines].name),
         line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
@@ -34,7 +34,7 @@ def test___task___add_di_chan_chan_per_line___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     num_lines: int,
-):
+) -> None:
     chans: DIChannel = task.di_channels.add_di_chan(
         flatten_channel_string(sim_6363_device.di_lines[:num_lines].name),
         line_grouping=LineGrouping.CHAN_PER_LINE,

--- a/tests/component/_task_modules/channels/test_di_channel.py
+++ b/tests/component/_task_modules/channels/test_di_channel.py
@@ -1,0 +1,46 @@
+import pytest
+
+from nidaqmx import Task
+from nidaqmx._task_modules.channels import DIChannel
+from nidaqmx.constants import LineGrouping, ChannelType
+from nidaqmx.system import Device
+from nidaqmx.utils import flatten_channel_string
+
+
+@pytest.mark.parametrize(
+    "num_lines",
+    [1, 2, 8],
+)
+def test___task___add_di_chan_chan_for_all_lines___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    num_lines: int,
+):
+    chan: DIChannel = task.di_channels.add_di_chan(
+        flatten_channel_string(sim_6363_device.di_lines[:num_lines].name),
+        line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+    )
+
+    assert len(chan) == 1
+    assert chan.chan_type == ChannelType.DIGITAL_INPUT
+    assert chan.di_num_lines == num_lines
+
+
+@pytest.mark.parametrize(
+    "num_lines",
+    [1, 2, 8],
+)
+def test___task___add_di_chan_chan_per_line___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    num_lines: int,
+):
+    chans: DIChannel = task.di_channels.add_di_chan(
+        flatten_channel_string(sim_6363_device.di_lines[:num_lines].name),
+        line_grouping=LineGrouping.CHAN_PER_LINE,
+    )
+
+    assert len(chans) == num_lines
+    for chan in chans:
+        assert chan.chan_type == ChannelType.DIGITAL_INPUT
+        assert chan.di_num_lines == 1

--- a/tests/component/_task_modules/channels/test_do_channel.py
+++ b/tests/component/_task_modules/channels/test_do_channel.py
@@ -15,7 +15,7 @@ def test___task___add_do_chan_chan_for_all_lines___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     num_lines: int,
-):
+) -> None:
     chan: DOChannel = task.do_channels.add_do_chan(
         flatten_channel_string(sim_6363_device.do_lines[:num_lines].name),
         line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
@@ -34,7 +34,7 @@ def test___task___add_do_chan_chan_per_line___sets_channel_attributes(
     task: Task,
     sim_6363_device: Device,
     num_lines: int,
-):
+) -> None:
     chans: DOChannel = task.do_channels.add_do_chan(
         flatten_channel_string(sim_6363_device.do_lines[:num_lines].name),
         line_grouping=LineGrouping.CHAN_PER_LINE,

--- a/tests/component/_task_modules/channels/test_do_channel.py
+++ b/tests/component/_task_modules/channels/test_do_channel.py
@@ -1,0 +1,46 @@
+import pytest
+
+from nidaqmx import Task
+from nidaqmx._task_modules.channels import DOChannel
+from nidaqmx.constants import LineGrouping, ChannelType
+from nidaqmx.system import Device
+from nidaqmx.utils import flatten_channel_string
+
+
+@pytest.mark.parametrize(
+    "num_lines",
+    [1, 2, 8],
+)
+def test___task___add_do_chan_chan_for_all_lines___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    num_lines: int,
+):
+    chan: DOChannel = task.do_channels.add_do_chan(
+        flatten_channel_string(sim_6363_device.do_lines[:num_lines].name),
+        line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+    )
+
+    assert len(chan) == 1
+    assert chan.chan_type == ChannelType.DIGITAL_OUTPUT
+    assert chan.do_num_lines == num_lines
+
+
+@pytest.mark.parametrize(
+    "num_lines",
+    [1, 2, 8],
+)
+def test___task___add_do_chan_chan_per_line___sets_channel_attributes(
+    task: Task,
+    sim_6363_device: Device,
+    num_lines: int,
+):
+    chans: DOChannel = task.do_channels.add_do_chan(
+        flatten_channel_string(sim_6363_device.do_lines[:num_lines].name),
+        line_grouping=LineGrouping.CHAN_PER_LINE,
+    )
+
+    assert len(chans) == num_lines
+    for chan in chans:
+        assert chan.chan_type == ChannelType.DIGITAL_OUTPUT
+        assert chan.do_num_lines == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
 
 @pytest.fixture(scope="function")
-def system(init_kwargs):
+def system(init_kwargs) -> nidaqmx.system.System:
     """Gets system instance based on the grpc options."""
     if "grpc_options" in init_kwargs:
         return nidaqmx.system.System.remote(**init_kwargs)
@@ -87,7 +87,9 @@ def system(init_kwargs):
         return nidaqmx.system.System.local(**init_kwargs)
 
 
-def _x_series_device(device_type, system):
+def _x_series_device(
+    device_type: DeviceType, system: nidaqmx.system.System
+) -> nidaqmx.system.Device:
     for device in system.devices:
         device_type_match = (
             device_type == DeviceType.ANY
@@ -113,7 +115,9 @@ def _x_series_device(device_type, system):
     return None
 
 
-def _device_by_product_type(product_type, device_type, system):
+def _device_by_product_type(
+    product_type, device_type: DeviceType, system: nidaqmx.system.System
+) -> nidaqmx.system.Device:
     for device in system.devices:
         device_type_match = (
             device_type == DeviceType.ANY
@@ -132,31 +136,31 @@ def _device_by_product_type(product_type, device_type, system):
 
 
 @pytest.fixture(scope="function")
-def any_x_series_device(system):
+def any_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets any X Series device information."""
     return _x_series_device(DeviceType.ANY, system)
 
 
 @pytest.fixture(scope="function")
-def real_x_series_device(system):
+def real_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets real X Series device information."""
     return _x_series_device(DeviceType.REAL, system)
 
 
 @pytest.fixture(scope="function")
-def sim_x_series_device(system):
+def sim_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets simulated X Series device information."""
     return _x_series_device(DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_6363_device(system):
+def sim_6363_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 6363."""
     return _device_by_product_type("PCIe-6363", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_ts_chassis(system):
+def sim_ts_chassis(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets simulated TestScale chassis information."""
     # Prefer tsChassisTester if available so that multi-module tests will use
     # modules from the same chassis.
@@ -176,7 +180,7 @@ def sim_ts_chassis(system):
 
 
 @pytest.fixture(scope="function")
-def sim_ts_power_device(sim_ts_chassis):
+def sim_ts_power_device(sim_ts_chassis: nidaqmx.system.Device) -> nidaqmx.system.Device:
     """Gets simulated power device information."""
     for device in sim_ts_chassis.chassis_module_devices:
         if (
@@ -195,7 +199,7 @@ def sim_ts_power_device(sim_ts_chassis):
 
 
 @pytest.fixture(scope="function")
-def sim_ts_voltage_device(sim_ts_chassis):
+def sim_ts_voltage_device(sim_ts_chassis: nidaqmx.system.Device) -> nidaqmx.system.Device:
     """Gets simulated voltage device information."""
     for device in sim_ts_chassis.chassis_module_devices:
         if (
@@ -214,7 +218,7 @@ def sim_ts_voltage_device(sim_ts_chassis):
 
 
 @pytest.fixture(scope="function")
-def sim_ts_power_devices(sim_ts_chassis):
+def sim_ts_power_devices(sim_ts_chassis: nidaqmx.system.Device) -> nidaqmx.system.Device:
     """Gets simulated power devices information."""
     devices = []
     for device in sim_ts_chassis.chassis_module_devices:
@@ -236,49 +240,49 @@ def sim_ts_power_devices(sim_ts_chassis):
 
 
 @pytest.fixture(scope="function")
-def sim_charge_device(system):
+def sim_charge_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 4480."""
     return _device_by_product_type("PXIe-4480", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_dsa_device(system):
+def sim_dsa_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 4466."""
     return _device_by_product_type("PXIe-4466", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_dmm_device(system):
+def sim_dmm_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated myDAQ."""
     return _device_by_product_type("NI myDAQ", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_bridge_device(system):
+def sim_bridge_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 4431."""
     return _device_by_product_type("PXIe-4331", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_position_device(system):
+def sim_position_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 4340."""
     return _device_by_product_type("PXIe-4340", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_temperature_device(system):
+def sim_temperature_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 4353."""
     return _device_by_product_type("PXIe-4353", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def sim_velocity_device(system):
+def sim_velocity_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets a simulated 9361."""
     return _device_by_product_type("NI 9361", DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
-def multi_threading_test_devices(system):
+def multi_threading_test_devices(system: nidaqmx.system.System) -> [nidaqmx.system.Device]:
     """Gets multi threading test devices information."""
     devices = []
     for device in system.devices:
@@ -300,7 +304,7 @@ def multi_threading_test_devices(system):
 
 
 @pytest.fixture(scope="function")
-def device(request, system):
+def device(request, system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets the device information based on the device name."""
     device_name = _get_marker_value(request, "device_name")
     for device in system.devices:
@@ -415,7 +419,7 @@ def generate_task(init_kwargs):
 
 
 @pytest.fixture(scope="function")
-def persisted_task(request, system):
+def persisted_task(request, system: nidaqmx.system.System):
     """Gets the persisted task based on the task name."""
     task_name = _get_marker_value(request, "task_name")
 
@@ -431,7 +435,7 @@ def persisted_task(request, system):
 
 
 @pytest.fixture(scope="function")
-def persisted_scale(request, system):
+def persisted_scale(request, system: nidaqmx.system.System):
     """Gets the persisted scale based on the scale name."""
     scale_name = _get_marker_value(request, "scale_name")
     if scale_name in system.scales:
@@ -445,7 +449,7 @@ def persisted_scale(request, system):
 
 
 @pytest.fixture(scope="function")
-def persisted_channel(request, system):
+def persisted_channel(request, system: nidaqmx.system.System):
     """Gets the persisted channel based on the channel name."""
     channel_name = _get_marker_value(request, "channel_name")
 
@@ -513,7 +517,7 @@ def thread_pool_executor() -> Generator[ThreadPoolExecutor, None, None]:
 
 
 @pytest.fixture
-def interpreter(system: nidaqmx.system.System) -> BaseInterpreter:
+def interpreter(system: nidaqmx.system.system) -> BaseInterpreter:
     """Gets an interpreter."""
     return system._interpreter
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,12 @@ def sim_temperature_device(system):
 
 
 @pytest.fixture(scope="function")
+def sim_velocity_device(system):
+    """Gets a simulated 9361."""
+    return _device_by_product_type("NI 9361", DeviceType.SIMULATED, system)
+
+
+@pytest.fixture(scope="function")
 def multi_threading_test_devices(system):
     """Gets multi threading test devices information."""
     devices = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,7 +517,7 @@ def thread_pool_executor() -> Generator[ThreadPoolExecutor, None, None]:
 
 
 @pytest.fixture
-def interpreter(system: nidaqmx.system.system) -> BaseInterpreter:
+def interpreter(system: nidaqmx.system.System) -> BaseInterpreter:
     """Gets an interpreter."""
     return system._interpreter
 

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -107,6 +107,13 @@ PreScaledUnits = Volts
 ScaledUnits = 
 ScaleType = Polynomial
 
+[DAQmxScale degrees_scale]
+Lin.Slope = 2
+Lin.YIntercept = 0
+PreScaledUnits = Degrees
+ScaledUnits = potatoes
+ScaleType = Linear
+
 [DAQmxDevice aoTester]
 ProductType = PXIe-4322
 DevSerialNum = 0x0
@@ -242,4 +249,11 @@ TCPIP.EthernetIP = 0.0.0.0
 TCPIP.EthernetMAC = 00:00:00:00:00:00
 TCPIP.EthernetMDNSServiceInstance = 
 TCPIP.DevIsReserved = 0
+
+[DAQmxCDAQModule cdaqTesterMod1]
+ProductType = NI 9361
+DevSerialNum = 0x0
+DevIsSimulated = 1
+CompactDAQ.ChassisDevName = cdaqChassisTester
+CompactDAQ.SlotNum = 1
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds a test per DI, DO, CI, and CO create channel methods to validate that they can successfully be used. There is a small amount of functional validation that parameters are properly being passed through the layers of Python and underlying driver API.

### Why should this Pull Request be merged?

This will give us confidence that we haven't broken anything as we refactor parts of the Python and driver stack.

### What testing has been done?

```
$ poetry run ni-python-styleguide fix tests && poetry run ni-python-styleguide lint tests && poetry run pytest -rs
================================ test session starts ================================
platform win32 -- Python 3.10.10, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1529 items
...
============= 1331 passed, 131 skipped, 67 xfailed in 116.93s (0:01:56) =============
```