### PR TITLE
Be more precise with X series device fixtures

### DIFF
--- a/tests/component/_task_modules/channels/test_channel_properties.py
+++ b/tests/component/_task_modules/channels/test_channel_properties.py
@@ -13,10 +13,10 @@ from nidaqmx.scale import Scale
 
 
 @pytest.fixture(scope="function")
-def ai_voltage_chan_with_excit(task, any_x_series_device):
+def ai_voltage_chan_with_excit(task, sim_6363_device):
     """Creates AI Channel object to measure voltage."""
     ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
-        any_x_series_device.ai_physical_chans[0].name,
+        sim_6363_device.ai_physical_chans[0].name,
         voltage_excit_source=ExcitationSource.EXTERNAL,
         voltage_excit_val=0.1,
     )
@@ -24,10 +24,10 @@ def ai_voltage_chan_with_excit(task, any_x_series_device):
 
 
 @pytest.fixture(scope="function")
-def ai_voltage_chan_with_scale(task, any_x_series_device):
+def ai_voltage_chan_with_scale(task, sim_6363_device):
     """Creates AI Channel object to measure voltage with a custom scale."""
     ai_channel = task.ai_channels.add_ai_voltage_chan(
-        any_x_series_device.ai_physical_chans[0].name,
+        sim_6363_device.ai_physical_chans[0].name,
         units=VoltageUnits.FROM_CUSTOM_SCALE,
         custom_scale_name="double_gain_scale",
     )
@@ -47,29 +47,29 @@ def ai_power_chan(task, sim_ts_power_device):
 
 
 @pytest.fixture(scope="function")
-def ai_rtd_chan(task, any_x_series_device):
+def ai_rtd_chan(task, sim_6363_device):
     """Creates AI Channel object that use an RTD to measure temperature."""
     ai_channel = task.ai_channels.add_ai_rtd_chan(
-        any_x_series_device.ai_physical_chans[0].name,
+        sim_6363_device.ai_physical_chans[0].name,
         rtd_type=RTDType.PT_3750,
     )
     yield ai_channel
 
 
 @pytest.fixture(scope="function")
-def ci_pulse_width_chan(task, any_x_series_device):
+def ci_pulse_width_chan(task, sim_6363_device):
     """Creates CI Channel object to measure the width of a digital pulse."""
     ci_channel = task.ci_channels.add_ci_pulse_width_chan(
-        any_x_series_device.ci_physical_chans[0].name,
+        sim_6363_device.ci_physical_chans[0].name,
     )
     yield ci_channel
 
 
 @pytest.fixture(scope="function")
-def ci_count_edges_chan(task, any_x_series_device):
+def ci_count_edges_chan(task, sim_6363_device):
     """Creates CI Channel object to count edges."""
     ci_channel = task.ci_channels.add_ci_count_edges_chan(
-        any_x_series_device.ci_physical_chans[0].name,
+        sim_6363_device.ci_physical_chans[0].name,
     )
     yield ci_channel
 

--- a/tests/component/_task_modules/test_export_signals_properties.py
+++ b/tests/component/_task_modules/test_export_signals_properties.py
@@ -7,16 +7,16 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_task(task, any_x_series_device):
+def ai_voltage_task(task, sim_6363_device):
     """Gets AI voltage task."""
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     yield task
 
 
 @pytest.fixture()
-def ao_voltage_task(task, any_x_series_device):
+def ao_voltage_task(task, sim_6363_device):
     """Gets AO voltage task."""
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     yield task
 
 

--- a/tests/component/_task_modules/test_in_stream.py
+++ b/tests/component/_task_modules/test_in_stream.py
@@ -19,10 +19,10 @@ FULLSCALE_RAW_MIN = -36768
 
 @pytest.fixture(params=[1, 2, 3])
 def ai_sine_task(
-    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device, request: pytest.FixtureRequest
 ) -> nidaqmx.Task:
     """Returns an analog input task with varying number of channels and a simulated sine wave."""
-    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=request.param)
+    _create_ai_sine_channels(task, sim_6363_device, number_of_channels=request.param)
     return task
 
 
@@ -110,9 +110,9 @@ def test___valid_array___readinto___returns_valid_samples(
 
 
 def test___odd_sized_array___readinto___returns_whole_samples_and_clears_padding(
-    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
 ) -> None:
-    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
+    _create_ai_sine_channels(task, sim_6363_device, number_of_channels=2)
     # Initialize the array to full-scale readings to ensure it is overwritten.
     data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
 
@@ -174,9 +174,9 @@ def test___valid_array___read_into___returns_valid_samples(
 
 
 def test___odd_sized_array___read_into___returns_whole_samples_and_clears_padding(
-    task: nidaqmx.Task, sim_x_series_device: nidaqmx.system.Device
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
 ) -> None:
-    _create_ai_sine_channels(task, sim_x_series_device, number_of_channels=2)
+    _create_ai_sine_channels(task, sim_6363_device, number_of_channels=2)
     # Initialize the array to full-scale readings to ensure it is overwritten.
     data = numpy.full(19, FULLSCALE_RAW_MIN, dtype=numpy.int16)
 

--- a/tests/component/_task_modules/test_in_stream_buffer_properties.py
+++ b/tests/component/_task_modules/test_in_stream_buffer_properties.py
@@ -1,8 +1,8 @@
 from nidaqmx.constants import SampleTimingType
 
 
-def test___ai_task___set_int32_property___value_is_set(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___ai_task___set_int32_property___value_is_set(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
 
     # Setting a valid input buffer size of type int32
@@ -11,8 +11,8 @@ def test___ai_task___set_int32_property___value_is_set(task, any_x_series_device
     assert task.in_stream.input_buf_size == 2000000000
 
 
-def test___ai_task___reset_int32_property___value_is_set_to_default(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___ai_task___reset_int32_property___value_is_set_to_default(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
     default_buffer_size = task.in_stream.input_buf_size
     task.in_stream.input_buf_size = 2000000000

--- a/tests/component/_task_modules/test_in_stream_read_properties.py
+++ b/tests/component/_task_modules/test_in_stream_read_properties.py
@@ -6,9 +6,9 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_task(task, any_x_series_device):
+def ai_task(task, sim_6363_device):
     """Gets AI voltage task."""
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     yield task
 
 

--- a/tests/component/_task_modules/test_out_stream.py
+++ b/tests/component/_task_modules/test_out_stream.py
@@ -6,10 +6,10 @@ import nidaqmx
 
 @pytest.fixture(params=[1, 2])
 def ao_task(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device, request: pytest.FixtureRequest
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device, request: pytest.FixtureRequest
 ) -> nidaqmx.Task:
     """Returns an analog output task with a varying number of channels."""
-    _create_ao_channels(task, any_x_series_device, number_of_channels=request.param)
+    _create_ao_channels(task, sim_6363_device, number_of_channels=request.param)
     return task
 
 
@@ -37,9 +37,9 @@ def test___valid_array___write___returns_samples_written(
 
 
 def test___odd_sized_array___write___returns_whole_samples(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
 ) -> None:
-    _create_ao_channels(task, any_x_series_device, number_of_channels=2)
+    _create_ao_channels(task, sim_6363_device, number_of_channels=2)
     task.out_stream.auto_start = True
     data = numpy.full(19, 0x1234, dtype=numpy.int16)
 

--- a/tests/component/_task_modules/test_out_stream_buffer_properties.py
+++ b/tests/component/_task_modules/test_out_stream_buffer_properties.py
@@ -7,9 +7,9 @@ from nidaqmx.errors import DaqError
 
 def test___ai_task___set_valid_value_to_unsupported_property___unsupported_error_raised(
     task,
-    any_x_series_device,
+    sim_6363_device,
 ):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.SAMPLE_CLOCK
 
     with pytest.raises(DaqError) as exc_info:

--- a/tests/component/_task_modules/test_out_stream_write_properties.py
+++ b/tests/component/_task_modules/test_out_stream_write_properties.py
@@ -6,9 +6,9 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ao_task(task, any_x_series_device):
+def ao_task(task, sim_6363_device):
     """Gets AO voltage task."""
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     yield task
 
 

--- a/tests/component/_task_modules/test_timing_properties.py
+++ b/tests/component/_task_modules/test_timing_properties.py
@@ -5,15 +5,15 @@ from nidaqmx.constants import AcquisitionType, SampleTimingType
 from nidaqmx.error_codes import DAQmxErrors
 
 
-def test___timing___get_boolean_property___returns_value(task, any_x_series_device):
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+def test___timing___get_boolean_property___returns_value(task, sim_6363_device):
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
 
     assert not task.timing.simultaneous_ao_enable
 
 
-def test___timing___set_boolean_property___returns_assigned_value(task, any_x_series_device):
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+def test___timing___set_boolean_property___returns_assigned_value(task, sim_6363_device):
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
 
     task.timing.simultaneous_ao_enable = True
@@ -21,8 +21,8 @@ def test___timing___set_boolean_property___returns_assigned_value(task, any_x_se
     assert task.timing.simultaneous_ao_enable
 
 
-def test___timing___reset_boolean_property___returns_default_value(task, any_x_series_device):
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+def test___timing___reset_boolean_property___returns_default_value(task, sim_6363_device):
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     task.timing.samp_timing_type = SampleTimingType.ON_DEMAND
     task.timing.simultaneous_ao_enable = True
 
@@ -31,33 +31,33 @@ def test___timing___reset_boolean_property___returns_default_value(task, any_x_s
     assert not task.timing.simultaneous_ao_enable
 
 
-def test___timing___get_string_property___returns_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___get_string_property___returns_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
-    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
+    assert task.timing.samp_clk_src == f"/{sim_6363_device.name}/ai/SampleClockTimebase"
 
 
-def test___timing___set_string_property___returns_assigned_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_string_property___returns_assigned_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
     task.timing.samp_clk_src = "PFI0"
 
-    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/PFI0"
+    assert task.timing.samp_clk_src == f"/{sim_6363_device.name}/PFI0"
 
 
-def test___timing___reset_string_property___returns_default_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___reset_string_property___returns_default_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000, source="PFI0")
 
     del task.timing.samp_clk_src
 
-    assert task.timing.samp_clk_src == f"/{any_x_series_device.name}/ai/SampleClockTimebase"
+    assert task.timing.samp_clk_src == f"/{sim_6363_device.name}/ai/SampleClockTimebase"
 
 
-def test___timing___set_invalid_source_terminal_name___throws_daqerror(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_invalid_source_terminal_name___throws_daqerror(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
     task.timing.cfg_samp_clk_timing(1000, source="Test_Invalid_Device_Source")
 
@@ -66,15 +66,15 @@ def test___timing___set_invalid_source_terminal_name___throws_daqerror(task, any
     assert e.value.error_type == DAQmxErrors.INVALID_ROUTING_SOURCE_TERMINAL_NAME_ROUTING
 
 
-def test___timing___get_enum_property___returns_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___get_enum_property___returns_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
     assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
 
-def test___timing___set_enum_property___returns_assigned_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_enum_property___returns_assigned_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
     task.timing.samp_quant_samp_mode = AcquisitionType.FINITE
@@ -82,8 +82,8 @@ def test___timing___set_enum_property___returns_assigned_value(task, any_x_serie
     assert task.timing.samp_quant_samp_mode == AcquisitionType.FINITE
 
 
-def test___timing___reset_enum_property___returns_default_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___reset_enum_property___returns_default_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.FINITE)
 
     del task.timing.samp_quant_samp_mode
@@ -91,15 +91,15 @@ def test___timing___reset_enum_property___returns_default_value(task, any_x_seri
     assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
 
-def test___timing___get_float64_property___returns_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___get_float64_property___returns_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
     assert task.timing.samp_clk_rate == 1000
 
 
-def test___timing___set_float64_property___returns_assigned_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_float64_property___returns_assigned_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
     task.timing.samp_clk_rate = 2000
@@ -107,8 +107,8 @@ def test___timing___set_float64_property___returns_assigned_value(task, any_x_se
     assert task.timing.samp_clk_rate == 2000
 
 
-def test___timing___reset_float64_property___returns_default_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___reset_float64_property___returns_default_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     default_value = task.timing.samp_clk_rate
     task.timing.cfg_samp_clk_timing(10000)
 
@@ -117,15 +117,15 @@ def test___timing___reset_float64_property___returns_default_value(task, any_x_s
     assert task.timing.samp_clk_rate == default_value
 
 
-def test___timing___get_uint32_property___returns_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___get_uint32_property___returns_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
     assert task.timing.samp_clk_timebase_div == 100000
 
 
-def test___timing___set_uint32_property___returns_assigned_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_uint32_property___returns_assigned_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
 
     task.timing.samp_clk_timebase_div = 500
@@ -133,8 +133,8 @@ def test___timing___set_uint32_property___returns_assigned_value(task, any_x_ser
     assert task.timing.samp_clk_timebase_div == 500
 
 
-def test___timing___reset_uint32_property___returns_default_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___reset_uint32_property___returns_default_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000)
     default_value = task.timing.samp_clk_timebase_div
     task.timing.samp_clk_timebase_div = 200000
@@ -145,23 +145,23 @@ def test___timing___reset_uint32_property___returns_default_value(task, any_x_se
     assert task.timing.samp_clk_timebase_div == default_value
 
 
-def test___timing___get_uint64_property___returns_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___get_uint64_property___returns_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     task.timing.cfg_samp_clk_timing(1000, samps_per_chan=100)
 
     assert task.timing.samp_quant_samp_per_chan == 100
 
 
-def test___timing___set_uint64_property___returns_assigned_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___set_uint64_property___returns_assigned_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
     task.timing.samp_quant_samp_per_chan = 10000
 
     assert task.timing.samp_quant_samp_per_chan == 10000
 
 
-def test___timing___reset_uint64_property___returns_default_value(task, any_x_series_device):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def test___timing___reset_uint64_property___returns_default_value(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     default_value = task.timing.samp_quant_samp_per_chan
     task.timing.cfg_samp_clk_timing(1000, samps_per_chan=10000)
 
@@ -171,9 +171,9 @@ def test___timing___reset_uint64_property___returns_default_value(task, any_x_se
 
 
 def test___timing___set_unint64_property_out_of_range_value___throws_daqerror(
-    task, any_x_series_device
+    task, sim_6363_device
 ):
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
     task.timing.cfg_samp_clk_timing(1000, samps_per_chan=1)
 

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -7,9 +7,9 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_task(task, any_x_series_device):
+def ai_voltage_task(task, sim_6363_device):
     """Gets AI voltage task."""
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     yield task
 
 

--- a/tests/component/system/_collections/test_physical_channel_collection.py
+++ b/tests/component/system/_collections/test_physical_channel_collection.py
@@ -92,9 +92,7 @@ def test___physical_channels___getitem_str_list___shared_interpreter(
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
-def test___physical_channels___iter___forward_order(
-    collection_name: str, sim_6363_device: Device
-):
+def test___physical_channels___iter___forward_order(collection_name: str, sim_6363_device: Device):
     physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = iter(physical_channels)
@@ -136,9 +134,7 @@ def test___physical_channels___reversed___shared_interpreter(
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
-def test___physical_channels___all___forward_order(
-    collection_name: str, sim_6363_device: Device
-):
+def test___physical_channels___all___forward_order(collection_name: str, sim_6363_device: Device):
     physical_channels = getattr(sim_6363_device, collection_name)
 
     channel = physical_channels.all

--- a/tests/component/system/_collections/test_physical_channel_collection.py
+++ b/tests/component/system/_collections/test_physical_channel_collection.py
@@ -17,9 +17,9 @@ COLLECTION_NAMES = [
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_int___forward_order(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = [physical_channels[i] for i in range(len(physical_channels))]
 
@@ -28,21 +28,21 @@ def test___physical_channels___getitem_int___forward_order(
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_int___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = [physical_channels[i] for i in range(len(physical_channels))]
 
-    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+    assert all(chan._interpreter is sim_6363_device._interpreter for chan in channels)
 
 
 @pytest.mark.xfail(reason="https://github.com/ni/nidaqmx-python/issues/392")
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_slice___forward_order(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = physical_channels[:]
 
@@ -52,50 +52,50 @@ def test___physical_channels___getitem_slice___forward_order(
 @pytest.mark.xfail(reason="https://github.com/ni/nidaqmx-python/issues/392")
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_slice___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = physical_channels[:]
 
-    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+    assert all(chan._interpreter is sim_6363_device._interpreter for chan in channels)
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_str___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
-    device_name = any_x_series_device.name
+    physical_channels = getattr(sim_6363_device, collection_name)
+    device_name = sim_6363_device.name
     unqualified_channel_names = [
         name.replace(device_name + "/", "") for name in physical_channels.channel_names
     ]
 
     channels = [physical_channels[name] for name in unqualified_channel_names]
 
-    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+    assert all(chan._interpreter is sim_6363_device._interpreter for chan in channels)
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___getitem_str_list___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
-    device_name = any_x_series_device.name
+    physical_channels = getattr(sim_6363_device, collection_name)
+    device_name = sim_6363_device.name
     unqualified_channel_names = [
         name.replace(device_name + "/", "") for name in physical_channels.channel_names
     ]
 
     channel = physical_channels[",".join(unqualified_channel_names)]
 
-    assert channel._interpreter == any_x_series_device._interpreter
+    assert channel._interpreter == sim_6363_device._interpreter
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___iter___forward_order(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = iter(physical_channels)
 
@@ -104,20 +104,20 @@ def test___physical_channels___iter___forward_order(
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___iter___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = iter(physical_channels)
 
-    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+    assert all(chan._interpreter is sim_6363_device._interpreter for chan in channels)
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___reversed___reverse_order(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = reversed(physical_channels)
 
@@ -126,20 +126,20 @@ def test___physical_channels___reversed___reverse_order(
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___reversed___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channels = reversed(physical_channels)
 
-    assert all(chan._interpreter is any_x_series_device._interpreter for chan in channels)
+    assert all(chan._interpreter is sim_6363_device._interpreter for chan in channels)
 
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___all___forward_order(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channel = physical_channels.all
 
@@ -148,10 +148,10 @@ def test___physical_channels___all___forward_order(
 
 @pytest.mark.parametrize("collection_name", COLLECTION_NAMES)
 def test___physical_channels___all___shared_interpreter(
-    collection_name: str, any_x_series_device: Device
+    collection_name: str, sim_6363_device: Device
 ):
-    physical_channels = getattr(any_x_series_device, collection_name)
+    physical_channels = getattr(sim_6363_device, collection_name)
 
     channel = physical_channels.all
 
-    assert channel._interpreter is any_x_series_device._interpreter
+    assert channel._interpreter is sim_6363_device._interpreter

--- a/tests/component/system/test_device.py
+++ b/tests/component/system/test_device.py
@@ -31,9 +31,9 @@ def test___devices_with_different_names___hash___not_equal(init_kwargs):
     assert hash(device1) != hash(device2)
 
 
-def test___self_test_device___no_errors(any_x_series_device: Device) -> None:
-    any_x_series_device.self_test_device()
+def test___self_test_device___no_errors(sim_6363_device: Device) -> None:
+    sim_6363_device.self_test_device()
 
 
-def test___self_cal___no_errors(any_x_series_device: Device) -> None:
-    any_x_series_device.self_cal()
+def test___self_cal___no_errors(sim_6363_device: Device) -> None:
+    sim_6363_device.self_cal()

--- a/tests/component/system/test_physical_channel.py
+++ b/tests/component/system/test_physical_channel.py
@@ -45,9 +45,9 @@ def test___physical_channels_with_different_names___hash___not_equal(
 
 
 def test___invalid_bitstream___write_to_teds_from_array___throws_data_error(
-    any_x_series_device,
+    sim_6363_device,
 ):
-    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+    phys_chan = sim_6363_device.ai_physical_chans["ai0"]
 
     with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_array([1, 2, 3, 4])
@@ -56,9 +56,9 @@ def test___invalid_bitstream___write_to_teds_from_array___throws_data_error(
 
 
 def test___valid_bitstream___write_to_teds_from_array___throws_config_or_detection_error(
-    any_x_series_device,
+    sim_6363_device,
 ):
-    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+    phys_chan = sim_6363_device.ai_physical_chans["ai0"]
 
     with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_array(VALUES_IN_TED)
@@ -70,9 +70,9 @@ def test___valid_bitstream___write_to_teds_from_array___throws_config_or_detecti
 
 
 def test___invalid_file_path___write_to_teds_from_file___throws_data_error(
-    any_x_series_device,
+    sim_6363_device,
 ):
-    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+    phys_chan = sim_6363_device.ai_physical_chans["ai0"]
 
     with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_file()
@@ -81,9 +81,9 @@ def test___invalid_file_path___write_to_teds_from_file___throws_data_error(
 
 
 def test___valid_file_path___write_to_teds_from_array___throws_config_or_detection_error(
-    any_x_series_device, voltage_teds_file_path
+    sim_6363_device, voltage_teds_file_path
 ):
-    phys_chan = any_x_series_device.ai_physical_chans["ai0"]
+    phys_chan = sim_6363_device.ai_physical_chans["ai0"]
 
     with pytest.raises(nidaqmx.DaqError) as exc_info:
         phys_chan.write_to_teds_from_file(str(voltage_teds_file_path))

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -25,8 +25,8 @@ def test___nonexistent_physical_channel___get_property___raises_physical_chan_do
     assert exc_info.value.error_code == DAQmxErrors.PHYSICAL_CHAN_DOES_NOT_EXIST
 
 
-def test___physical_channel___get_bool_property___returns_value(any_x_series_device):
-    phys_chans = any_x_series_device.di_lines
+def test___physical_channel___get_bool_property___returns_value(sim_6363_device):
+    phys_chans = sim_6363_device.di_lines
 
     assert phys_chans[0].di_change_detect_supported
 
@@ -44,9 +44,9 @@ def test___physical_channel_with_teds___get_bit_stream___returns_configured_valu
 
 @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___physical_channel___get_int32_array_property___returns_default_value(
-    any_x_series_device,
+    sim_6363_device,
 ):
-    phys_chans = any_x_series_device.ai_physical_chans
+    phys_chans = sim_6363_device.ai_physical_chans
     ai_channel = phys_chans["ai0"]
     expected_configs = [
         TerminalConfiguration.RSE,

--- a/tests/component/system/test_watchdog_properties.py
+++ b/tests/component/system/test_watchdog_properties.py
@@ -37,8 +37,8 @@ def test___watchdog_task___task_not_running_get_expired_property____throws_daqer
     )
 
 
-def test___watchdog_task___get_enum_property___returns_value(any_x_series_device, watchdog_task):
-    do_line = any_x_series_device.do_lines[0]
+def test___watchdog_task___get_enum_property___returns_value(sim_6363_device, watchdog_task):
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -48,9 +48,9 @@ def test___watchdog_task___get_enum_property___returns_value(any_x_series_device
 
 
 def test___watchdog_task___set_enum_property___returns_assigned_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -62,9 +62,9 @@ def test___watchdog_task___set_enum_property___returns_assigned_value(
 
 
 def test___watchdog_task___reset_enum_property___returns_default_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -76,8 +76,8 @@ def test___watchdog_task___reset_enum_property___returns_default_value(
     assert watchdog_task.expir_trig_dig_edge_edge == Edge.RISING
 
 
-def test___watchdog_task___get_float64_property___returns_value(any_x_series_device, watchdog_task):
-    do_line = any_x_series_device.do_lines[0]
+def test___watchdog_task___get_float64_property___returns_value(sim_6363_device, watchdog_task):
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -87,9 +87,9 @@ def test___watchdog_task___get_float64_property___returns_value(any_x_series_dev
 
 
 def test___watchdog_task___set_float64_property___returns_assigned_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -101,9 +101,9 @@ def test___watchdog_task___set_float64_property___returns_assigned_value(
 
 
 def test___watchdog_task___reset_float64_property___returns_default_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -114,8 +114,8 @@ def test___watchdog_task___reset_float64_property___returns_default_value(
     assert watchdog_task.timeout == 10
 
 
-def test___watchdog_task___get_string_property___returns_value(any_x_series_device, watchdog_task):
-    do_line = any_x_series_device.do_lines[0]
+def test___watchdog_task___get_string_property___returns_value(sim_6363_device, watchdog_task):
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -125,9 +125,9 @@ def test___watchdog_task___get_string_property___returns_value(any_x_series_devi
 
 
 def test___watchdog_task___set_string_property___returns_assigned_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -139,9 +139,9 @@ def test___watchdog_task___set_string_property___returns_assigned_value(
 
 
 def test___watchdog_task___reset_string_property___returns_default_value(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -154,9 +154,9 @@ def test___watchdog_task___reset_string_property___returns_default_value(
 
 
 def test___watchdog_task___get_deprecated_properties___reports_warnings(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -170,9 +170,9 @@ def test___watchdog_task___get_deprecated_properties___reports_warnings(
 
 
 def test___watchdog_task___set_deprecated_properties___reports_warnings(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]
@@ -183,9 +183,9 @@ def test___watchdog_task___set_deprecated_properties___reports_warnings(
 
 
 def test___watchdog_task___reset_deprecated_properties___reports_warnings(
-    any_x_series_device, watchdog_task
+    sim_6363_device, watchdog_task
 ):
-    do_line = any_x_series_device.do_lines[0]
+    do_line = sim_6363_device.do_lines[0]
     expir_states = [
         DOExpirationState(physical_channel=do_line.name, expiration_state=Level.TRISTATE)
     ]

--- a/tests/component/test_stream_writers.py
+++ b/tests/component/test_stream_writers.py
@@ -9,18 +9,18 @@ from nidaqmx.stream_writers import AnalogMultiChannelWriter, AnalogSingleChannel
 
 @pytest.fixture
 def ao_single_channel_task(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
 ) -> nidaqmx.Task:
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     return task
 
 
 @pytest.fixture
 def ao_multi_channel_task(
-    task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
 ) -> nidaqmx.Task:
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[1].name)
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[1].name)
     return task
 
 

--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -18,8 +18,8 @@ from tests._event_utils import (
 
 
 @pytest.fixture
-def ai_task(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> nidaqmx.Task:
-    task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+def ai_task(task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device) -> nidaqmx.Task:
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     return task
 
 
@@ -32,8 +32,8 @@ def ai_task_with_real_device(
 
 
 @pytest.fixture
-def ao_task(task: nidaqmx.Task, any_x_series_device: nidaqmx.system.Device) -> nidaqmx.Task:
-    task.ao_channels.add_ao_voltage_chan(any_x_series_device.ao_physical_chans[0].name)
+def ao_task(task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device) -> nidaqmx.Task:
+    task.ao_channels.add_ao_voltage_chan(sim_6363_device.ao_physical_chans[0].name)
     return task
 
 

--- a/tests/component/test_task_properties.py
+++ b/tests/component/test_task_properties.py
@@ -5,10 +5,10 @@ from nidaqmx.system import Device
 
 
 @pytest.fixture
-def ai_task(task: Task, any_x_series_device: Device) -> Task:
+def ai_task(task: Task, sim_6363_device: Device) -> Task:
     """Gets an AI task."""
     task.ai_channels.add_ai_voltage_chan(
-        f"{any_x_series_device.name}/ai0:3", name_to_assign_to_channel="MyChannel"
+        f"{sim_6363_device.name}/ai0:3", name_to_assign_to_channel="MyChannel"
     )
     return task
 
@@ -25,10 +25,10 @@ def test___get_channels___shared_interpreter(ai_task: Task):
     assert channel._interpreter is ai_task._interpreter
 
 
-def test___get_devices___returns_devices(ai_task: Task, any_x_series_device: Device):
+def test___get_devices___returns_devices(ai_task: Task, sim_6363_device: Device):
     devices = ai_task.devices
 
-    assert [dev.name for dev in devices] == [any_x_series_device.name]
+    assert [dev.name for dev in devices] == [sim_6363_device.name]
 
 
 def test___get_devices___shared_interpreter(ai_task: Task):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,21 +136,9 @@ def _device_by_product_type(
 
 
 @pytest.fixture(scope="function")
-def any_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
-    """Gets any X Series device information."""
-    return _x_series_device(DeviceType.ANY, system)
-
-
-@pytest.fixture(scope="function")
 def real_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets real X Series device information."""
     return _x_series_device(DeviceType.REAL, system)
-
-
-@pytest.fixture(scope="function")
-def sim_x_series_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
-    """Gets simulated X Series device information."""
-    return _x_series_device(DeviceType.SIMULATED, system)
 
 
 @pytest.fixture(scope="function")
@@ -466,11 +454,11 @@ def persisted_channel(request, system: nidaqmx.system.System):
 
 @pytest.fixture(scope="function")
 def watchdog_task(
-    request, any_x_series_device, generate_watchdog_task
+    request, sim_6363_device, generate_watchdog_task
 ) -> nidaqmx.system.WatchdogTask:
     """Gets a watchdog task instance."""
     # set default values used for the initialization of the task.
-    device_name = _get_marker_value(request, "device_name", any_x_series_device.name)
+    device_name = _get_marker_value(request, "device_name", sim_6363_device.name)
     timeout = _get_marker_value(request, "timeout", 0.5)
 
     return generate_watchdog_task(device_name=device_name, timeout=timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,9 +453,7 @@ def persisted_channel(request, system: nidaqmx.system.System):
 
 
 @pytest.fixture(scope="function")
-def watchdog_task(
-    request, sim_6363_device, generate_watchdog_task
-) -> nidaqmx.system.WatchdogTask:
+def watchdog_task(request, sim_6363_device, generate_watchdog_task) -> nidaqmx.system.WatchdogTask:
     """Gets a watchdog task instance."""
     # set default values used for the initialization of the task.
     device_name = _get_marker_value(request, "device_name", sim_6363_device.name)

--- a/tests/legacy/test_channel_creation.py
+++ b/tests/legacy/test_channel_creation.py
@@ -32,12 +32,12 @@ class TestAnalogCreateChannels:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_voltage_chan(self, task, any_x_series_device, seed):
+    def test_create_ai_voltage_chan(self, task, sim_6363_device, seed):
         """Test for creating AI voltage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_voltage_chan(
             ai_phys_chan,
@@ -58,12 +58,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_custom_scale.name == "double_gain_scale"
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_current_chan(self, task, any_x_series_device, seed):
+    def test_create_ai_current_chan(self, task, sim_6363_device, seed):
         """Test for creating AI current channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_current_chan(
             ai_phys_chan,
@@ -86,11 +86,11 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_current_shunt_resistance == 100.0
 
     # @pytest.mark.parametrize('seed', [generate_random_seed()])
-    # def test_create_ai_voltage_rms_chan(self, task, any_x_series_device, seed):
+    # def test_create_ai_voltage_rms_chan(self, task, sim_6363_device, seed):
     #     # Reset the pseudorandom number generator with seed.
     #     random.seed(seed)
     #
-    #     ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+    #     ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
     #
     #     ai_channel = task.ai_channels.add_ai_voltage_rms_chan(
     #         ai_phys_chan, name_to_assign_to_channel="VoltageRMSChannel",
@@ -105,12 +105,12 @@ class TestAnalogCreateChannels:
     #     assert ai_channel.ai_custom_scale.name == ""
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_rtd_chan(self, task, any_x_series_device, seed):
+    def test_create_ai_rtd_chan(self, task, sim_6363_device, seed):
         """Test for creating AI RTD channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_rtd_chan(
             ai_phys_chan,
@@ -137,12 +137,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_rtd_r0 == 100.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_iex(self, task, any_x_series_device, seed):
+    def test_create_ai_thrmstr_chan_iex(self, task, sim_6363_device, seed):
         """Test for creating AI thermistor channel with current excitation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_thrmstr_chan_iex(
             ai_phys_chan,
@@ -172,12 +172,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_thrmstr_c == 0.000000102
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_thrmstr_chan_vex(self, task, any_x_series_device, seed):
+    def test_create_ai_thrmstr_chan_vex(self, task, sim_6363_device, seed):
         """Test for creating AI thermistor channel with voltage excitation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_thrmstr_chan_vex(
             ai_phys_chan,
@@ -209,12 +209,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_thrmstr_r1 == 5000.0
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_resistance_chan(self, task, any_x_series_device, seed):
+    def test_create_ai_resistance_chan(self, task, sim_6363_device, seed):
         """Test for creating AI resistance channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         # Note: 1000 ohms @ 5 mA = 5V range, which exists on most X Series devices.
         ai_channel = task.ai_channels.add_ai_resistance_chan(
@@ -239,12 +239,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_excit_val == 0.005
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_ai_strain_gage_chan(self, task, any_x_series_device, seed):
+    def test_ai_strain_gage_chan(self, task, sim_6363_device, seed):
         """Test for creating AI strain gage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_strain_gage_chan(
             ai_phys_chan,
@@ -277,12 +277,12 @@ class TestAnalogCreateChannels:
         assert ai_channel.ai_lead_wire_resistance == 0.1
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_create_ai_voltage_chan_with_excit(self, task, any_x_series_device, seed):
+    def test_create_ai_voltage_chan_with_excit(self, task, sim_6363_device, seed):
         """Test for creating AI voltage channel."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chan = random.choice(any_x_series_device.ai_physical_chans).name
+        ai_phys_chan = random.choice(sim_6363_device.ai_physical_chans).name
 
         ai_channel = task.ai_channels.add_ai_voltage_chan_with_excit(
             ai_phys_chan,

--- a/tests/legacy/test_channels.py
+++ b/tests/legacy/test_channels.py
@@ -10,19 +10,19 @@ class TestChannels:
     This validate the channel objects in the NI-DAQmx Python API.
     """
 
-    def test_ai_channel(self, task, any_x_series_device):
+    def test_ai_channel(self, task, sim_6363_device):
         """Tests for creating ai channel."""
         ai_channel = task.ai_channels.add_ai_voltage_chan(
-            any_x_series_device.ai_physical_chans[0].name, max_val=10
+            sim_6363_device.ai_physical_chans[0].name, max_val=10
         )
 
         # Test property default value.
         assert ai_channel.ai_max == 10
 
-    def test_ao_channel(self, task, any_x_series_device):
+    def test_ao_channel(self, task, sim_6363_device):
         """Tests for creating ao channel."""
         ao_channel = task.ao_channels.add_ao_voltage_chan(
-            any_x_series_device.ao_physical_chans[0].name, max_val=5
+            sim_6363_device.ao_physical_chans[0].name, max_val=5
         )
 
         # Test property default value.
@@ -38,24 +38,24 @@ class TestChannels:
 
         assert ci_channel.ci_count == 10
 
-    def test_co_channel(self, task, any_x_series_device):
+    def test_co_channel(self, task, sim_6363_device):
         """Tests for creating co channel."""
         co_channel = task.co_channels.add_co_pulse_chan_freq(
-            any_x_series_device.co_physical_chans[0].name, freq=5000
+            sim_6363_device.co_physical_chans[0].name, freq=5000
         )
 
         task.control(TaskMode.TASK_COMMIT)
 
         numpy.testing.assert_allclose([co_channel.co_pulse_freq], [5000], rtol=0.05)
 
-    def test_di_channel(self, task, any_x_series_device):
+    def test_di_channel(self, task, sim_6363_device):
         """Tests for creating di channel."""
-        di_channel = task.di_channels.add_di_chan(any_x_series_device.di_lines[0].name)
+        di_channel = task.di_channels.add_di_chan(sim_6363_device.di_lines[0].name)
 
         assert di_channel.di_num_lines == 1
 
-    def test_do_channel(self, task, any_x_series_device):
+    def test_do_channel(self, task, sim_6363_device):
         """Tests for creating do channel."""
-        do_channel = task.do_channels.add_do_chan(any_x_series_device.do_lines[0].name)
+        do_channel = task.do_channels.add_do_chan(sim_6363_device.do_lines[0].name)
 
         assert do_channel.do_num_lines == 1

--- a/tests/legacy/test_container_operations.py
+++ b/tests/legacy/test_container_operations.py
@@ -14,12 +14,12 @@ class TestContainerOperations:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_concatenate_operations(self, task, any_x_series_device, seed):
+    def test_concatenate_operations(self, task, sim_6363_device, seed):
         """Test for concatenate operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
+        ai_phys_chans = random.sample(sim_6363_device.ai_physical_chans, 2)
 
         ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
             ai_phys_chans[0].name, max_val=5, min_val=-5
@@ -62,12 +62,12 @@ class TestContainerOperations:
         assert ai_channel_2.ai_min == -0.2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_equality_operations(self, task, any_x_series_device, seed):
+    def test_equality_operations(self, task, sim_6363_device, seed):
         """Test for equality operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 2)
+        ai_phys_chans = random.sample(sim_6363_device.ai_physical_chans, 2)
 
         ai_channel_1 = task.ai_channels.add_ai_voltage_chan(
             ai_phys_chans[0].name, max_val=5, min_val=-5
@@ -81,12 +81,12 @@ class TestContainerOperations:
         assert ai_channel_1 != ai_channel_2
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_hash_operations(self, generate_task, any_x_series_device, seed):
+    def test_hash_operations(self, generate_task, sim_6363_device, seed):
         """Test for hash operation."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_phys_chans = random.sample(any_x_series_device.ai_physical_chans, 3)
+        ai_phys_chans = random.sample(sim_6363_device.ai_physical_chans, 3)
         task_1 = generate_task()
         task_2 = generate_task()
         ai_channel_1 = task_1.ai_channels.add_ai_voltage_chan(

--- a/tests/legacy/test_events.py
+++ b/tests/legacy/test_events.py
@@ -19,7 +19,7 @@ class TestEvents:
         reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
     )
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_every_n_samples_event(self, task, any_x_series_device, seed):
+    def test_every_n_samples_event(self, task, sim_6363_device, seed):
         """Test for validating every n samples event."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
@@ -27,7 +27,7 @@ class TestEvents:
         samples_chunk = 100
         sample_rate = 5000
 
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
         samples_multiple = random.randint(2, 5)
         num_samples = samples_chunk * samples_multiple

--- a/tests/legacy/test_export_signals.py
+++ b/tests/legacy/test_export_signals.py
@@ -17,13 +17,13 @@ class TestExportSignals(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_export_signals(self, task, any_x_series_device, seed):
+    def test_export_signals(self, task, sim_6363_device, seed):
         """Test for validating export signals."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        ai_chan = random.choice(any_x_series_device.ai_physical_chans)
-        pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
+        ai_chan = random.choice(sim_6363_device.ai_physical_chans)
+        pfi_line = random.choice(self._get_device_pfi_lines(sim_6363_device))
 
         task.ai_channels.add_ai_voltage_chan(ai_chan.name)
         task.timing.cfg_samp_clk_timing(1000)

--- a/tests/legacy/test_invalid_reads.py
+++ b/tests/legacy/test_invalid_reads.py
@@ -6,7 +6,7 @@
 # import nidaqmx
 # from nidaqmx.errors import DaqError
 # from nidaqmx.utils import flatten_channel_string
-# from .fixtures import any_x_series_device
+# from .fixtures import sim_6363_device
 # from tests.helpers import generate_random_seed
 # from tests.legacy.test_read_write import TestDAQmxIOBase
 
@@ -14,15 +14,15 @@
 # class TestInvalidReads(TestReadWriteBase):
 
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_one_chan_read_for_n_chan_task(self, task, any_x_series_device, seed):
+# def test_one_chan_read_for_n_chan_task(self, task, sim_6363_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
 #     number_of_channels = random.randint(
-#         2, len(any_x_series_device.ai_physical_chans))
+#         2, len(sim_6363_device.ai_physical_chans))
 #
 #     ai_channels = random.sample(
-#         any_x_series_device.ai_physical_chans, number_of_channels)
+#         sim_6363_device.ai_physical_chans, number_of_channels)
 #
 #     task.ai_channels.add_ai_voltage_chan(
 #         flatten_channel_string([c.name for c in ai_channels]),
@@ -33,11 +33,11 @@
 #     assert e.value.error_code == -200523
 
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_numpy_read_for_counter_pulse_task(self, task, any_x_series_device, seed):
+# def test_numpy_read_for_counter_pulse_task(self, task, sim_6363_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
-#     counter = random.choice(self._get_device_counters(any_x_series_device))
+#     counter = random.choice(self._get_device_counters(sim_6363_device))
 #
 #     task.ci_channels.add_ci_pulse_chan_freq(counter)
 #
@@ -46,15 +46,15 @@
 #     assert e.value.error_code == -1
 #
 # @pytest.mark.parametrize('seed', [generate_random_seed()])
-# def test_numpy_read_incorrectly_shaped_data(self, task, any_x_series_device, seed):
+# def test_numpy_read_incorrectly_shaped_data(self, task, sim_6363_device, seed):
 #     # Reset the pseudorandom number generator with seed.
 #     random.seed(seed)
 #
 #     # Randomly select physical channels to test.
 #     number_of_channels = random.randint(
-#         2, len(any_x_series_device.ai_physical_chans))
+#         2, len(sim_6363_device.ai_physical_chans))
 #     channels_to_test = random.sample(
-#         any_x_series_device.ai_physical_chans, number_of_channels)
+#         sim_6363_device.ai_physical_chans, number_of_channels)
 #     number_of_samples = random.randint(50, 100)
 #
 #     task.ai_channels.add_ai_voltage_chan(

--- a/tests/legacy/test_invalid_writes.py
+++ b/tests/legacy/test_invalid_writes.py
@@ -16,14 +16,14 @@ class TestInvalidWrites:
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_insufficient_write_data(self, task, any_x_series_device, seed):
+    def test_insufficient_write_data(self, task, sim_6363_device, seed):
         """Test for validating write functionality with insufficient data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
-        number_of_channels = random.randint(2, len(any_x_series_device.ao_physical_chans))
-        channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
+        number_of_channels = random.randint(2, len(sim_6363_device.ao_physical_chans))
+        channels_to_test = random.sample(sim_6363_device.ao_physical_chans, number_of_channels)
 
         task.ao_channels.add_ao_voltage_chan(
             flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
@@ -41,14 +41,14 @@ class TestInvalidWrites:
         assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_insufficient_numpy_write_data(self, task, any_x_series_device, seed):
+    def test_insufficient_numpy_write_data(self, task, sim_6363_device, seed):
         """Test for validating write functionality with insufficient data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
-        number_of_channels = random.randint(2, len(any_x_series_device.ao_physical_chans))
-        channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
+        number_of_channels = random.randint(2, len(sim_6363_device.ao_physical_chans))
+        channels_to_test = random.sample(sim_6363_device.ao_physical_chans, number_of_channels)
 
         task.ao_channels.add_ao_voltage_chan(
             flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
@@ -62,14 +62,14 @@ class TestInvalidWrites:
         assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_extraneous_write_data(self, task, any_x_series_device, seed):
+    def test_extraneous_write_data(self, task, sim_6363_device, seed):
         """Test for validating write functionality with extraneous data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
-        number_of_channels = random.randint(1, len(any_x_series_device.ao_physical_chans))
-        channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
+        number_of_channels = random.randint(1, len(sim_6363_device.ao_physical_chans))
+        channels_to_test = random.sample(sim_6363_device.ao_physical_chans, number_of_channels)
 
         task.ao_channels.add_ao_voltage_chan(
             flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
@@ -87,14 +87,14 @@ class TestInvalidWrites:
         assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_extraneous_numpy_write_data(self, task, any_x_series_device, seed):
+    def test_extraneous_numpy_write_data(self, task, sim_6363_device, seed):
         """Test for validating write functionality with extraneous data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
-        number_of_channels = random.randint(1, len(any_x_series_device.ao_physical_chans))
-        channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
+        number_of_channels = random.randint(1, len(sim_6363_device.ao_physical_chans))
+        channels_to_test = random.sample(sim_6363_device.ao_physical_chans, number_of_channels)
 
         task.ao_channels.add_ao_voltage_chan(
             flatten_channel_string([c.name for c in channels_to_test]), max_val=10, min_val=-10
@@ -114,14 +114,14 @@ class TestInvalidWrites:
         assert e.value.error_code == -200524
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_numpy_write_incorrectly_shaped_data(self, task, any_x_series_device, seed):
+    def test_numpy_write_incorrectly_shaped_data(self, task, sim_6363_device, seed):
         """Test for validating write functionality with incorrectly shaped data."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         # Randomly select physical channels to test.
-        number_of_channels = random.randint(2, len(any_x_series_device.ao_physical_chans))
-        channels_to_test = random.sample(any_x_series_device.ao_physical_chans, number_of_channels)
+        number_of_channels = random.randint(2, len(sim_6363_device.ao_physical_chans))
+        channels_to_test = random.sample(sim_6363_device.ao_physical_chans, number_of_channels)
         number_of_samples = random.randint(50, 100)
 
         task.ao_channels.add_ao_voltage_chan(

--- a/tests/legacy/test_properties.py
+++ b/tests/legacy/test_properties.py
@@ -98,9 +98,7 @@ class TestPropertyBasicDataTypes:
 
     def test_string_property(self, task, sim_6363_device):
         """Test for validating string property."""
-        ai_channel = task.ai_channels.add_ai_voltage_chan(
-            sim_6363_device.ai_physical_chans[0].name
-        )
+        ai_channel = task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
         # Test property default value.
         assert ai_channel.description == ""

--- a/tests/legacy/test_properties.py
+++ b/tests/legacy/test_properties.py
@@ -14,13 +14,13 @@ class TestPropertyBasicDataTypes:
     This validates the property getter,setter and deleter methods for different basic data types.
     """
 
-    def test_boolean_property(self, task, any_x_series_device):
+    def test_boolean_property(self, task, sim_6363_device):
         """Test for validating boolean property."""
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
         task.timing.cfg_samp_clk_timing(1000)
         task.triggers.start_trigger.cfg_dig_edge_start_trig(
-            f"/{any_x_series_device.name}/Ctr0InternalOutput"
+            f"/{sim_6363_device.name}/Ctr0InternalOutput"
         )
 
         # Test property initial value.
@@ -34,9 +34,9 @@ class TestPropertyBasicDataTypes:
         del task.triggers.start_trigger.retriggerable
         assert not task.triggers.start_trigger.retriggerable
 
-    def test_enum_property(self, task, any_x_series_device):
+    def test_enum_property(self, task, sim_6363_device):
         """Test for validating enum property."""
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
         task.timing.cfg_samp_clk_timing(1000, sample_mode=AcquisitionType.CONTINUOUS)
 
@@ -51,10 +51,10 @@ class TestPropertyBasicDataTypes:
         del task.timing.samp_quant_samp_mode
         assert task.timing.samp_quant_samp_mode == AcquisitionType.CONTINUOUS
 
-    def test_float_property(self, task, any_x_series_device):
+    def test_float_property(self, task, sim_6363_device):
         """Test for validating float property."""
         ai_channel = task.ai_channels.add_ai_voltage_chan(
-            any_x_series_device.ai_physical_chans[0].name, max_val=5
+            sim_6363_device.ai_physical_chans[0].name, max_val=5
         )
 
         # Test property default value.
@@ -73,12 +73,12 @@ class TestPropertyBasicDataTypes:
         assert e.value.error_code == -200695
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_int_property(self, task, any_x_series_device, seed):
+    def test_int_property(self, task, sim_6363_device, seed):
         """Test for validating integer property."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        task.ci_channels.add_ci_count_edges_chan(any_x_series_device.ci_physical_chans[0].name)
+        task.ci_channels.add_ci_count_edges_chan(sim_6363_device.ci_physical_chans[0].name)
 
         # Test property default value.
         assert task.in_stream.offset == 0
@@ -96,10 +96,10 @@ class TestPropertyBasicDataTypes:
         del task.in_stream.offset
         assert task.in_stream.offset == 0
 
-    def test_string_property(self, task, any_x_series_device):
+    def test_string_property(self, task, sim_6363_device):
         """Test for validating string property."""
         ai_channel = task.ai_channels.add_ai_voltage_chan(
-            any_x_series_device.ai_physical_chans[0].name
+            sim_6363_device.ai_physical_chans[0].name
         )
 
         # Test property default value.
@@ -115,12 +115,12 @@ class TestPropertyBasicDataTypes:
         assert ai_channel.description == ""
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_uint_property(self, task, any_x_series_device, seed):
+    def test_uint_property(self, task, sim_6363_device, seed):
         """Test for validating uint property."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        task.ai_channels.add_ai_voltage_chan(any_x_series_device.ai_physical_chans[0].name)
+        task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
 
         task.timing.cfg_samp_clk_timing(1000)
 
@@ -145,16 +145,16 @@ class TestPropertyListDataTypes:
     list data types.
     """
 
-    def test_list_of_strings_property(self, any_x_series_device):
+    def test_list_of_strings_property(self, sim_6363_device):
         """Test for validating list of strings property."""
-        terminals = any_x_series_device.terminals
+        terminals = sim_6363_device.terminals
 
         assert isinstance(terminals, list)
         assert isinstance(terminals[0], str)
 
-    def test_list_of_enums_property(self, any_x_series_device):
+    def test_list_of_enums_property(self, sim_6363_device):
         """Test for validating list of enums property."""
-        terminals = any_x_series_device.ai_meas_types
+        terminals = sim_6363_device.ai_meas_types
 
         assert isinstance(terminals, list)
         assert isinstance(terminals[0], UsageTypeAI)

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -760,9 +760,7 @@ class TestPowerRead(TestDAQmxIOBase):
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        task.ai_channels.add_ai_voltage_chan(
-            f"{sim_6363_device.name}/ai0", max_val=10, min_val=-10
-        )
+        task.ai_channels.add_ai_voltage_chan(f"{sim_6363_device.name}/ai0", max_val=10, min_val=-10)
         task.ai_channels.add_ai_current_chan(
             f"{sim_6363_device.name}/ai1", max_val=0.01, min_val=-0.01
         )

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -755,16 +755,16 @@ class TestPowerRead(TestDAQmxIOBase):
                 assert all(math.isnan(sample.current) for sample in channel_values)
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_mixed_chans(self, task, sim_x_series_device, seed):
+    def test_mixed_chans(self, task, sim_6363_device, seed):
         """Test to validate mixed channels."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
         task.ai_channels.add_ai_voltage_chan(
-            f"{sim_x_series_device.name}/ai0", max_val=10, min_val=-10
+            f"{sim_6363_device.name}/ai0", max_val=10, min_val=-10
         )
         task.ai_channels.add_ai_current_chan(
-            f"{sim_x_series_device.name}/ai1", max_val=0.01, min_val=-0.01
+            f"{sim_6363_device.name}/ai1", max_val=0.01, min_val=-0.01
         )
 
         task.start()

--- a/tests/legacy/test_system_collections.py
+++ b/tests/legacy/test_system_collections.py
@@ -61,9 +61,9 @@ class TestSystemCollections:
             # Test specific property on object.
             assert isinstance(global_channels[0].author, str)
 
-    def test_physical_channel_collection_property(self, any_x_series_device):
+    def test_physical_channel_collection_property(self, sim_6363_device):
         """Test to validate physical channel collection property."""
-        phys_chans = any_x_series_device.ai_physical_chans
+        phys_chans = sim_6363_device.ai_physical_chans
 
         assert isinstance(phys_chans, PhysicalChannelCollection)
         assert isinstance(phys_chans, collections.abc.Sequence)

--- a/tests/legacy/test_triggers.py
+++ b/tests/legacy/test_triggers.py
@@ -16,12 +16,12 @@ class TestTriggers(TestDAQmxIOBase):
     """
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_arm_start_trigger(self, task, any_x_series_device, seed):
+    def test_arm_start_trigger(self, task, sim_6363_device, seed):
         """Test to validate start trigger functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(any_x_series_device))
+        counter = random.choice(self._get_device_counters(sim_6363_device))
 
         task.co_channels.add_co_pulse_chan_freq(counter)
         task.triggers.arm_start_trigger.trig_type = TriggerType.DIGITAL_EDGE
@@ -31,12 +31,12 @@ class TestTriggers(TestDAQmxIOBase):
         assert task.triggers.arm_start_trigger.trig_type == TriggerType.NONE
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_handshake_trigger(self, task, any_x_series_device, seed):
+    def test_handshake_trigger(self, task, sim_6363_device, seed):
         """Test to validate trigger handshake."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(any_x_series_device))
+        counter = random.choice(self._get_device_counters(sim_6363_device))
 
         task.co_channels.add_co_pulse_chan_freq(counter)
 
@@ -45,12 +45,12 @@ class TestTriggers(TestDAQmxIOBase):
         assert e.value.error_code == -200452
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_pause_trigger(self, task, any_x_series_device, seed):
+    def test_pause_trigger(self, task, sim_6363_device, seed):
         """Test to validate pause trigger."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(any_x_series_device))
+        counter = random.choice(self._get_device_counters(sim_6363_device))
 
         task.co_channels.add_co_pulse_chan_freq(counter)
         task.timing.cfg_implicit_timing(sample_mode=AcquisitionType.CONTINUOUS)
@@ -62,12 +62,12 @@ class TestTriggers(TestDAQmxIOBase):
         assert task.triggers.pause_trigger.trig_type == TriggerType.NONE
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_reference_trigger(self, task, any_x_series_device, seed):
+    def test_reference_trigger(self, task, sim_6363_device, seed):
         """Test to validate reference trigger."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(any_x_series_device))
+        counter = random.choice(self._get_device_counters(sim_6363_device))
 
         task.co_channels.add_co_pulse_chan_freq(counter)
 
@@ -76,13 +76,13 @@ class TestTriggers(TestDAQmxIOBase):
         assert e.value.error_code == -200452
 
     @pytest.mark.parametrize("seed", [generate_random_seed()])
-    def test_start_trigger(self, task, any_x_series_device, seed):
+    def test_start_trigger(self, task, sim_6363_device, seed):
         """Test to validate start trigger functionality."""
         # Reset the pseudorandom number generator with seed.
         random.seed(seed)
 
-        counter = random.choice(self._get_device_counters(any_x_series_device))
-        pfi_line = random.choice(self._get_device_pfi_lines(any_x_series_device))
+        counter = random.choice(self._get_device_counters(sim_6363_device))
+        pfi_line = random.choice(self._get_device_pfi_lines(sim_6363_device))
 
         task.co_channels.add_co_pulse_chan_freq(counter)
         task.triggers.start_trigger.cfg_dig_edge_start_trig(pfi_line, trigger_edge=Edge.FALLING)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove `sim_x_series_device` and `any_x_series_device` fixtures. Uses of both have all been replaced with `sim_6363_device`.

### Why should this Pull Request be merged?

Those two fixtures are too ambiguous. My real X Series device does not support Analog Triggers, and some tests were failing since that won out for `any_x_series_device`.

### What testing has been done?

```
$ poetry run pytest
...

============ 1616 passed, 25 skipped, 68 xfailed in 157.88s (0:02:37) =============
```
