### PR TITLE
Update libtime to accept time before 1970

### DIFF
--- a/generated/nidaqmx/_grpc_time.py
+++ b/generated/nidaqmx/_grpc_time.py
@@ -16,10 +16,30 @@ _YS_PER_US = 10**18
 _YS_PER_NS = 10**15
 _YS_PER_FS = 10**9
 
+def convert_to_desired_timezone(expected_time_utc, tzinfo):
+    current_time_utc = ht_datetime.now(timezone.utc)
+    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+    desired_expected_time = expected_time_utc + desired_timezone_offset
+    new_datetime = ht_datetime(
+        desired_expected_time.year,
+        desired_expected_time.month,
+        desired_expected_time.day,
+        desired_expected_time.hour,
+        desired_expected_time.minute,
+        desired_expected_time.second,
+        desired_expected_time.microsecond,
+        desired_expected_time.femtosecond,
+        desired_expected_time.yoctosecond,
+        tzinfo = tzinfo)
+    return new_datetime
+
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
-    utc_dt = dt.astimezone(tz=timezone.utc)
-    seconds = int(utc_dt.timestamp())
+    epoch_1970 = ht_datetime(1970, 1, 1, tzinfo=timezone.utc)
+    if dt < epoch_1970:
+        seconds_since_1970 = -int(abs(dt - epoch_1970).total_seconds())
+    else:
+        seconds_since_1970 = int(abs(dt - epoch_1970).total_seconds())
     if ts is None:
         ts = GrpcTimestamp()
 
@@ -32,44 +52,21 @@ def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional
         if remainder_yoctoseconds >= _YS_PER_NS / 2:
             nanos += 1
     else:
-        nanos = utc_dt.microsecond * _NS_PER_US
+        nanos = dt.microsecond * _NS_PER_US
 
-    ts.FromNanoseconds(seconds * _NS_PER_S + nanos)
+    ts.FromNanoseconds(seconds_since_1970 * _NS_PER_S + nanos)
     return ts
 
 
-def convert_to_desired_timezone(expected_time_utc, tzinfo):
-    current_time_utc = ht_datetime.now(timezone.utc)
-    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-    desired_expected_time = expected_time_utc + desired_timezone_offset
-    new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
-    return new_datetime
-
-
-def timestamp_to_1904_epoch(timestamp, yoctoseconds):
-    epoch_1904 = ht_datetime(1904, 1, 1)
-    if timestamp < 0:
-        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH - abs(timestamp))
-    else:
-        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH + abs(timestamp))
-    datetime_1904 = epoch_1904 + seconds_from_1904 + ht_timedelta(yoctoseconds=yoctoseconds)
-    return datetime_1904
-
+def timestamp_to_1970_epoch(timestamp, yoctoseconds):
+    epoch_1970 = ht_datetime(1970, 1, 1)
+    datetime_1970 = epoch_1970 + ht_timedelta(seconds = timestamp) + ht_timedelta(yoctoseconds=yoctoseconds)
+    return datetime_1970
 
 def convert_timestamp_to_time(ts: GrpcTimestamp, tzinfo: Optional[timezone] = None) -> ht_datetime:
     total_nanos = ts.ToNanoseconds()
     seconds, nanos = divmod(total_nanos, _NS_PER_S)
     # Convert the nanoseconds to yoctoseconds.
     total_yoctoseconds = int(round(_YS_PER_NS * nanos))
-    dt = timestamp_to_1904_epoch(seconds, total_yoctoseconds)
+    dt = timestamp_to_1970_epoch(seconds, total_yoctoseconds)
     return convert_to_desired_timezone(dt, tzinfo)

--- a/generated/nidaqmx/_grpc_time.py
+++ b/generated/nidaqmx/_grpc_time.py
@@ -3,6 +3,7 @@ from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
+from nidaqmx._time import _convert_to_desired_timezone
 
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
 
@@ -17,24 +18,6 @@ _YS_PER_NS = 10**15
 _YS_PER_FS = 10**9
 
 _EPOCH_1970 = ht_datetime(1970, 1, 1, tzinfo=timezone.utc)
-
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
-    current_time_utc = ht_datetime.now(timezone.utc)
-    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-    desired_expected_time = expected_time_utc + desired_timezone_offset
-    new_datetime = ht_datetime(
-        desired_expected_time.year,
-        desired_expected_time.month,
-        desired_expected_time.day,
-        desired_expected_time.hour,
-        desired_expected_time.minute,
-        desired_expected_time.second,
-        desired_expected_time.microsecond,
-        desired_expected_time.femtosecond,
-        desired_expected_time.yoctosecond,
-        tzinfo = tzinfo)
-    return new_datetime
-
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
     seconds_since_1970 = int((dt - _EPOCH_1970).total_seconds())

--- a/generated/nidaqmx/_grpc_time.py
+++ b/generated/nidaqmx/_grpc_time.py
@@ -37,7 +37,7 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
 
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
-    seconds_since_1970 = int((dt - _EPOCH_1970) / ht_timedelta(seconds=1))
+    seconds_since_1970 = int((dt - _EPOCH_1970).total_seconds())
     # We need to add one more negative second if applicable to compensate for a non-zero microsecond.
     if dt.microsecond and (dt < _EPOCH_1970):
         seconds_since_1970 -=1

--- a/generated/nidaqmx/_grpc_time.py
+++ b/generated/nidaqmx/_grpc_time.py
@@ -1,10 +1,13 @@
 from datetime import timezone
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
+from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
 
+# 66 years, 17 leap days = 24107 days = 2082844800 seconds
+_BIAS_FROM_1970_EPOCH = 2082844800
 
 _NS_PER_S = 10**9
 _NS_PER_US = 10**3
@@ -35,19 +38,38 @@ def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional
     return ts
 
 
+def convert_to_desired_timezone(expected_time_utc, tzinfo):
+    current_time_utc = ht_datetime.now(timezone.utc)
+    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+    desired_expected_time = expected_time_utc + desired_timezone_offset
+    new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+    return new_datetime
+
+
+def timestamp_to_1904_epoch(timestamp, yoctoseconds):
+    epoch_1904 = ht_datetime(1904, 1, 1)
+    if timestamp < 0:
+        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH - abs(timestamp))
+    else:
+        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH + abs(timestamp))
+    datetime_1904 = epoch_1904 + seconds_from_1904 + ht_timedelta(yoctoseconds=yoctoseconds)
+    return datetime_1904
+
+
 def convert_timestamp_to_time(ts: GrpcTimestamp, tzinfo: Optional[timezone] = None) -> ht_datetime:
     total_nanos = ts.ToNanoseconds()
     seconds, nanos = divmod(total_nanos, _NS_PER_S)
-
-    # Convert the nanoseconds to micro, femto, and yoctorseconds.
+    # Convert the nanoseconds to yoctoseconds.
     total_yoctoseconds = int(round(_YS_PER_NS * nanos))
-    microsecond, remainder_yoctoseconds = divmod(total_yoctoseconds, _YS_PER_US)
-    femtosecond, remainder_yoctoseconds = divmod(remainder_yoctoseconds, _YS_PER_FS)
-    yoctosecond = remainder_yoctoseconds
-
-    # Start with UTC
-    dt = ht_datetime.fromtimestamp(seconds, timezone.utc)
-    # Add in precision
-    dt = dt.replace(microsecond=microsecond, femtosecond=femtosecond, yoctosecond=yoctosecond)
-    # Then convert to requested timezone
-    return dt.astimezone(tz=tzinfo)
+    dt = timestamp_to_1904_epoch(seconds, total_yoctoseconds)
+    return convert_to_desired_timezone(dt, tzinfo)

--- a/generated/nidaqmx/_lib_time.py
+++ b/generated/nidaqmx/_lib_time.py
@@ -51,7 +51,7 @@ class AbsoluteTime(ctypes.Structure):
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
-        seconds_since_1904 = int(abs(dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
+        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
 
         # Convert the subseconds.
         if isinstance(dt, ht_datetime):
@@ -66,11 +66,7 @@ class AbsoluteTime(ctypes.Structure):
                 round(AbsoluteTime._NUM_SUBSECONDS * dt.microsecond / AbsoluteTime._US_PER_S)
             )
 
-        # Consider if the date is before or after 1904
-        if dt < AbsoluteTime._EPOCH_1904:
-            return AbsoluteTime(lsb=lsb, msb=-seconds_since_1904)
-        else:
-            return AbsoluteTime(lsb=lsb, msb=seconds_since_1904)
+        return AbsoluteTime(lsb=lsb, msb=seconds_since_1904)
 
     def to_datetime(self, tzinfo: Optional[timezone] = None) -> ht_datetime:
         total_yoctoseconds = int(

--- a/generated/nidaqmx/_lib_time.py
+++ b/generated/nidaqmx/_lib_time.py
@@ -51,7 +51,7 @@ class AbsoluteTime(ctypes.Structure):
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
-        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
+        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904).total_seconds())
 
         # Convert the subseconds.
         if isinstance(dt, ht_datetime):

--- a/generated/nidaqmx/_lib_time.py
+++ b/generated/nidaqmx/_lib_time.py
@@ -7,7 +7,7 @@ from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
-
+from nidaqmx._time import _convert_to_desired_timezone
 
 @functools.total_ordering
 class AbsoluteTime(ctypes.Structure):
@@ -32,22 +32,6 @@ class AbsoluteTime(ctypes.Structure):
 
     _EPOCH_1904 = ht_datetime(1904, 1, 1, tzinfo=timezone.utc)
 
-    def _convert_to_desired_timezone(self, expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
-        current_time_utc = ht_datetime.now(timezone.utc)
-        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-        desired_expected_time = expected_time_utc + desired_timezone_offset
-        new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
-        return new_datetime
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
@@ -73,7 +57,7 @@ class AbsoluteTime(ctypes.Structure):
             round(AbsoluteTime._YS_PER_S * self.lsb / AbsoluteTime._NUM_SUBSECONDS)
         )
         dt = AbsoluteTime._EPOCH_1904 + ht_timedelta(seconds=self.msb) + ht_timedelta(yoctoseconds=total_yoctoseconds)
-        return self._convert_to_desired_timezone(dt,tzinfo)
+        return _convert_to_desired_timezone(dt,tzinfo)
 
     def __str__(self) -> str:
         return f"AbsoluteTime(lsb=0x{self.lsb:x}, msb=0x{self.msb:x})"

--- a/generated/nidaqmx/_lib_time.py
+++ b/generated/nidaqmx/_lib_time.py
@@ -5,6 +5,7 @@ import functools
 from datetime import timezone
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
+from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
 
 
@@ -58,33 +59,30 @@ class AbsoluteTime(ctypes.Structure):
 
         return AbsoluteTime(lsb=lsb, msb=timestamp_1904_epoch)
 
+    def convert_to_desired_timezone(self, expected_time_utc, tzinfo):
+        current_time_utc = ht_datetime.now(timezone.utc)
+        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+        desired_expected_time = expected_time_utc + desired_timezone_offset
+        new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+        return new_datetime
+
     def to_datetime(self, tzinfo: Optional[timezone] = None) -> ht_datetime:
-        # First, calculate whole seconds by converting from the 1904 to 1970 epoch.
-        timestamp_1904_epoch = self.msb
-        was_positive = timestamp_1904_epoch > 0
-        timestamp_1970_epoch = int(timestamp_1904_epoch - AbsoluteTime._BIAS_FROM_1970_EPOCH)
-
-        # Our bias is negative, so our sign should only change if we were previously positive.
-        is_positive = timestamp_1970_epoch > 0
-        if is_positive != was_positive and not was_positive:
-            raise OverflowError(f"Can't represent {str(self)} in datetime (1970 epoch)")
-
-        # Finally, convert the subseconds to micro, femto, and yoctoseconds.
         total_yoctoseconds = int(
             round(AbsoluteTime._YS_PER_S * self.lsb / AbsoluteTime._NUM_SUBSECONDS)
         )
-        microsecond, remainder_yoctoseconds = divmod(total_yoctoseconds, AbsoluteTime._YS_PER_US)
-        femtosecond, remainder_yoctoseconds = divmod(
-            remainder_yoctoseconds, AbsoluteTime._YS_PER_FS
-        )
-        yoctosecond = remainder_yoctoseconds
-
-        # Start with UTC
-        dt = ht_datetime.fromtimestamp(timestamp_1970_epoch, timezone.utc)
-        # Add in precision
-        dt = dt.replace(microsecond=microsecond, femtosecond=femtosecond, yoctosecond=yoctosecond)
-        # Then convert to requested timezone
-        return dt.astimezone(tz=tzinfo)
+        datetime_1904 = ht_datetime(1904, 1, 1, tzinfo=timezone.utc)
+        dt = datetime_1904 + ht_timedelta(seconds=self.msb) + ht_timedelta(yoctoseconds=total_yoctoseconds)
+        return self.convert_to_desired_timezone(dt,tzinfo)
 
     def __str__(self) -> str:
         return f"AbsoluteTime(lsb=0x{self.lsb:x}, msb=0x{self.msb:x})"

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -18,8 +18,8 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
     if tzinfo is None:
         tzinfo = get_localzone()
 
-    # use pytz.tzinfo.BaseTzInfo here to account for daylight savings
-    if hasattr(tzinfo, "zone") or isinstance(tzinfo, ZoneInfo):
+    # use ZoneInfo here to account for daylight savings
+    if isinstance(tzinfo, ZoneInfo):
         localized_time = expected_time_utc.replace(tzinfo=tzinfo)
         desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -6,7 +6,10 @@ from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
-from backports.zoneinfo import ZoneInfo
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
 def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:
@@ -19,7 +22,7 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
         tzinfo = get_localzone()
 
     # use ZoneInfo here to account for daylight savings
-    if isinstance(tzinfo, ZoneInfo):
+    if isinstance(tzinfo, zoneinfo.ZoneInfo):
         localized_time = expected_time_utc.replace(tzinfo=tzinfo)
         desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -1,46 +1,33 @@
 from __future__ import annotations
 
-import pytz
 from tzlocal import get_localzone
 from datetime import timezone
+from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
+from zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None):
     # if timezone matches, no need to do conversion
     if expected_time_utc.tzinfo is tzinfo:
         return expected_time_utc
 
     # if timezone is not defined, use system timezone
     if tzinfo is None:
-        local_timezone = get_localzone()
-        tzinfo = pytz.timezone(str(local_timezone))
+        tzinfo = get_localzone()
 
-    # use pytz here to account for daylight savings
-    if isinstance(tzinfo, pytz.tzinfo.BaseTzInfo):
-        target_tz = pytz.timezone(str(tzinfo))
-        # we need to make expected_time_utc naive in order to use localize
-        expected_time_utc = expected_time_utc.replace(tzinfo=None)
-        localized_time = target_tz.localize(expected_time_utc)
-        desired_expected_time = target_tz.fromutc(localized_time)
+    # use pytz.tzinfo.BaseTzInfo here to account for daylight savings
+    if hasattr(tzinfo, "zone") or isinstance(tzinfo, ZoneInfo):
+        localized_time = expected_time_utc.replace(tzinfo=tzinfo)
+        desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)
 
     # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
-    elif isinstance(tzinfo, timezone) and tzinfo.utcoffset(None) is not None:
+    elif isinstance(tzinfo, dt_tzinfo) and tzinfo.utcoffset(None) is not None:
         current_time_utc = ht_datetime.now(timezone.utc)
         desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
         desired_expected_time = expected_time_utc + desired_timezone_offset
-        new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
+        new_datetime = desired_expected_time.replace(tzinfo=tzinfo)
         return new_datetime

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytz
+from tzlocal import get_localzone
+from datetime import timezone
+from datetime import datetime as std_datetime
+from hightime import datetime as ht_datetime
+from typing import Optional, Union
+
+# theoretically the same as astimezone(), but with support for dates before 1970
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
+    # if timezone matches, no need to do conversion
+    if expected_time_utc.tzinfo is tzinfo:
+        return expected_time_utc
+
+    # if timezone is not defined, use system timezone
+    if tzinfo is None:
+        local_timezone = get_localzone()
+        tzinfo = pytz.timezone(str(local_timezone))
+
+    # use pytz here to account for daylight savings
+    if isinstance(tzinfo, pytz.tzinfo.BaseTzInfo):
+        target_tz = pytz.timezone(str(tzinfo))
+        # we need to make expected_time_utc naive in order to use localize
+        expected_time_utc = expected_time_utc.replace(tzinfo=None)
+        localized_time = target_tz.localize(expected_time_utc)
+        desired_expected_time = target_tz.fromutc(localized_time)
+        return(desired_expected_time)
+
+    # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
+    elif isinstance(tzinfo, timezone) and tzinfo.utcoffset(None) is not None:
+        current_time_utc = ht_datetime.now(timezone.utc)
+        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+        desired_expected_time = expected_time_utc + desired_timezone_offset
+        new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+        return new_datetime

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None):
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:
     # if timezone matches, no need to do conversion
     if expected_time_utc.tzinfo is tzinfo:
         return expected_time_utc
@@ -25,9 +25,13 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
         return(desired_expected_time)
 
     # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
-    elif isinstance(tzinfo, dt_tzinfo) and tzinfo.utcoffset(None) is not None:
+    elif tzinfo.utcoffset(None) is not None:
         current_time_utc = ht_datetime.now(timezone.utc)
         desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
         desired_expected_time = expected_time_utc + desired_timezone_offset
         new_datetime = desired_expected_time.replace(tzinfo=tzinfo)
         return new_datetime
+
+    # if the tzinfo passed in is none of the above, fall back to original astimezone()
+    else:
+        return expected_time_utc.astimezone(tzinfo)

--- a/generated/nidaqmx/_time.py
+++ b/generated/nidaqmx/_time.py
@@ -6,7 +6,7 @@ from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
-from zoneinfo import ZoneInfo
+from backports.zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
 def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:

--- a/src/handwritten/_grpc_time.py
+++ b/src/handwritten/_grpc_time.py
@@ -16,10 +16,30 @@ _YS_PER_US = 10**18
 _YS_PER_NS = 10**15
 _YS_PER_FS = 10**9
 
+def convert_to_desired_timezone(expected_time_utc, tzinfo):
+    current_time_utc = ht_datetime.now(timezone.utc)
+    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+    desired_expected_time = expected_time_utc + desired_timezone_offset
+    new_datetime = ht_datetime(
+        desired_expected_time.year,
+        desired_expected_time.month,
+        desired_expected_time.day,
+        desired_expected_time.hour,
+        desired_expected_time.minute,
+        desired_expected_time.second,
+        desired_expected_time.microsecond,
+        desired_expected_time.femtosecond,
+        desired_expected_time.yoctosecond,
+        tzinfo = tzinfo)
+    return new_datetime
+
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
-    utc_dt = dt.astimezone(tz=timezone.utc)
-    seconds = int(utc_dt.timestamp())
+    epoch_1970 = ht_datetime(1970, 1, 1, tzinfo=timezone.utc)
+    if dt < epoch_1970:
+        seconds_since_1970 = -int(abs(dt - epoch_1970).total_seconds())
+    else:
+        seconds_since_1970 = int(abs(dt - epoch_1970).total_seconds())
     if ts is None:
         ts = GrpcTimestamp()
 
@@ -32,44 +52,21 @@ def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional
         if remainder_yoctoseconds >= _YS_PER_NS / 2:
             nanos += 1
     else:
-        nanos = utc_dt.microsecond * _NS_PER_US
+        nanos = dt.microsecond * _NS_PER_US
 
-    ts.FromNanoseconds(seconds * _NS_PER_S + nanos)
+    ts.FromNanoseconds(seconds_since_1970 * _NS_PER_S + nanos)
     return ts
 
 
-def convert_to_desired_timezone(expected_time_utc, tzinfo):
-    current_time_utc = ht_datetime.now(timezone.utc)
-    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-    desired_expected_time = expected_time_utc + desired_timezone_offset
-    new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
-    return new_datetime
-
-
-def timestamp_to_1904_epoch(timestamp, yoctoseconds):
-    epoch_1904 = ht_datetime(1904, 1, 1)
-    if timestamp < 0:
-        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH - abs(timestamp))
-    else:
-        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH + abs(timestamp))
-    datetime_1904 = epoch_1904 + seconds_from_1904 + ht_timedelta(yoctoseconds=yoctoseconds)
-    return datetime_1904
-
+def timestamp_to_1970_epoch(timestamp, yoctoseconds):
+    epoch_1970 = ht_datetime(1970, 1, 1)
+    datetime_1970 = epoch_1970 + ht_timedelta(seconds = timestamp) + ht_timedelta(yoctoseconds=yoctoseconds)
+    return datetime_1970
 
 def convert_timestamp_to_time(ts: GrpcTimestamp, tzinfo: Optional[timezone] = None) -> ht_datetime:
     total_nanos = ts.ToNanoseconds()
     seconds, nanos = divmod(total_nanos, _NS_PER_S)
     # Convert the nanoseconds to yoctoseconds.
     total_yoctoseconds = int(round(_YS_PER_NS * nanos))
-    dt = timestamp_to_1904_epoch(seconds, total_yoctoseconds)
+    dt = timestamp_to_1970_epoch(seconds, total_yoctoseconds)
     return convert_to_desired_timezone(dt, tzinfo)

--- a/src/handwritten/_grpc_time.py
+++ b/src/handwritten/_grpc_time.py
@@ -3,6 +3,7 @@ from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
+from nidaqmx._time import _convert_to_desired_timezone
 
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
 
@@ -17,24 +18,6 @@ _YS_PER_NS = 10**15
 _YS_PER_FS = 10**9
 
 _EPOCH_1970 = ht_datetime(1970, 1, 1, tzinfo=timezone.utc)
-
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
-    current_time_utc = ht_datetime.now(timezone.utc)
-    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-    desired_expected_time = expected_time_utc + desired_timezone_offset
-    new_datetime = ht_datetime(
-        desired_expected_time.year,
-        desired_expected_time.month,
-        desired_expected_time.day,
-        desired_expected_time.hour,
-        desired_expected_time.minute,
-        desired_expected_time.second,
-        desired_expected_time.microsecond,
-        desired_expected_time.femtosecond,
-        desired_expected_time.yoctosecond,
-        tzinfo = tzinfo)
-    return new_datetime
-
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
     seconds_since_1970 = int((dt - _EPOCH_1970).total_seconds())

--- a/src/handwritten/_grpc_time.py
+++ b/src/handwritten/_grpc_time.py
@@ -37,7 +37,7 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
 
 
 def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional[GrpcTimestamp] = None) -> GrpcTimestamp:
-    seconds_since_1970 = int((dt - _EPOCH_1970) / ht_timedelta(seconds=1))
+    seconds_since_1970 = int((dt - _EPOCH_1970).total_seconds())
     # We need to add one more negative second if applicable to compensate for a non-zero microsecond.
     if dt.microsecond and (dt < _EPOCH_1970):
         seconds_since_1970 -=1

--- a/src/handwritten/_grpc_time.py
+++ b/src/handwritten/_grpc_time.py
@@ -1,10 +1,13 @@
 from datetime import timezone
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
+from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
 
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
 
+# 66 years, 17 leap days = 24107 days = 2082844800 seconds
+_BIAS_FROM_1970_EPOCH = 2082844800
 
 _NS_PER_S = 10**9
 _NS_PER_US = 10**3
@@ -35,19 +38,38 @@ def convert_time_to_timestamp(dt: Union[std_datetime, ht_datetime], ts: Optional
     return ts
 
 
+def convert_to_desired_timezone(expected_time_utc, tzinfo):
+    current_time_utc = ht_datetime.now(timezone.utc)
+    desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+    desired_expected_time = expected_time_utc + desired_timezone_offset
+    new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+    return new_datetime
+
+
+def timestamp_to_1904_epoch(timestamp, yoctoseconds):
+    epoch_1904 = ht_datetime(1904, 1, 1)
+    if timestamp < 0:
+        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH - abs(timestamp))
+    else:
+        seconds_from_1904 = ht_timedelta(seconds = _BIAS_FROM_1970_EPOCH + abs(timestamp))
+    datetime_1904 = epoch_1904 + seconds_from_1904 + ht_timedelta(yoctoseconds=yoctoseconds)
+    return datetime_1904
+
+
 def convert_timestamp_to_time(ts: GrpcTimestamp, tzinfo: Optional[timezone] = None) -> ht_datetime:
     total_nanos = ts.ToNanoseconds()
     seconds, nanos = divmod(total_nanos, _NS_PER_S)
-
-    # Convert the nanoseconds to micro, femto, and yoctorseconds.
+    # Convert the nanoseconds to yoctoseconds.
     total_yoctoseconds = int(round(_YS_PER_NS * nanos))
-    microsecond, remainder_yoctoseconds = divmod(total_yoctoseconds, _YS_PER_US)
-    femtosecond, remainder_yoctoseconds = divmod(remainder_yoctoseconds, _YS_PER_FS)
-    yoctosecond = remainder_yoctoseconds
-
-    # Start with UTC
-    dt = ht_datetime.fromtimestamp(seconds, timezone.utc)
-    # Add in precision
-    dt = dt.replace(microsecond=microsecond, femtosecond=femtosecond, yoctosecond=yoctosecond)
-    # Then convert to requested timezone
-    return dt.astimezone(tz=tzinfo)
+    dt = timestamp_to_1904_epoch(seconds, total_yoctoseconds)
+    return convert_to_desired_timezone(dt, tzinfo)

--- a/src/handwritten/_lib_time.py
+++ b/src/handwritten/_lib_time.py
@@ -51,7 +51,7 @@ class AbsoluteTime(ctypes.Structure):
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
-        seconds_since_1904 = int(abs(dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
+        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
 
         # Convert the subseconds.
         if isinstance(dt, ht_datetime):
@@ -66,11 +66,7 @@ class AbsoluteTime(ctypes.Structure):
                 round(AbsoluteTime._NUM_SUBSECONDS * dt.microsecond / AbsoluteTime._US_PER_S)
             )
 
-        # Consider if the date is before or after 1904
-        if dt < AbsoluteTime._EPOCH_1904:
-            return AbsoluteTime(lsb=lsb, msb=-seconds_since_1904)
-        else:
-            return AbsoluteTime(lsb=lsb, msb=seconds_since_1904)
+        return AbsoluteTime(lsb=lsb, msb=seconds_since_1904)
 
     def to_datetime(self, tzinfo: Optional[timezone] = None) -> ht_datetime:
         total_yoctoseconds = int(

--- a/src/handwritten/_lib_time.py
+++ b/src/handwritten/_lib_time.py
@@ -51,7 +51,7 @@ class AbsoluteTime(ctypes.Structure):
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
-        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904) / ht_timedelta(seconds=1))
+        seconds_since_1904 = int((dt - AbsoluteTime._EPOCH_1904).total_seconds())
 
         # Convert the subseconds.
         if isinstance(dt, ht_datetime):

--- a/src/handwritten/_lib_time.py
+++ b/src/handwritten/_lib_time.py
@@ -7,7 +7,7 @@ from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
-
+from nidaqmx._time import _convert_to_desired_timezone
 
 @functools.total_ordering
 class AbsoluteTime(ctypes.Structure):
@@ -32,22 +32,6 @@ class AbsoluteTime(ctypes.Structure):
 
     _EPOCH_1904 = ht_datetime(1904, 1, 1, tzinfo=timezone.utc)
 
-    def _convert_to_desired_timezone(self, expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
-        current_time_utc = ht_datetime.now(timezone.utc)
-        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
-        desired_expected_time = expected_time_utc + desired_timezone_offset
-        new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
-        return new_datetime
 
     @classmethod
     def from_datetime(cls, dt: Union[std_datetime, ht_datetime]) -> AbsoluteTime:
@@ -73,7 +57,7 @@ class AbsoluteTime(ctypes.Structure):
             round(AbsoluteTime._YS_PER_S * self.lsb / AbsoluteTime._NUM_SUBSECONDS)
         )
         dt = AbsoluteTime._EPOCH_1904 + ht_timedelta(seconds=self.msb) + ht_timedelta(yoctoseconds=total_yoctoseconds)
-        return self._convert_to_desired_timezone(dt,tzinfo)
+        return _convert_to_desired_timezone(dt,tzinfo)
 
     def __str__(self) -> str:
         return f"AbsoluteTime(lsb=0x{self.lsb:x}, msb=0x{self.msb:x})"

--- a/src/handwritten/_lib_time.py
+++ b/src/handwritten/_lib_time.py
@@ -5,6 +5,7 @@ import functools
 from datetime import timezone
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
+from hightime import timedelta as ht_timedelta
 from typing import Optional, Union
 
 
@@ -58,33 +59,30 @@ class AbsoluteTime(ctypes.Structure):
 
         return AbsoluteTime(lsb=lsb, msb=timestamp_1904_epoch)
 
+    def convert_to_desired_timezone(self, expected_time_utc, tzinfo):
+        current_time_utc = ht_datetime.now(timezone.utc)
+        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+        desired_expected_time = expected_time_utc + desired_timezone_offset
+        new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+        return new_datetime
+
     def to_datetime(self, tzinfo: Optional[timezone] = None) -> ht_datetime:
-        # First, calculate whole seconds by converting from the 1904 to 1970 epoch.
-        timestamp_1904_epoch = self.msb
-        was_positive = timestamp_1904_epoch > 0
-        timestamp_1970_epoch = int(timestamp_1904_epoch - AbsoluteTime._BIAS_FROM_1970_EPOCH)
-
-        # Our bias is negative, so our sign should only change if we were previously positive.
-        is_positive = timestamp_1970_epoch > 0
-        if is_positive != was_positive and not was_positive:
-            raise OverflowError(f"Can't represent {str(self)} in datetime (1970 epoch)")
-
-        # Finally, convert the subseconds to micro, femto, and yoctoseconds.
         total_yoctoseconds = int(
             round(AbsoluteTime._YS_PER_S * self.lsb / AbsoluteTime._NUM_SUBSECONDS)
         )
-        microsecond, remainder_yoctoseconds = divmod(total_yoctoseconds, AbsoluteTime._YS_PER_US)
-        femtosecond, remainder_yoctoseconds = divmod(
-            remainder_yoctoseconds, AbsoluteTime._YS_PER_FS
-        )
-        yoctosecond = remainder_yoctoseconds
-
-        # Start with UTC
-        dt = ht_datetime.fromtimestamp(timestamp_1970_epoch, timezone.utc)
-        # Add in precision
-        dt = dt.replace(microsecond=microsecond, femtosecond=femtosecond, yoctosecond=yoctosecond)
-        # Then convert to requested timezone
-        return dt.astimezone(tz=tzinfo)
+        datetime_1904 = ht_datetime(1904, 1, 1, tzinfo=timezone.utc)
+        dt = datetime_1904 + ht_timedelta(seconds=self.msb) + ht_timedelta(yoctoseconds=total_yoctoseconds)
+        return self.convert_to_desired_timezone(dt,tzinfo)
 
     def __str__(self) -> str:
         return f"AbsoluteTime(lsb=0x{self.lsb:x}, msb=0x{self.msb:x})"

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -18,8 +18,8 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
     if tzinfo is None:
         tzinfo = get_localzone()
 
-    # use pytz.tzinfo.BaseTzInfo here to account for daylight savings
-    if hasattr(tzinfo, "zone") or isinstance(tzinfo, ZoneInfo):
+    # use ZoneInfo here to account for daylight savings
+    if isinstance(tzinfo, ZoneInfo):
         localized_time = expected_time_utc.replace(tzinfo=tzinfo)
         desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -6,7 +6,10 @@ from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
-from backports.zoneinfo import ZoneInfo
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
 def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:
@@ -19,7 +22,7 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
         tzinfo = get_localzone()
 
     # use ZoneInfo here to account for daylight savings
-    if isinstance(tzinfo, ZoneInfo):
+    if isinstance(tzinfo, zoneinfo.ZoneInfo):
         localized_time = expected_time_utc.replace(tzinfo=tzinfo)
         desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -1,46 +1,33 @@
 from __future__ import annotations
 
-import pytz
 from tzlocal import get_localzone
 from datetime import timezone
+from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
+from zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None):
     # if timezone matches, no need to do conversion
     if expected_time_utc.tzinfo is tzinfo:
         return expected_time_utc
 
     # if timezone is not defined, use system timezone
     if tzinfo is None:
-        local_timezone = get_localzone()
-        tzinfo = pytz.timezone(str(local_timezone))
+        tzinfo = get_localzone()
 
-    # use pytz here to account for daylight savings
-    if isinstance(tzinfo, pytz.tzinfo.BaseTzInfo):
-        target_tz = pytz.timezone(str(tzinfo))
-        # we need to make expected_time_utc naive in order to use localize
-        expected_time_utc = expected_time_utc.replace(tzinfo=None)
-        localized_time = target_tz.localize(expected_time_utc)
-        desired_expected_time = target_tz.fromutc(localized_time)
+    # use pytz.tzinfo.BaseTzInfo here to account for daylight savings
+    if hasattr(tzinfo, "zone") or isinstance(tzinfo, ZoneInfo):
+        localized_time = expected_time_utc.replace(tzinfo=tzinfo)
+        desired_expected_time = tzinfo.fromutc(localized_time)
         return(desired_expected_time)
 
     # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
-    elif isinstance(tzinfo, timezone) and tzinfo.utcoffset(None) is not None:
+    elif isinstance(tzinfo, dt_tzinfo) and tzinfo.utcoffset(None) is not None:
         current_time_utc = ht_datetime.now(timezone.utc)
         desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
         desired_expected_time = expected_time_utc + desired_timezone_offset
-        new_datetime = ht_datetime(
-            desired_expected_time.year,
-            desired_expected_time.month,
-            desired_expected_time.day,
-            desired_expected_time.hour,
-            desired_expected_time.minute,
-            desired_expected_time.second,
-            desired_expected_time.microsecond,
-            desired_expected_time.femtosecond,
-            desired_expected_time.yoctosecond,
-            tzinfo = tzinfo)
+        new_datetime = desired_expected_time.replace(tzinfo=tzinfo)
         return new_datetime

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytz
+from tzlocal import get_localzone
+from datetime import timezone
+from datetime import datetime as std_datetime
+from hightime import datetime as ht_datetime
+from typing import Optional, Union
+
+# theoretically the same as astimezone(), but with support for dates before 1970
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[timezone] = None):
+    # if timezone matches, no need to do conversion
+    if expected_time_utc.tzinfo is tzinfo:
+        return expected_time_utc
+
+    # if timezone is not defined, use system timezone
+    if tzinfo is None:
+        local_timezone = get_localzone()
+        tzinfo = pytz.timezone(str(local_timezone))
+
+    # use pytz here to account for daylight savings
+    if isinstance(tzinfo, pytz.tzinfo.BaseTzInfo):
+        target_tz = pytz.timezone(str(tzinfo))
+        # we need to make expected_time_utc naive in order to use localize
+        expected_time_utc = expected_time_utc.replace(tzinfo=None)
+        localized_time = target_tz.localize(expected_time_utc)
+        desired_expected_time = target_tz.fromutc(localized_time)
+        return(desired_expected_time)
+
+    # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
+    elif isinstance(tzinfo, timezone) and tzinfo.utcoffset(None) is not None:
+        current_time_utc = ht_datetime.now(timezone.utc)
+        desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
+        desired_expected_time = expected_time_utc + desired_timezone_offset
+        new_datetime = ht_datetime(
+            desired_expected_time.year,
+            desired_expected_time.month,
+            desired_expected_time.day,
+            desired_expected_time.hour,
+            desired_expected_time.minute,
+            desired_expected_time.second,
+            desired_expected_time.microsecond,
+            desired_expected_time.femtosecond,
+            desired_expected_time.yoctosecond,
+            tzinfo = tzinfo)
+        return new_datetime

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
-def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None):
+def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:
     # if timezone matches, no need to do conversion
     if expected_time_utc.tzinfo is tzinfo:
         return expected_time_utc
@@ -25,9 +25,13 @@ def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datet
         return(desired_expected_time)
 
     # if the tzinfo passed in is a timedelta function, then we don't need to consider daylight savings
-    elif isinstance(tzinfo, dt_tzinfo) and tzinfo.utcoffset(None) is not None:
+    elif tzinfo.utcoffset(None) is not None:
         current_time_utc = ht_datetime.now(timezone.utc)
         desired_timezone_offset = current_time_utc.astimezone(tz=tzinfo).utcoffset()
         desired_expected_time = expected_time_utc + desired_timezone_offset
         new_datetime = desired_expected_time.replace(tzinfo=tzinfo)
         return new_datetime
+
+    # if the tzinfo passed in is none of the above, fall back to original astimezone()
+    else:
+        return expected_time_utc.astimezone(tzinfo)

--- a/src/handwritten/_time.py
+++ b/src/handwritten/_time.py
@@ -6,7 +6,7 @@ from datetime import tzinfo as dt_tzinfo
 from datetime import datetime as std_datetime
 from hightime import datetime as ht_datetime
 from typing import Optional, Union
-from zoneinfo import ZoneInfo
+from backports.zoneinfo import ZoneInfo
 
 # theoretically the same as astimezone(), but with support for dates before 1970
 def _convert_to_desired_timezone(expected_time_utc: Union[std_datetime, ht_datetime], tzinfo: Optional[dt_tzinfo] = None) -> Union[std_datetime, ht_datetime]:

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -1,8 +1,7 @@
 from datetime import timezone
 
 import pytest
-from hightime import datetime as ht_datetime
-from hightime import timedelta as ht_timedelta
+from hightime import datetime as ht_datetime, timedelta as ht_timedelta
 
 from nidaqmx.constants import Timescale
 from nidaqmx.task import Task
@@ -19,8 +18,8 @@ def test___default_arguments___cfg_time_start_trig___no_errors(
     ai_voltage_task: Task,
 ):
     ai_voltage_task.timing.cfg_samp_clk_timing(1000)
-    utc_dt = ht_datetime.now(timezone.utc) # UTC time
-    dt_now = utc_dt.astimezone() # local time
+    utc_dt = ht_datetime.now(timezone.utc)  # UTC time
+    dt_now = utc_dt.astimezone()  # local time
     trigger_time = dt_now + ht_timedelta(seconds=10)
 
     ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time)
@@ -40,8 +39,8 @@ def test___arguments_provided___cfg_time_start_trig___no_errors(
     ai_voltage_task: Task,
 ):
     ai_voltage_task.timing.cfg_samp_clk_timing(1000)
-    utc_dt = ht_datetime.now(timezone.utc) # UTC time
-    dt_now = utc_dt.astimezone() # local time
+    utc_dt = ht_datetime.now(timezone.utc)  # UTC time
+    dt_now = utc_dt.astimezone()  # local time
     trigger_time = dt_now + ht_timedelta(seconds=10)
     # simulated devices don't support setting timescale to USE_IO_DEVICE
     timescale = Timescale.USE_HOST

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -1,7 +1,8 @@
-from datetime import timedelta
+from datetime import timezone
 
 import pytest
 from hightime import datetime as ht_datetime
+from hightime import timedelta as ht_timedelta
 
 from nidaqmx.constants import Timescale
 from nidaqmx.task import Task
@@ -18,7 +19,9 @@ def test___default_arguments___cfg_time_start_trig___no_errors(
     ai_voltage_task: Task,
 ):
     ai_voltage_task.timing.cfg_samp_clk_timing(1000)
-    trigger_time = ht_datetime.now() + timedelta(seconds=10)
+    utc_dt = ht_datetime.now(timezone.utc) # UTC time
+    dt_now = utc_dt.astimezone() # local time
+    trigger_time = dt_now + ht_timedelta(seconds=10)
 
     ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time)
 
@@ -37,7 +40,9 @@ def test___arguments_provided___cfg_time_start_trig___no_errors(
     ai_voltage_task: Task,
 ):
     ai_voltage_task.timing.cfg_samp_clk_timing(1000)
-    trigger_time = ht_datetime.now() + timedelta(seconds=10)
+    utc_dt = ht_datetime.now(timezone.utc) # UTC time
+    dt_now = utc_dt.astimezone() # local time
+    trigger_time = dt_now + ht_timedelta(seconds=10)
     # simulated devices don't support setting timescale to USE_IO_DEVICE
     timescale = Timescale.USE_HOST
 

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -3,12 +3,12 @@ from datetime import timezone
 import pytest
 from hightime import datetime as ht_datetime
 
+from nidaqmx._time import _convert_to_desired_timezone
 from nidaqmx.constants import TaskMode, TriggerType
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 from tests.unit._time_utils import JAN_01_1904_HIGHTIME, JAN_01_2002_HIGHTIME
-from nidaqmx._time import _convert_to_desired_timezone
 
 
 @pytest.fixture()

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -1,7 +1,4 @@
-from datetime import timezone
-
 import pytest
-from hightime import datetime as ht_datetime
 
 from nidaqmx._time import _convert_to_desired_timezone
 from nidaqmx.constants import TaskMode, TriggerType

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -8,6 +8,7 @@ from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 from tests.unit._time_utils import JAN_01_1904_HIGHTIME, JAN_01_2002_HIGHTIME
+from nidaqmx._time import _convert_to_desired_timezone
 
 
 @pytest.fixture()
@@ -22,13 +23,6 @@ def ai_voltage_time_aware_task(task, sim_time_aware_9215_device):
     """Gets AI voltage task."""
     task.ai_channels.add_ai_voltage_chan(sim_time_aware_9215_device.ai_physical_chans[0].name)
     yield task
-
-
-def convert_to_local_timezone(expected_time_utc):
-    current_time_utc = ht_datetime.now(timezone.utc)
-    local_timezone_offset = current_time_utc.astimezone().utcoffset()
-    local_expected_time = expected_time_utc + local_timezone_offset
-    return local_expected_time
 
 
 def test___ai_task___get_float_property___returns_default_value(ai_voltage_task: Task):
@@ -119,7 +113,6 @@ def test___ai_task___reset_uint32_property___returns_default_value(ai_voltage_ta
     assert ai_voltage_task.triggers.reference_trigger.pretrig_samples == 2
 
 
-@pytest.mark.xfail(reason="Timestamp conversion doesn't work on dates before 1970", raises=OSError)
 def test___ai_voltage_time_aware_task___get_timestamp_property___returns_default_value(
     ai_voltage_time_aware_task: Task,
 ):
@@ -127,7 +120,7 @@ def test___ai_voltage_time_aware_task___get_timestamp_property___returns_default
 
     when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
 
-    localized_default_value = convert_to_local_timezone(JAN_01_1904_HIGHTIME)
+    localized_default_value = _convert_to_desired_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
     assert when_value.month == localized_default_value.month
     assert when_value.day == localized_default_value.day
@@ -145,7 +138,7 @@ def test___ai_voltage_time_aware_task___set_timestamp_property___returns_assigne
     ai_voltage_time_aware_task.triggers.start_trigger.trig_when = value_to_test
 
     when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
-    localized_value_to_test = convert_to_local_timezone(value_to_test)
+    localized_value_to_test = _convert_to_desired_timezone(value_to_test)
     assert when_value.year == localized_value_to_test.year
     assert when_value.month == localized_value_to_test.month
     assert when_value.day == localized_value_to_test.day
@@ -154,7 +147,6 @@ def test___ai_voltage_time_aware_task___set_timestamp_property___returns_assigne
     assert when_value.second == localized_value_to_test.second
 
 
-@pytest.mark.xfail(reason="Timestamp conversion doesn't work on dates before 1970", raises=OSError)
 def test___ai_voltage_time_aware_task___reset_timestamp_property___returns_default_value(
     ai_voltage_time_aware_task: Task,
 ):
@@ -164,7 +156,7 @@ def test___ai_voltage_time_aware_task___reset_timestamp_property___returns_defau
     del ai_voltage_time_aware_task.triggers.start_trigger.trig_when
 
     when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
-    localized_default_value = convert_to_local_timezone(JAN_01_1904_HIGHTIME)
+    localized_default_value = _convert_to_desired_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
     assert when_value.month == localized_default_value.month
     assert when_value.day == localized_default_value.day

--- a/tests/unit/_time_utils.py
+++ b/tests/unit/_time_utils.py
@@ -7,8 +7,12 @@ from hightime import datetime as ht_datetime
 JAN_01_2002_TIMESTAMP_1970_EPOCH = 0x3C30FC00
 # Jan 1, 2002 = 98 years + 25 leapdays = 35795 days = 3092688000 seconds
 JAN_01_2002_TIMESTAMP_1904_EPOCH = 0xB856AC80
+JAN_01_1904_TIMESTAMP_1904_EPOCH = 0
+JAN_01_1850_TIMESTAMP_1904_EPOCH = -0x6590AF00
 
 JAN_01_2002_DATETIME = std_datetime(2002, 1, 1, tzinfo=timezone.utc)
 JAN_01_2002_HIGHTIME = ht_datetime(2002, 1, 1, tzinfo=timezone.utc)
 JAN_01_1904_DATETIME = std_datetime(1904, 1, 1, tzinfo=timezone.utc)
 JAN_01_1904_HIGHTIME = ht_datetime(1904, 1, 1, tzinfo=timezone.utc)
+JAN_01_1850_DATETIME = std_datetime(1850, 1, 1, tzinfo=timezone.utc)
+JAN_01_1850_HIGHTIME = ht_datetime(1850, 1, 1, tzinfo=timezone.utc)

--- a/tests/unit/_time_utils.py
+++ b/tests/unit/_time_utils.py
@@ -5,6 +5,7 @@ from hightime import datetime as ht_datetime
 
 # Jan 1, 2002 = 32 years + 8 leapdays = 11688 days = 1009843200 seconds
 JAN_01_2002_TIMESTAMP_1970_EPOCH = 0x3C30FC00
+JAN_01_1850_TIMESTAMP_1970_EPOCH = -0xE1B65F80
 # Jan 1, 2002 = 98 years + 25 leapdays = 35795 days = 3092688000 seconds
 JAN_01_2002_TIMESTAMP_1904_EPOCH = 0xB856AC80
 JAN_01_1904_TIMESTAMP_1904_EPOCH = 0

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -125,7 +125,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # type: ignore # ZoneInfo is a concrete class that takes in abstract tzinfo
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -20,9 +20,9 @@ except ImportError:
     pass
 
 if sys.version_info >= (3, 9):
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 else:
-    import backports.zoneinfo as zoneinfo
+    from backports.zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
@@ -125,7 +125,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -120,7 +120,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
         (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
     ],
 )
-def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible_grpc(date):
+def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
     target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -22,7 +22,7 @@ except ImportError:
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import ZoneInfo
+    from backports.zoneinfo import zoneinfo as ZoneInfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -198,10 +198,7 @@ def test___datetime_before_1970_with_microseconds___convert_to_timestamp___is_re
     grpc_time.convert_time_to_timestamp(from_dt, to_ts)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
-    if microsecond:
-        assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH + 1
-    else:
-        assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
+    assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
     assert to_ts.nanos == nanoseconds
     assert roundtrip_dt.microsecond == microsecond
 
@@ -242,7 +239,7 @@ def test___datetime_after_1970_with_femtoseconds___convert_to_timestamp___is_rev
     [
         (JAN_01_1850_HIGHTIME, 0, 0),
         (JAN_01_1850_HIGHTIME, 1, 0),
-        # If femtoseconds get high enough, then it should round up
+        # # If femtoseconds get high enough, then it should round up
         (JAN_01_1850_HIGHTIME, 500000, 1),
         (JAN_01_1850_HIGHTIME, 999999, 1),
         # And of course, whole nanos

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -21,7 +21,7 @@ except ImportError:
 try:
     import zoneinfo
 except ImportError:
-    from backports import zoneinfo
+    import backports.zoneinfo as zoneinfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,16 +1,16 @@
 from datetime import datetime as std_datetime, timedelta, timezone
 
-import pytz
 import pytest
+import pytz
 from hightime import datetime as ht_datetime
 
 from tests.unit._time_utils import (
-    JAN_01_2002_TIMESTAMP_1970_EPOCH,
+    JAN_01_1850_DATETIME,
+    JAN_01_1850_HIGHTIME,
     JAN_01_1850_TIMESTAMP_1970_EPOCH,
     JAN_01_2002_DATETIME,
     JAN_01_2002_HIGHTIME,
-    JAN_01_1850_DATETIME,
-    JAN_01_1850_HIGHTIME,
+    JAN_01_2002_TIMESTAMP_1970_EPOCH,
 )
 
 try:
@@ -120,11 +120,9 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
         (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
     ],
 )
-def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible_grpc(
-    date
-):
+def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible_grpc(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = pytz.timezone('America/Los_Angeles') # Pacific Time
+    target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -22,7 +22,7 @@ except ImportError:
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import zoneinfo
+    from backports.zoneinfo import ZoneInfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
@@ -128,7 +128,7 @@ def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     if sys.version_info >= (3, 9):
         target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     else:
-        target_timezone = zoneinfo("America/Los_Angeles")  # Pacific Time
+        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -239,7 +239,7 @@ def test___datetime_after_1970_with_femtoseconds___convert_to_timestamp___is_rev
     [
         (JAN_01_1850_HIGHTIME, 0, 0),
         (JAN_01_1850_HIGHTIME, 1, 0),
-        # # If femtoseconds get high enough, then it should round up
+        # If femtoseconds get high enough, then it should round up
         (JAN_01_1850_HIGHTIME, 500000, 1),
         (JAN_01_1850_HIGHTIME, 999999, 1),
         # And of course, whole nanos

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -125,10 +125,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    if sys.version_info >= (3, 9):
-        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
-    else:
-        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -4,9 +4,12 @@ import pytest
 from hightime import datetime as ht_datetime
 
 from tests.unit._time_utils import (
+    JAN_01_2002_TIMESTAMP_1970_EPOCH,
+    JAN_01_1850_TIMESTAMP_1970_EPOCH,
     JAN_01_2002_DATETIME,
     JAN_01_2002_HIGHTIME,
-    JAN_01_2002_TIMESTAMP_1970_EPOCH,
+    JAN_01_1850_DATETIME,
+    JAN_01_1850_HIGHTIME,
 )
 
 try:
@@ -17,8 +20,9 @@ except ImportError:
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
-def test___utc_datetime___convert_to_timestamp___is_reversible(from_dt):
-    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
+def test___utc_datetime_after_1970___convert_to_timestamp___is_reversible(from_dt):
+    to_ts = GrpcTimestamp()
+    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     total_nanoseconds = to_ts.ToNanoseconds()
@@ -28,8 +32,21 @@ def test___utc_datetime___convert_to_timestamp___is_reversible(from_dt):
     assert roundtrip_dt == JAN_01_2002_HIGHTIME
 
 
+@pytest.mark.parametrize("from_dt", [(JAN_01_1850_DATETIME), (JAN_01_1850_HIGHTIME)])
+def test___utc_datetime_before_1970___convert_to_timestamp___is_reversible(from_dt):
+    to_ts = GrpcTimestamp()
+    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
+
+    total_nanoseconds = to_ts.ToNanoseconds()
+    seconds, nanos = divmod(total_nanoseconds, grpc_time._NS_PER_S)
+    assert seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
+    assert nanos == 0
+    assert roundtrip_dt == JAN_01_1850_HIGHTIME
+
+
 @pytest.mark.parametrize("request_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
-def test___utc_datetime___convert_to_grpc_request___succeeds(request_dt):
+def test___utc_datetime_after_1970___convert_to_grpc_request___succeeds(request_dt):
     request = nidaqmx_pb2.CfgTimeStartTrigRequest()
 
     grpc_time.convert_time_to_timestamp(request_dt, request.when)
@@ -40,14 +57,36 @@ def test___utc_datetime___convert_to_grpc_request___succeeds(request_dt):
     assert nanos == 0
 
 
+@pytest.mark.parametrize("request_dt", [(JAN_01_1850_DATETIME), (JAN_01_1850_HIGHTIME)])
+def test___utc_datetime_before_1970___convert_to_grpc_request___succeeds(request_dt):
+    request = nidaqmx_pb2.CfgTimeStartTrigRequest()
+
+    grpc_time.convert_time_to_timestamp(request_dt, request.when)
+
+    total_nanoseconds = request.when.ToNanoseconds()
+    seconds, nanos = divmod(total_nanoseconds, grpc_time._NS_PER_S)
+    assert seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
+    assert nanos == 0
+
+
 @pytest.mark.parametrize("response_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
-def test___grpc_response___convert_to_timestamp___succeeds(response_dt):
+def test___grpc_response_after_1970___convert_to_timestamp___succeeds(response_dt):
     response = nidaqmx_pb2.GetStartTrigTrigWhenResponse()
     grpc_time.convert_time_to_timestamp(response_dt, response.data)
 
     to_dt = grpc_time.convert_timestamp_to_time(response.data, tzinfo=timezone.utc)
 
     assert to_dt == JAN_01_2002_HIGHTIME
+
+
+@pytest.mark.parametrize("response_dt", [(JAN_01_1850_DATETIME), (JAN_01_1850_HIGHTIME)])
+def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_dt):
+    response = nidaqmx_pb2.GetStartTrigTrigWhenResponse()
+    grpc_time.convert_time_to_timestamp(response_dt, response.data)
+
+    to_dt = grpc_time.convert_timestamp_to_time(response.data, tzinfo=timezone.utc)
+
+    assert to_dt == JAN_01_1850_HIGHTIME
 
 
 @pytest.mark.parametrize(
@@ -63,7 +102,7 @@ def test___grpc_response___convert_to_timestamp___succeeds(response_dt):
         (ht_datetime, timezone(timedelta(hours=-1)), 3600),
     ],
 )
-def test___tz_datetime___convert_to_timestamp___is_reversible(
+def test___tz_datetime_after_1970___convert_to_timestamp___is_reversible(
     datetime_cls, tzinfo, expected_offset
 ):
     from_dt = datetime_cls(2002, 1, 1, tzinfo=tzinfo)
@@ -72,6 +111,33 @@ def test___tz_datetime___convert_to_timestamp___is_reversible(
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=tzinfo)
 
     assert to_ts.seconds == JAN_01_2002_TIMESTAMP_1970_EPOCH + expected_offset
+    assert to_ts.nanos == 0
+    assert from_dt == roundtrip_dt
+
+
+@pytest.mark.parametrize(
+    "datetime_cls, tzinfo, expected_offset",
+    [
+        (std_datetime, timezone(timedelta(minutes=30)), -1800),
+        (std_datetime, timezone(timedelta(minutes=-30)), 1800),
+        (std_datetime, timezone(timedelta(hours=1)), -3600),
+        (std_datetime, timezone(timedelta(hours=-1)), 3600),
+        (ht_datetime, timezone(timedelta(minutes=30)), -1800),
+        (ht_datetime, timezone(timedelta(minutes=-30)), 1800),
+        (ht_datetime, timezone(timedelta(hours=1)), -3600),
+        (ht_datetime, timezone(timedelta(hours=-1)), 3600),
+    ],
+)
+def test___tz_datetime_before_1970___convert_to_timestamp___is_reversible(
+    datetime_cls, tzinfo, expected_offset
+):
+    from_dt = datetime_cls(1850, 1, 1, tzinfo=tzinfo)
+
+    to_ts = GrpcTimestamp()
+    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=tzinfo)
+
+    assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH + expected_offset
     assert to_ts.nanos == 0
     assert from_dt == roundtrip_dt
 
@@ -93,7 +159,7 @@ def test___tz_datetime___convert_to_timestamp___is_reversible(
         (JAN_01_2002_HIGHTIME, 999999, 999999000),
     ],
 )
-def test___datetime_with_microseconds___convert_to_timestamp___is_reversible(
+def test___datetime_after_1970_with_microseconds___convert_to_timestamp___is_reversible(
     base_dt, microsecond, nanoseconds
 ):
     from_dt = base_dt.replace(microsecond=microsecond)
@@ -102,6 +168,40 @@ def test___datetime_with_microseconds___convert_to_timestamp___is_reversible(
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     assert to_ts.seconds == JAN_01_2002_TIMESTAMP_1970_EPOCH
+    assert to_ts.nanos == nanoseconds
+    assert roundtrip_dt.microsecond == microsecond
+
+
+@pytest.mark.parametrize(
+    "base_dt, microsecond, nanoseconds",
+    [
+        (JAN_01_1850_DATETIME, 0, 0),
+        (JAN_01_1850_DATETIME, 1, 1000),
+        (JAN_01_1850_DATETIME, 250000, 250000000),
+        (JAN_01_1850_DATETIME, 500000, 500000000),
+        (JAN_01_1850_DATETIME, 750000, 750000000),
+        (JAN_01_1850_DATETIME, 999999, 999999000),
+        (JAN_01_1850_HIGHTIME, 0, 0),
+        (JAN_01_1850_HIGHTIME, 1, 1000),
+        (JAN_01_1850_HIGHTIME, 250000, 250000000),
+        (JAN_01_1850_HIGHTIME, 500000, 500000000),
+        (JAN_01_1850_HIGHTIME, 750000, 750000000),
+        (JAN_01_1850_HIGHTIME, 999999, 999999000),
+    ],
+)
+def test___datetime_before_1970_with_microseconds___convert_to_timestamp___is_reversible(
+    base_dt, microsecond, nanoseconds
+):
+    from_dt = base_dt.replace(microsecond=microsecond)
+
+    to_ts = GrpcTimestamp()
+    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
+
+    if microsecond:
+        assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH + 1
+    else:
+        assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
     assert to_ts.nanos == nanoseconds
     assert roundtrip_dt.microsecond == microsecond
 
@@ -123,7 +223,7 @@ def test___datetime_with_microseconds___convert_to_timestamp___is_reversible(
         (JAN_01_2002_HIGHTIME, 2000001, 2),
     ],
 )
-def test___datetime_with_femtoseconds___convert_to_timestamp___is_reversible(
+def test___datetime_after_1970_with_femtoseconds___convert_to_timestamp___is_reversible(
     base_dt, femtosecond, nanoseconds
 ):
     from_dt = base_dt.replace(femtosecond=femtosecond)
@@ -132,6 +232,38 @@ def test___datetime_with_femtoseconds___convert_to_timestamp___is_reversible(
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     assert to_ts.seconds == JAN_01_2002_TIMESTAMP_1970_EPOCH
+    assert to_ts.nanos == nanoseconds
+    # we lost femtosecond precision coercing to nanoseconds.
+    assert roundtrip_dt.femtosecond == nanoseconds * (10**6)
+
+
+@pytest.mark.parametrize(
+    "base_dt, femtosecond, nanoseconds",
+    [
+        (JAN_01_1850_HIGHTIME, 0, 0),
+        (JAN_01_1850_HIGHTIME, 1, 0),
+        # If femtoseconds get high enough, then it should round up
+        (JAN_01_1850_HIGHTIME, 500000, 1),
+        (JAN_01_1850_HIGHTIME, 999999, 1),
+        # And of course, whole nanos
+        (JAN_01_1850_HIGHTIME, 1000000, 1),
+        (JAN_01_1850_HIGHTIME, 1000001, 1),
+        (JAN_01_1850_HIGHTIME, 1500000, 2),
+        (JAN_01_1850_HIGHTIME, 1999999, 2),
+        (JAN_01_1850_HIGHTIME, 2000000, 2),
+        (JAN_01_1850_HIGHTIME, 2000001, 2),
+    ],
+)
+def test___datetime_before_1970_with_femtoseconds___convert_to_timestamp___is_reversible(
+    base_dt, femtosecond, nanoseconds
+):
+    from_dt = base_dt.replace(femtosecond=femtosecond)
+
+    to_ts = GrpcTimestamp()
+    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
+
+    assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
     assert to_ts.nanos == nanoseconds
     # we lost femtosecond precision coercing to nanoseconds.
     assert roundtrip_dt.femtosecond == nanoseconds * (10**6)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -22,7 +22,7 @@ except ImportError:
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import zoneinfo as ZoneInfo
+    from backports.zoneinfo import zoneinfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
@@ -125,7 +125,10 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    if sys.version_info >= (3, 9):
+        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    else:
+        target_timezone = zoneinfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,7 +1,7 @@
-import zoneinfo
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
+from backports.zoneinfo import ZoneInfo
 from hightime import datetime as ht_datetime
 
 from tests.unit._time_utils import (
@@ -120,7 +120,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
@@ -18,9 +19,9 @@ try:
 except ImportError:
     pass
 
-try:
+if sys.version_info >= (3, 9):
     import zoneinfo
-except ImportError:
+else:
     import backports.zoneinfo as zoneinfo
 
 

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -22,8 +22,7 @@ except ImportError:
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
 def test___utc_datetime_after_1970___convert_to_timestamp___is_reversible(from_dt):
-    to_ts = GrpcTimestamp()
-    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     total_nanoseconds = to_ts.ToNanoseconds()
@@ -35,8 +34,7 @@ def test___utc_datetime_after_1970___convert_to_timestamp___is_reversible(from_d
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_1850_DATETIME), (JAN_01_1850_HIGHTIME)])
 def test___utc_datetime_before_1970___convert_to_timestamp___is_reversible(from_dt):
-    to_ts = GrpcTimestamp()
-    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     total_nanoseconds = to_ts.ToNanoseconds()
@@ -175,8 +173,7 @@ def test___tz_datetime_before_1970___convert_to_timestamp___is_reversible(
 ):
     from_dt = datetime_cls(1850, 1, 1, tzinfo=tzinfo)
 
-    to_ts = GrpcTimestamp()
-    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=tzinfo)
 
     assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH + expected_offset
@@ -236,8 +233,7 @@ def test___datetime_before_1970_with_microseconds___convert_to_timestamp___is_re
 ):
     from_dt = base_dt.replace(microsecond=microsecond)
 
-    to_ts = GrpcTimestamp()
-    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH
@@ -298,8 +294,7 @@ def test___datetime_before_1970_with_femtoseconds___convert_to_timestamp___is_re
 ):
     from_dt = base_dt.replace(femtosecond=femtosecond)
 
-    to_ts = GrpcTimestamp()
-    grpc_time.convert_time_to_timestamp(from_dt, to_ts)
+    to_ts = grpc_time.convert_time_to_timestamp(from_dt)
     roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=timezone.utc)
 
     assert to_ts.seconds == JAN_01_1850_TIMESTAMP_1970_EPOCH

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,5 +1,6 @@
 from datetime import datetime as std_datetime, timedelta, timezone
 
+import pytz
 import pytest
 from hightime import datetime as ht_datetime
 
@@ -87,6 +88,49 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
     to_dt = grpc_time.convert_timestamp_to_time(response.data, tzinfo=timezone.utc)
 
     assert to_dt == JAN_01_1850_HIGHTIME
+
+
+@pytest.mark.parametrize(
+    "date",
+    [
+        (std_datetime(1904, 1, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 1, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 2, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 3, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 4, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 5, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 6, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 7, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 8, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 9, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 10, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 11, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 12, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 1, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 2, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 3, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 4, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 5, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 6, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 7, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 8, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 9, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 10, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 11, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
+    ],
+)
+def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible_grpc(
+    date
+):
+    # we use a location that has daylight savings date change on the dates above
+    target_timezone = pytz.timezone('America/Los_Angeles') # Pacific Time
+    astimezone_date = date.astimezone(target_timezone)
+
+    to_ts = grpc_time.convert_time_to_timestamp(date)
+    roundtrip_dt = grpc_time.convert_timestamp_to_time(to_ts, tzinfo=target_timezone)
+
+    assert astimezone_date == roundtrip_dt
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,7 +1,7 @@
+import zoneinfo
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
-import pytz
 from hightime import datetime as ht_datetime
 
 from tests.unit._time_utils import (
@@ -120,7 +120,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
+    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -1,7 +1,6 @@
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
-from backports.zoneinfo import ZoneInfo
 from hightime import datetime as ht_datetime
 
 from tests.unit._time_utils import (
@@ -18,6 +17,11 @@ try:
     import nidaqmx._stubs.nidaqmx_pb2 as nidaqmx_pb2
 except ImportError:
     pass
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
@@ -120,7 +124,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,9 +1,9 @@
 import random
-import zoneinfo
 from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
+from backports.zoneinfo import ZoneInfo
 from hightime import datetime as ht_datetime
 
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
@@ -97,7 +97,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -22,7 +22,7 @@ from tests.unit._time_utils import (
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import zoneinfo as ZoneInfo
+    from backports.zoneinfo import zoneinfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
@@ -102,7 +102,10 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    if sys.version_info >= (3, 9):
+        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    else:
+        target_timezone = zoneinfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -22,7 +22,7 @@ from tests.unit._time_utils import (
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import ZoneInfo
+    from backports.zoneinfo import zoneinfo as ZoneInfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -22,7 +22,7 @@ from tests.unit._time_utils import (
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
 else:
-    from backports.zoneinfo import zoneinfo
+    from backports.zoneinfo import ZoneInfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
@@ -105,7 +105,7 @@ def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     if sys.version_info >= (3, 9):
         target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     else:
-        target_timezone = zoneinfo("America/Los_Angeles")  # Pacific Time
+        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -3,7 +3,6 @@ from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
-from backports.zoneinfo import ZoneInfo
 from hightime import datetime as ht_datetime
 
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
@@ -18,6 +17,11 @@ from tests.unit._time_utils import (
     JAN_01_2002_HIGHTIME,
     JAN_01_2002_TIMESTAMP_1904_EPOCH,
 )
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
@@ -97,7 +101,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,9 +1,9 @@
 import random
-import pytz
 from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
+import pytz
 from hightime import datetime as ht_datetime
 
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
@@ -95,11 +95,9 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
         (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
     ],
 )
-def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible(
-    date
-):
+def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = pytz.timezone('America/Los_Angeles') # Pacific Time
+    target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -102,7 +102,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # type: ignore # ZoneInfo is a concrete class that takes in abstract tzinfo
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,4 +1,5 @@
 import random
+import sys
 from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
@@ -18,9 +19,9 @@ from tests.unit._time_utils import (
     JAN_01_2002_TIMESTAMP_1904_EPOCH,
 )
 
-try:
+if sys.version_info >= (3, 9):
     import zoneinfo
-except ImportError:
+else:
     import backports.zoneinfo as zoneinfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -20,9 +20,9 @@ from tests.unit._time_utils import (
 )
 
 if sys.version_info >= (3, 9):
-    import zoneinfo
+    from zoneinfo import ZoneInfo
 else:
-    import backports.zoneinfo as zoneinfo
+    from backports.zoneinfo import ZoneInfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
@@ -102,7 +102,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -95,7 +95,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
         (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
     ],
 )
-def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible(date):
+def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
     target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -21,7 +21,7 @@ from tests.unit._time_utils import (
 try:
     import zoneinfo
 except ImportError:
-    from backports import zoneinfo
+    import backports.zoneinfo as zoneinfo
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,24 +1,22 @@
 import random
 from copy import copy
-from datetime import datetime as std_datetime
-from datetime import timedelta, timezone
+from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
 from hightime import datetime as ht_datetime
 
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
 from tests.unit._time_utils import (
-    JAN_01_2002_TIMESTAMP_1904_EPOCH,
-    JAN_01_1904_TIMESTAMP_1904_EPOCH,
-    JAN_01_1850_TIMESTAMP_1904_EPOCH,
-    JAN_01_2002_DATETIME,
-    JAN_01_2002_HIGHTIME,
-    JAN_01_1904_DATETIME,
-    JAN_01_1904_HIGHTIME,
     JAN_01_1850_DATETIME,
     JAN_01_1850_HIGHTIME,
+    JAN_01_1850_TIMESTAMP_1904_EPOCH,
+    JAN_01_1904_DATETIME,
+    JAN_01_1904_HIGHTIME,
+    JAN_01_1904_TIMESTAMP_1904_EPOCH,
+    JAN_01_2002_DATETIME,
+    JAN_01_2002_HIGHTIME,
+    JAN_01_2002_TIMESTAMP_1904_EPOCH,
 )
-
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
 JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
@@ -186,11 +184,7 @@ def test___datetime_before_1904_with_microseconds___convert_to_timestamp___is_re
     assert to_ts.lsb == subseconds
     # comparison is tricky since imprecision in the conversion to NI-BTF are
     # caught by the higher precision values in hightime, so we round here.
-    roundtrip_dt_microsecond = roundtrip_dt.microsecond
-    if roundtrip_dt.femtosecond > LibTimestamp.MAX_FS / 2:
-        roundtrip_dt_microsecond += 1
-
-    assert roundtrip_dt_microsecond == microsecond
+    assert pytest.approx(roundtrip_dt.microsecond, abs=1) == microsecond
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,9 +1,9 @@
 import random
+import zoneinfo
 from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
 import pytest
-import pytz
 from hightime import datetime as ht_datetime
 
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
@@ -97,7 +97,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone = pytz.timezone("America/Los_Angeles")  # Pacific Time
+    target_timezone = zoneinfo.ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -102,7 +102,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone : ZoneInfo  = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -9,12 +9,20 @@ from hightime import datetime as ht_datetime
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
 from tests.unit._time_utils import (
     JAN_01_2002_TIMESTAMP_1904_EPOCH,
+    JAN_01_1904_TIMESTAMP_1904_EPOCH,
+    JAN_01_1850_TIMESTAMP_1904_EPOCH,
     JAN_01_2002_DATETIME,
     JAN_01_2002_HIGHTIME,
+    JAN_01_1904_DATETIME,
+    JAN_01_1904_HIGHTIME,
+    JAN_01_1850_DATETIME,
+    JAN_01_1850_HIGHTIME,
 )
 
 
 JAN_01_2002_LIB = LibTimestamp(lsb=0, msb=JAN_01_2002_TIMESTAMP_1904_EPOCH)
+JAN_01_1904_LIB = LibTimestamp(lsb=0, msb=JAN_01_1904_TIMESTAMP_1904_EPOCH)
+JAN_01_1850_LIB = LibTimestamp(lsb=0, msb=JAN_01_1850_TIMESTAMP_1904_EPOCH)
 
 
 def test___timestamps___sort___is_ordered():
@@ -32,12 +40,30 @@ def test___timestamps___sort___is_ordered():
 
 
 @pytest.mark.parametrize("from_dt", [(JAN_01_2002_DATETIME), (JAN_01_2002_HIGHTIME)])
-def test___utc_datetime___convert_to_timestamp___is_reversible(from_dt):
+def test___utc_datetime_after_1904___convert_to_timestamp___is_reversible(from_dt):
     to_ts = LibTimestamp.from_datetime(from_dt)
     roundtrip_dt = to_ts.to_datetime(tzinfo=timezone.utc)
 
     assert to_ts == JAN_01_2002_LIB
     assert roundtrip_dt == JAN_01_2002_HIGHTIME
+
+
+@pytest.mark.parametrize("from_dt", [(JAN_01_1904_DATETIME), (JAN_01_1904_HIGHTIME)])
+def test___utc_datetime_on_1904___convert_to_timestamp___is_reversible(from_dt):
+    to_ts = LibTimestamp.from_datetime(from_dt)
+    roundtrip_dt = to_ts.to_datetime(tzinfo=timezone.utc)
+
+    assert to_ts == JAN_01_1904_LIB
+    assert roundtrip_dt == JAN_01_1904_HIGHTIME
+
+
+@pytest.mark.parametrize("from_dt", [(JAN_01_1850_DATETIME), (JAN_01_1850_HIGHTIME)])
+def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_dt):
+    to_ts = LibTimestamp.from_datetime(from_dt)
+    roundtrip_dt = to_ts.to_datetime(tzinfo=timezone.utc)
+
+    assert to_ts == JAN_01_1850_LIB
+    assert roundtrip_dt == JAN_01_1850_HIGHTIME
 
 
 @pytest.mark.parametrize(
@@ -53,7 +79,7 @@ def test___utc_datetime___convert_to_timestamp___is_reversible(from_dt):
         (ht_datetime, timezone(timedelta(hours=-1)), 3600),
     ],
 )
-def test___tz_datetime___convert_to_timestamp___is_reversible(
+def test___tz_datetime_after_1904___convert_to_timestamp___is_reversible(
     datetime_cls, tzinfo, expected_offset
 ):
     from_dt = datetime_cls(2002, 1, 1, tzinfo=tzinfo)
@@ -63,6 +89,32 @@ def test___tz_datetime___convert_to_timestamp___is_reversible(
 
     assert to_ts.msb == JAN_01_2002_LIB.msb + expected_offset
     assert to_ts.lsb == JAN_01_2002_LIB.lsb
+    assert roundtrip_dt == from_dt
+
+
+@pytest.mark.parametrize(
+    "datetime_cls, tzinfo, expected_offset",
+    [
+        (std_datetime, timezone(timedelta(minutes=30)), -1800),
+        (std_datetime, timezone(timedelta(minutes=-30)), 1800),
+        (std_datetime, timezone(timedelta(hours=1)), -3600),
+        (std_datetime, timezone(timedelta(hours=-1)), 3600),
+        (ht_datetime, timezone(timedelta(minutes=30)), -1800),
+        (ht_datetime, timezone(timedelta(minutes=-30)), 1800),
+        (ht_datetime, timezone(timedelta(hours=1)), -3600),
+        (ht_datetime, timezone(timedelta(hours=-1)), 3600),
+    ],
+)
+def test___tz_datetime_before_1904___convert_to_timestamp___is_reversible(
+    datetime_cls, tzinfo, expected_offset
+):
+    from_dt = datetime_cls(1850, 1, 1, tzinfo=tzinfo)
+
+    to_ts = LibTimestamp.from_datetime(from_dt)
+    roundtrip_dt = to_ts.to_datetime(tzinfo=tzinfo)
+
+    assert to_ts.msb == JAN_01_1850_LIB.msb + expected_offset
+    assert to_ts.lsb == JAN_01_1850_LIB.lsb
     assert roundtrip_dt == from_dt
 
 
@@ -83,7 +135,7 @@ def test___tz_datetime___convert_to_timestamp___is_reversible(
         (JAN_01_2002_HIGHTIME, 999999, 0xFFFFEF39085F4800),
     ],
 )
-def test___datetime_with_microseconds___convert_to_timestamp___is_reversible(
+def test___datetime_after_1904_with_microseconds___convert_to_timestamp___is_reversible(
     base_dt, microsecond, subseconds
 ):
     from_dt = base_dt.replace(microsecond=microsecond)
@@ -92,6 +144,45 @@ def test___datetime_with_microseconds___convert_to_timestamp___is_reversible(
     roundtrip_dt = to_ts.to_datetime(tzinfo=timezone.utc)
 
     assert to_ts.msb == JAN_01_2002_LIB.msb
+    assert to_ts.lsb == subseconds
+    # comparison is tricky since imprecision in the conversion to NI-BTF are
+    # caught by the higher precision values in hightime, so we round here.
+    roundtrip_dt_microsecond = roundtrip_dt.microsecond
+    if roundtrip_dt.femtosecond > LibTimestamp.MAX_FS / 2:
+        roundtrip_dt_microsecond += 1
+
+    assert roundtrip_dt_microsecond == microsecond
+
+
+@pytest.mark.parametrize(
+    "base_dt, microsecond, subseconds",
+    [
+        (JAN_01_1850_DATETIME, 0, 0),
+        (JAN_01_1850_DATETIME, 1, 0x10C6F7A0B5EE),
+        (JAN_01_1850_DATETIME, 250000, 0x4000000000000000),
+        (JAN_01_1850_DATETIME, 500000, 0x8000000000000000),
+        (JAN_01_1850_DATETIME, 750000, 0xC000000000000000),
+        (JAN_01_1850_DATETIME, 999999, 0xFFFFEF39085F4800),
+        (JAN_01_1850_HIGHTIME, 0, 0),
+        (JAN_01_1850_HIGHTIME, 1, 0x10C6F7A0B5EE),
+        (JAN_01_1850_HIGHTIME, 250000, 0x4000000000000000),
+        (JAN_01_1850_HIGHTIME, 500000, 0x8000000000000000),
+        (JAN_01_1850_HIGHTIME, 750000, 0xC000000000000000),
+        (JAN_01_1850_HIGHTIME, 999999, 0xFFFFEF39085F4800),
+    ],
+)
+def test___datetime_before_1904_with_microseconds___convert_to_timestamp___is_reversible(
+    base_dt, microsecond, subseconds
+):
+    from_dt = base_dt.replace(microsecond=microsecond)
+
+    to_ts = LibTimestamp.from_datetime(from_dt)
+    roundtrip_dt = to_ts.to_datetime(tzinfo=timezone.utc)
+
+    if microsecond:
+        assert to_ts.msb == JAN_01_1850_LIB.msb + 1
+    else:
+        assert to_ts.msb == JAN_01_1850_LIB.msb
     assert to_ts.lsb == subseconds
     # comparison is tricky since imprecision in the conversion to NI-BTF are
     # caught by the higher precision values in hightime, so we round here.
@@ -128,6 +219,31 @@ def test___datetime_with_femtoseconds___convert_to_timestamp___is_reversible(
 
 
 @pytest.mark.parametrize(
+    "base_dt, femtosecond, subseconds",
+    [
+        (JAN_01_1850_HIGHTIME, 0, 0),
+        (JAN_01_1850_HIGHTIME, 1, 0x480F),
+    ],
+)
+def test___datetime_before_1904_with_femtoseconds___convert_to_timestamp___is_reversible(
+    base_dt, femtosecond, subseconds
+):
+    from_dt = base_dt.replace(femtosecond=femtosecond)
+
+    ts = LibTimestamp.from_datetime(from_dt)
+    roundtrip_dt = ts.to_datetime(tzinfo=timezone.utc)
+
+    assert ts.msb == JAN_01_1850_LIB.msb
+    assert ts.lsb == subseconds
+    # comparison is tricky since imprecision in the conversion to NI-BTF are
+    # caught by the higher precision values in hightime, so we round here.
+    roundtrip_dt_femtosecond = roundtrip_dt.femtosecond
+    if roundtrip_dt.yoctosecond > LibTimestamp.MAX_YS / 2:
+        roundtrip_dt_femtosecond += 1
+    assert roundtrip_dt_femtosecond == femtosecond
+
+
+@pytest.mark.parametrize(
     "base_dt, yoctosecond, subseconds, yoctosecond_round_trip",
     [
         (JAN_01_2002_HIGHTIME, 0, 0, 0),
@@ -136,7 +252,7 @@ def test___datetime_with_femtoseconds___convert_to_timestamp___is_reversible(
         (JAN_01_2002_HIGHTIME, 54211, 1, 54210),
     ],
 )
-def test___datetime_with_yoctoseconds___convert_to_timestamp___is_reversible(
+def test___datetime_after_1904_with_yoctoseconds___convert_to_timestamp___is_reversible(
     base_dt, yoctosecond, subseconds, yoctosecond_round_trip
 ):
     from_dt = base_dt.replace(yoctosecond=yoctosecond)
@@ -149,6 +265,23 @@ def test___datetime_with_yoctoseconds___convert_to_timestamp___is_reversible(
     assert to_dt.yoctosecond == yoctosecond_round_trip
 
 
-# Note: I can't actually test overflow because Python's datetime object is
-# limited to years 1-9999, but the NI-BTF format can represent time before the
-# Big Bang and until about year 292 billion. Oh well.
+@pytest.mark.parametrize(
+    "base_dt, yoctosecond, subseconds, yoctosecond_round_trip",
+    [
+        (JAN_01_1850_HIGHTIME, 0, 0, 0),
+        # Yoctoseconds is quite a bit more precise than NI-BTF
+        (JAN_01_1850_HIGHTIME, 54210, 1, 54210),
+        (JAN_01_1850_HIGHTIME, 54211, 1, 54210),
+    ],
+)
+def test___datetime_before_1904_with_yoctoseconds___convert_to_timestamp___is_reversible(
+    base_dt, yoctosecond, subseconds, yoctosecond_round_trip
+):
+    from_dt = base_dt.replace(yoctosecond=yoctosecond)
+
+    ts = LibTimestamp.from_datetime(from_dt)
+    to_dt = ts.to_datetime(tzinfo=timezone.utc)
+
+    assert ts.msb == JAN_01_1850_LIB.msb
+    assert ts.lsb == subseconds
+    assert to_dt.yoctosecond == yoctosecond_round_trip

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -1,4 +1,5 @@
 import random
+import pytz
 from copy import copy
 from datetime import datetime as std_datetime, timedelta, timezone
 
@@ -62,6 +63,49 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 
     assert to_ts == JAN_01_1850_LIB
     assert roundtrip_dt == JAN_01_1850_HIGHTIME
+
+
+@pytest.mark.parametrize(
+    "date",
+    [
+        (std_datetime(1904, 1, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 1, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 2, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 3, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 4, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 5, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 6, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 7, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 8, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 9, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 10, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 11, 1, tzinfo=timezone.utc)),
+        (std_datetime(2023, 12, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 1, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 2, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 3, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 4, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 5, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 6, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 7, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 8, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 9, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 10, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 11, 1, tzinfo=timezone.utc)),
+        (ht_datetime(2023, 12, 1, tzinfo=timezone.utc)),
+    ],
+)
+def test___utc_datetime___convert_to_timestamp_with_DST___is_reversible(
+    date
+):
+    # we use a location that has daylight savings date change on the dates above
+    target_timezone = pytz.timezone('America/Los_Angeles') # Pacific Time
+    astimezone_date = date.astimezone(target_timezone)
+
+    to_ts = LibTimestamp.from_datetime(date)
+    roundtrip_dt = to_ts.to_datetime(tzinfo=target_timezone)
+
+    assert astimezone_date == roundtrip_dt
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -102,10 +102,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    if sys.version_info >= (3, 9):
-        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
-    else:
-        target_timezone = ZoneInfo("America/Los_Angeles")  # Pacific Time
+    target_timezone : ZoneInfo  = ZoneInfo("America/Los_Angeles")  # Pacific Time
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Modify _lib_time.py and _grpc_time.py to accept time before 1970.
Add unit test coverage to test for times before 1904 and on 1904.


### Why should this Pull Request be merged?
Adding [a component test for cfg_time_start_trig](https://github.com/ni/nidaqmx-python/pull/488) uncovered the fact that @zhindes's time conversion functions don't work with dates before 1970 because they rely on POSIX timestamps. 
We want to fix this aspect of the time conversion functions and simplify them to make better use of the hightime library. 
We also want to add enough coverage to validate that the problem is entirely fixed. For example, AbsoluteTime.from_datetime still uses datetime.timestamp(), which uses POSIX time.

### What testing has been done?
Built successfully. All test passed including newly added tests
![image](https://github.com/ni/nidaqmx-python/assets/74756143/21a61125-25a3-4375-84e3-ef12ab0605cd)
