### PR TITLE
Fix raw-read Function Names Spacing Issue

### DIFF
--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -1087,7 +1087,7 @@ class InStream:
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
     
-    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_all instead.")
+    @deprecation.deprecated(deprecated_in="1.0.0", removed_in="1.2.0", details="Use read_all instead.")
     def readall(self):
         return self.read_all()
 
@@ -1141,7 +1141,7 @@ class InStream:
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
 
-    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_into instead.")
+    @deprecation.deprecated(deprecated_in="1.2.0", removed_in="1.2.0", details="Use read_into instead.")
     def readinto(self, numpy_array):
         return self.read_into(numpy_array)
 

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -1087,7 +1087,7 @@ class InStream:
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
 
-    def readall(self):
+    def read_all(self):
         """
         Reads all available raw samples from the task or virtual channels
         you specify.
@@ -1137,7 +1137,7 @@ class InStream:
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
 
-    def readinto(self, numpy_array):
+    def read_into(self, numpy_array):
         """
         Reads raw samples from the task or virtual channels you specify
         into numpy_array.

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -1086,6 +1086,10 @@ class InStream:
         if number_of_channels * samples_read != number_of_samples:
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
+    
+    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_all instead.")
+    def readall(self):
+        return self.read_all()
 
     def read_all(self):
         """
@@ -1136,6 +1140,10 @@ class InStream:
             type to create and return based on your device specifications.
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
+
+    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_into instead.")
+    def readinto(self, numpy_array):
+        return self.read_into(numpy_array)
 
     def read_into(self, numpy_array):
         """

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -1141,7 +1141,7 @@ class InStream:
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
 
-    @deprecation.deprecated(deprecated_in="1.2.0", removed_in="1.2.0", details="Use read_into instead.")
+    @deprecation.deprecated(deprecated_in="1.0.0", removed_in="1.2.0", details="Use read_into instead.")
     def readinto(self, numpy_array):
         return self.read_into(numpy_array)
 

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -208,7 +208,7 @@ ${property_template.script_property(attribute)}\
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
 
-    def readall(self):
+    def read_all(self):
         """
         Reads all available raw samples from the task or virtual channels
         you specify.
@@ -258,7 +258,7 @@ ${property_template.script_property(attribute)}\
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
 
-    def readinto(self, numpy_array):
+    def read_into(self, numpy_array):
         """
         Reads raw samples from the task or virtual channels you specify
         into numpy_array.

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -208,7 +208,7 @@ ${property_template.script_property(attribute)}\
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
     
-    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_all instead.")
+    @deprecation.deprecated(deprecated_in="1.0.0", removed_in="1.2.0", details="Use read_all instead.")
     def readall(self):
         return self.read_all()
 
@@ -262,7 +262,7 @@ ${property_template.script_property(attribute)}\
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
 
-    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_into instead.")
+    @deprecation.deprecated(deprecated_in="1.0.0", removed_in="1.2.0", details="Use read_into instead.")
     def readinto(self, numpy_array):
         return self.read_into(numpy_array)
 

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -207,6 +207,10 @@ ${property_template.script_property(attribute)}\
         if number_of_channels * samples_read != number_of_samples:
             return numpy_array[:number_of_channels * samples_read]
         return numpy_array
+    
+    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_all instead.")
+    def readall(self):
+        return self.read_all()
 
     def read_all(self):
         """
@@ -257,6 +261,10 @@ ${property_template.script_property(attribute)}\
             type to create and return based on your device specifications.
         """
         return self.read(number_of_samples_per_channel=READ_ALL_AVAILABLE)
+
+    @deprecation.deprecated(deprecated_in="1.2.0", details="Use read_into instead.")
+    def readinto(self, numpy_array):
+        return self.read_into(numpy_array)
 
     def read_into(self, numpy_array):
         """

--- a/tests/component/_task_modules/test_in_stream.py
+++ b/tests/component/_task_modules/test_in_stream.py
@@ -56,6 +56,7 @@ def test___ai_task___read___returns_valid_samples_shape_and_dtype(
     assert data.dtype == numpy.int16
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
 
+
 def test___ai_finite_task___readall___returns_valid_samples_shape_and_dtype(
     ai_sine_task: nidaqmx.Task,
 ) -> None:
@@ -69,6 +70,7 @@ def test___ai_finite_task___readall___returns_valid_samples_shape_and_dtype(
     assert data.shape == (ai_sine_task.number_of_channels * 100,)
     assert data.dtype == numpy.int16
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
 
 def test___ai_continuous_task___readall___returns_valid_samples_shape_and_dtype(
     ai_sine_task: nidaqmx.Task,
@@ -113,7 +115,7 @@ def test___odd_sized_array___readinto___returns_whole_samples_and_clears_padding
     _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
     # Initialize the array to full-scale readings to ensure it is overwritten.
     data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
-    
+
     with pytest.deprecated_call():
         samples_read = task.in_stream.readinto(data)
 

--- a/tests/component/_task_modules/test_in_stream.py
+++ b/tests/component/_task_modules/test_in_stream.py
@@ -57,7 +57,7 @@ def test___ai_task___read___returns_valid_samples_shape_and_dtype(
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
 
 
-def test___ai_finite_task___readall___returns_valid_samples_shape_and_dtype(
+def test___ai_finite_task___read_all___returns_valid_samples_shape_and_dtype(
     ai_sine_task: nidaqmx.Task,
 ) -> None:
     ai_sine_task.timing.cfg_samp_clk_timing(

--- a/tests/component/_task_modules/test_in_stream.py
+++ b/tests/component/_task_modules/test_in_stream.py
@@ -64,14 +64,14 @@ def test___ai_finite_task___readall___returns_valid_samples_shape_and_dtype(
         rate=1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=100
     )
 
-    data = ai_sine_task.in_stream.readall()
+    data = ai_sine_task.in_stream.read_all()
 
     assert data.shape == (ai_sine_task.number_of_channels * 100,)
     assert data.dtype == numpy.int16
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
 
 
-def test___ai_continuous_task___readall___returns_valid_samples_shape_and_dtype(
+def test___ai_continuous_task___read_all___returns_valid_samples_shape_and_dtype(
     ai_sine_task: nidaqmx.Task,
 ) -> None:
     ai_sine_task.timing.cfg_samp_clk_timing(
@@ -83,7 +83,7 @@ def test___ai_continuous_task___readall___returns_valid_samples_shape_and_dtype(
     while ai_sine_task.in_stream.avail_samp_per_chan < min_samples_per_channel:
         time.sleep(10e-3)
 
-    data = ai_sine_task.in_stream.readall()
+    data = ai_sine_task.in_stream.read_all()
 
     assert data.shape[0] >= ai_sine_task.number_of_channels * min_samples_per_channel
     assert data.shape[0] % ai_sine_task.number_of_channels == 0
@@ -92,7 +92,7 @@ def test___ai_continuous_task___readall___returns_valid_samples_shape_and_dtype(
 
 
 @pytest.mark.parametrize("samples_to_read", [1, 10])
-def test___valid_array___readinto___returns_valid_samples(
+def test___valid_array___read_into___returns_valid_samples(
     ai_sine_task: nidaqmx.Task, samples_to_read: int
 ) -> None:
     # Initialize the array to full-scale readings to ensure it is overwritten.
@@ -100,20 +100,20 @@ def test___valid_array___readinto___returns_valid_samples(
         ai_sine_task.number_of_channels * samples_to_read, FULLSCALE_RAW_MAX, dtype=numpy.int16
     )
 
-    samples_read = ai_sine_task.in_stream.readinto(data)
+    samples_read = ai_sine_task.in_stream.read_into(data)
 
     assert samples_read == samples_to_read
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
 
 
-def test___odd_sized_array___readinto___returns_whole_samples_and_clears_padding(
+def test___odd_sized_array___read_into___returns_whole_samples_and_clears_padding(
     task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device
 ) -> None:
     _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
     # Initialize the array to full-scale readings to ensure it is overwritten.
     data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
 
-    samples_read = task.in_stream.readinto(data)
+    samples_read = task.in_stream.read_into(data)
 
     assert samples_read == 9
     assert (SINE_RAW_MIN <= data[:-1]).all() and (data[:-1] <= SINE_RAW_MAX).all()

--- a/tests/component/_task_modules/test_in_stream.py
+++ b/tests/component/_task_modules/test_in_stream.py
@@ -56,6 +56,71 @@ def test___ai_task___read___returns_valid_samples_shape_and_dtype(
     assert data.dtype == numpy.int16
     assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
 
+def test___ai_finite_task___readall___returns_valid_samples_shape_and_dtype(
+    ai_sine_task: nidaqmx.Task,
+) -> None:
+    ai_sine_task.timing.cfg_samp_clk_timing(
+        rate=1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=100
+    )
+
+    with pytest.deprecated_call():
+        data = ai_sine_task.in_stream.readall()
+
+    assert data.shape == (ai_sine_task.number_of_channels * 100,)
+    assert data.dtype == numpy.int16
+    assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
+def test___ai_continuous_task___readall___returns_valid_samples_shape_and_dtype(
+    ai_sine_task: nidaqmx.Task,
+) -> None:
+    ai_sine_task.timing.cfg_samp_clk_timing(
+        rate=1000.0, sample_mode=AcquisitionType.CONTINUOUS, samps_per_chan=1000
+    )
+    ai_sine_task.start()
+    # Wait until there are some samples to read.
+    min_samples_per_channel = 100
+    while ai_sine_task.in_stream.avail_samp_per_chan < min_samples_per_channel:
+        time.sleep(10e-3)
+
+    with pytest.deprecated_call():
+        data = ai_sine_task.in_stream.readall()
+
+    assert data.shape[0] >= ai_sine_task.number_of_channels * min_samples_per_channel
+    assert data.shape[0] % ai_sine_task.number_of_channels == 0
+    assert data.dtype == numpy.int16
+    assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
+
+@pytest.mark.parametrize("samples_to_read", [1, 10])
+def test___valid_array___readinto___returns_valid_samples(
+    ai_sine_task: nidaqmx.Task, samples_to_read: int
+) -> None:
+    # Initialize the array to full-scale readings to ensure it is overwritten.
+    data = numpy.full(
+        ai_sine_task.number_of_channels * samples_to_read, FULLSCALE_RAW_MAX, dtype=numpy.int16
+    )
+
+    with pytest.deprecated_call():
+        samples_read = ai_sine_task.in_stream.readinto(data)
+
+    assert samples_read == samples_to_read
+    assert (SINE_RAW_MIN <= data).all() and (data <= SINE_RAW_MAX).all()
+
+
+def test___odd_sized_array___readinto___returns_whole_samples_and_clears_padding(
+    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device
+) -> None:
+    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
+    # Initialize the array to full-scale readings to ensure it is overwritten.
+    data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
+    
+    with pytest.deprecated_call():
+        samples_read = task.in_stream.readinto(data)
+
+    assert samples_read == 9
+    assert (SINE_RAW_MIN <= data[:-1]).all() and (data[:-1] <= SINE_RAW_MAX).all()
+    assert data[-1] == 0  # not FULLSCALE_RAW_MIN
+
 
 def test___ai_finite_task___read_all___returns_valid_samples_shape_and_dtype(
     ai_sine_task: nidaqmx.Task,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR aims to address the issue brought up in #38 
- `readall ` modified to `read_all`
- `readinto` modified to `read_into`

### Why should this Pull Request be merged?
To standardize the raw-read function names spacing.  

### What testing has been done?
- Ran nidaqmx-python code generator and validate the generated file 
- Added and modified regression tests for the related test cases and all tests passed in local machine
Test cases for deprecated function:
![image](https://github.com/ni/nidaqmx-python/assets/55676809/d30b5f83-a73f-4348-8f13-3f54d57d8ce5)
Test cases for new function name:
![image](https://github.com/ni/nidaqmx-python/assets/55676809/419a280b-e774-4b88-b87f-3adf28aeb79d)
