### PR TITLE
 Add Digital Stream Reader tests

### DIFF
--- a/tests/component/test_stream_readers.py
+++ b/tests/component/test_stream_readers.py
@@ -1,6 +1,6 @@
 import ctypes
 import math
-from typing import Callable, List, Union
+from typing import Callable, List, TypeVar, Union
 
 import numpy
 import numpy.typing
@@ -716,9 +716,12 @@ def _bool_array_to_int(bool_array: numpy.typing.NDArray[numpy.bool_]) -> int:
     return result
 
 
+_DType = TypeVar("_DType", bound=numpy.typing.DTypeLike)
+
+
 def _read_and_copy(
-    read_func: Callable[[numpy.typing.NDArray], None], array: numpy.typing.NDArray
-) -> numpy.ndarray:
+    read_func: Callable[[numpy.typing.NDArray[_DType]], None], array: numpy.typing.NDArray[_DType]
+) -> numpy.ndarray[_DType]:
     read_func(array)
     return array.copy()
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This ensures we have a test per method for each of the Digital stream readers classes. The existing and new tests all have channel-specific data validation by taking advantage of the behavior of simulated DAQ digital data. This ensures we don't inadvertently swap channels within the Python or underlying C bindings.

### Why should this Pull Request be merged?

This will give us confidence that we haven't broken anything as we refactor parts of the Python and driver stack.

### What testing has been done?

```
$ poetry run ni-python-styleguide fix tests && poetry run ni-python-styleguide lint tests && poetry run pytest -rsP -k test___digital
=============================== test session starts ===============================
platform win32 -- Python 3.10.10, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1641 items / 1585 deselected / 56 selected

tests\component\test_stream_readers.py ..................................... [ 66%]
...................                                                          [100%]

===================================== PASSES ======================================
======================= 56 passed, 1585 deselected in 2.44s =======================
```