### PR TITLE
fix typing issue in Python 3.8

### DIFF
--- a/tests/component/test_stream_readers.py
+++ b/tests/component/test_stream_readers.py
@@ -725,7 +725,7 @@ _DType = TypeVar("_DType", bound=numpy.typing.DTypeLike)
 
 def _read_and_copy(
     read_func: Callable[[numpy.typing.NDArray[_DType]], None], array: numpy.typing.NDArray[_DType]
-) -> numpy.ndarray[_DType]:
+) -> numpy.typing.NDArray[_DType]:
     read_func(array)
     return array.copy()
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes a typing issue breaking PR/CI with Python 3.8.

### Why should this Pull Request be merged?

Unbreak Actions.

### What testing has been done?

```
$ poetry run tox -epy38-base
...
py38-base: commands[2]> poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=test_results/system-py38-base.xml -k "not grpc and test_stream_readers"
............................................................sssssssssssssssssssss                                [100%]
--------------------- generated xml file: C:\dev\nidaqmx-python\test_results\system-py38-base.xml ---------------------
60 passed, 21 skipped, 1628 deselected in 2.72s
  py38-base: OK (9.48=setup[0.19]+cmd[1.06,3.25,4.98] seconds)
  congratulations :) (9.78 seconds)
```