### PR TITLE
Update AI Bridge Default Argument Values 

### DIFF
--- a/generated/nidaqmx/_task_modules/ai_channel_collection.py
+++ b/generated/nidaqmx/_task_modules/ai_channel_collection.py
@@ -534,10 +534,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if forward_coeffs is None:
-            forward_coeffs = []
+            forward_coeffs = [0.0, 50]
 
         if reverse_coeffs is None:
-            reverse_coeffs = []
+            reverse_coeffs = [0.0, 0.02]
 
         forward_coeffs = numpy.float64(forward_coeffs)
         reverse_coeffs = numpy.float64(reverse_coeffs)
@@ -624,10 +624,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if electrical_vals is None:
-            electrical_vals = []
+            electrical_vals = [-2.0, 0.0, 2.0]
 
         if physical_vals is None:
-            physical_vals = []
+            physical_vals = [-100.0, 0.0, 100.0]
 
         electrical_vals = numpy.float64(electrical_vals)
         physical_vals = numpy.float64(physical_vals)
@@ -1197,10 +1197,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if forward_coeffs is None:
-            forward_coeffs = []
+            forward_coeffs = [0.0, 50]
 
         if reverse_coeffs is None:
-            reverse_coeffs = []
+            reverse_coeffs = [0.0, 0.02]
 
         forward_coeffs = numpy.float64(forward_coeffs)
         reverse_coeffs = numpy.float64(reverse_coeffs)
@@ -1289,10 +1289,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if electrical_vals is None:
-            electrical_vals = []
+            electrical_vals = [-2.0, 0.0, 2.0]
 
         if physical_vals is None:
-            physical_vals = []
+            physical_vals = [-100.0, 0.0, 100.0]
 
         electrical_vals = numpy.float64(electrical_vals)
         physical_vals = numpy.float64(physical_vals)
@@ -1921,10 +1921,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if forward_coeffs is None:
-            forward_coeffs = []
+            forward_coeffs = [0.0, 50]
 
         if reverse_coeffs is None:
-            reverse_coeffs = []
+            reverse_coeffs = [0.0, 0.02]
 
         forward_coeffs = numpy.float64(forward_coeffs)
         reverse_coeffs = numpy.float64(reverse_coeffs)
@@ -2012,10 +2012,10 @@ class AIChannelCollection(ChannelCollection):
             Indicates the newly created channel object.
         """
         if electrical_vals is None:
-            electrical_vals = []
+            electrical_vals = [-2.0, 0.0, 2.0]
 
         if physical_vals is None:
-            physical_vals = []
+            physical_vals = [-100.0, 0.0, 100.0]
 
         electrical_vals = numpy.float64(electrical_vals)
         physical_vals = numpy.float64(physical_vals)

--- a/src/codegen/templates/function_template.py.mako
+++ b/src/codegen/templates/function_template.py.mako
@@ -2,7 +2,7 @@
 <%
     from codegen.utilities.interpreter_helpers import INTERPRETER_CAMEL_TO_SNAKE_CASE_REGEXES
     from codegen.utilities.helpers import camel_to_snake_case
-    from codegen.utilities.function_helpers import order_function_parameters_by_optional,get_parameters_docstring_lines_length,get_parameter_signature,get_instantiation_lines,generate_function_call_args
+    from codegen.utilities.function_helpers import order_function_parameters_by_optional,get_parameters_docstring_lines_length,get_parameter_signature,get_instantiation_lines,generate_function_call_args, get_list_default_value
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
     %>\
 ################################################################################
@@ -56,7 +56,7 @@
     %for input_param in func.parameters:
         %if input_param.is_list:
         if ${input_param.parameter_name} is None:
-            ${input_param.parameter_name} = []
+            ${input_param.parameter_name} = ${get_list_default_value(func, input_param)}
 
         %endif
     %endfor

--- a/src/codegen/utilities/function_helpers.py
+++ b/src/codegen/utilities/function_helpers.py
@@ -34,6 +34,15 @@ EXCLUDED_FUNCTIONS = [
     "SetDigitalPullUpPullDownStates",
 ]
 
+FUNCTIONS_WITH_LIST_DEFAULT = [
+    "add_ai_force_bridge_polynomial_chan",
+    "add_ai_force_bridge_table_chan",
+    "add_ai_pressure_bridge_polynomial_chan",
+    "add_ai_pressure_bridge_table_chan",
+    "add_ai_torque_bridge_polynomial_chan",
+    "add_ai_torque_bridge_table_chan",
+]
+
 
 def get_functions(metadata, class_name=""):
     """Converts the scrapigen metadata into a list of functions."""
@@ -269,3 +278,22 @@ def instantiate_explicit_output_param(param):
         )
     elif param.ctypes_data_type == "ctypes.c_char_p":
         return f"{param.parameter_name} = ctypes.create_string_buffer(temp_size)"
+
+
+def get_list_default_value(func, param):
+    """Gets the default value for list parameters."""
+    if func.function_name in FUNCTIONS_WITH_LIST_DEFAULT:
+        if param.parameter_name == "forward_coeffs":
+            return "[0.0, 50]"
+        elif param.parameter_name == "reverse_coeffs":
+            return "[0.0, 0.02]"
+        elif param.parameter_name == "electrical_vals":
+            return "[-2.0, 0.0, 2.0]"
+        elif param.parameter_name == "physical_vals":
+            return "[-100.0, 0.0, 100.0]"
+        else:
+            raise RuntimeError(
+                f'Unable to find parameter name while getting list default value for "{func.function_name}"'
+            )
+    else:
+        return "[]"

--- a/tests/component/_task_modules/channels/test_ai_channel.py
+++ b/tests/component/_task_modules/channels/test_ai_channel.py
@@ -739,14 +739,13 @@ def test___task___add_ai_pressure_bridge_polynomial_chan___sets_channel_attribut
     task: Task,
     sim_bridge_device: Device,
 ) -> None:
-    # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_pressure_bridge_polynomial_chan(
         sim_bridge_device.ai_physical_chans[0].name,
-        forward_coeffs=[0.0, 1.0],
-        reverse_coeffs=[0.0, 1.0],
     )
 
     assert chan.ai_meas_type == UsageTypeAI.PRESSURE_BRIDGE
+    assert chan.ai_bridge_poly_forward_coeff == [0.0, 50]
+    assert chan.ai_bridge_poly_reverse_coeff == [0.0, 0.02]
 
 
 # Nothing novel here vs. other bridge-based channels.
@@ -754,14 +753,14 @@ def test___task___add_ai_pressure_bridge_table_chan___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
 ) -> None:
-    # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_pressure_bridge_table_chan(
         sim_bridge_device.ai_physical_chans[0].name,
-        electrical_vals=[-1.0, 0.0, 1.0],
-        physical_vals=[-100.0, 0.0, 100.0],
     )
 
     assert chan.ai_meas_type == UsageTypeAI.PRESSURE_BRIDGE
+    assert chan.ai_bridge_table_electrical_vals == [-2.0, 0.0, 2.0]
+    assert chan.ai_bridge_table_physical_vals == [-100.0, 0.0, 100.0]
+    
 
 
 # Nothing novel here vs. other bridge-based channels.
@@ -1144,14 +1143,13 @@ def test___task___add_ai_torque_bridge_polynomial_chan___sets_channel_attributes
     task: Task,
     sim_bridge_device: Device,
 ) -> None:
-    # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_torque_bridge_polynomial_chan(
         sim_bridge_device.ai_physical_chans[0].name,
-        forward_coeffs=[0.0, 1.0],
-        reverse_coeffs=[0.0, 1.0],
     )
 
     assert chan.ai_meas_type == UsageTypeAI.TORQUE_BRIDGE
+    assert chan.ai_bridge_poly_forward_coeff == [0.0, 50]
+    assert chan.ai_bridge_poly_reverse_coeff == [0.0, 0.02]
 
 
 # Nothing novel here vs. other bridge-based channels.
@@ -1159,14 +1157,13 @@ def test___task___add_ai_torque_bridge_table_chan___sets_channel_attributes(
     task: Task,
     sim_bridge_device: Device,
 ) -> None:
-    # #482: Default argument values for bridge create channel functions are unusable
     chan: AIChannel = task.ai_channels.add_ai_torque_bridge_table_chan(
         sim_bridge_device.ai_physical_chans[0].name,
-        electrical_vals=[-1.0, 0.0, 1.0],
-        physical_vals=[-100.0, 0.0, 100.0],
     )
 
     assert chan.ai_meas_type == UsageTypeAI.TORQUE_BRIDGE
+    assert chan.ai_bridge_table_electrical_vals == [-2.0, 0.0, 2.0]
+    assert chan.ai_bridge_table_physical_vals == [-100.0, 0.0, 100.0]
 
 
 # Nothing novel here vs. other bridge-based channels.

--- a/tests/component/_task_modules/channels/test_ai_channel.py
+++ b/tests/component/_task_modules/channels/test_ai_channel.py
@@ -760,7 +760,6 @@ def test___task___add_ai_pressure_bridge_table_chan___sets_channel_attributes(
     assert chan.ai_meas_type == UsageTypeAI.PRESSURE_BRIDGE
     assert chan.ai_bridge_table_electrical_vals == [-2.0, 0.0, 2.0]
     assert chan.ai_bridge_table_physical_vals == [-100.0, 0.0, 100.0]
-    
 
 
 # Nothing novel here vs. other bridge-based channels.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR aims to address the issue brought up in https://github.com/ni/nidaqmx-python/issues/482
- Currently, default value for `forward_coeffs`,  `reverse_coeffs`, `electrical_vals` and `physical_vals` are set to `None`
- Impacted functions are: 
   * `add_ai_force_bridge_polynomial_chan`
   * `add_ai_force_bridge_table_chan`
   * `add_ai_pressure_bridge_polynomial_chan`
   * `add_ai_pressure_bridge_table_chan`
   * `add_ai_torque_bridge_polynomial_chan`
   * `add_ai_torque_bridge_table_chan`


### Why should this Pull Request be merged?
This PR will address issue https://github.com/ni/nidaqmx-python/issues/482 and changes the default values of the respective parameter for the impacted functions, following the default value set in LabVIEW. 
```
forward_coeffs=[0.0, 50.0], reverse_coeffs=[0.0, 0.02]

electrical_vals=[-2.0, 0.0, 2.0], physical_vals=[-100.0, 0.0, 100.0]
```

### What testing has been done?
Regression tests modified to return default value for respective parameters: 
```
PS C:\dev\nidaqmx-python> poetry run pytest -k test___task___add_ai_torque_bridge_polynomial_chan___sets_channel_attributes
======================================================================================== test session starts ========================================================================================
platform win32 -- Python 3.9.13, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1742 items / 1740 deselected / 2 selected

tests\component\_task_modules\channels\test_ai_channel.py .s                                                                                                                                   [100%]

=========================================================================== 1 passed, 1 skipped, 1740 deselected in 1.05s ===========================================================================
PS C:\dev\nidaqmx-python> poetry run pytest -k test___task___add_ai_torque_bridge_table_chan___sets_channel_attributes
======================================================================================== test session starts ========================================================================================
platform win32 -- Python 3.9.13, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1742 items / 1740 deselected / 2 selected

tests\component\_task_modules\channels\test_ai_channel.py .s                                                                                                                                   [100%]

=========================================================================== 1 passed, 1 skipped, 1740 deselected in 1.14s ===========================================================================
PS C:\dev\nidaqmx-python> poetry run pytest -k test___task___add_ai_pressure_bridge_polynomial_chan___sets_channel_attributes
======================================================================================== test session starts ========================================================================================
platform win32 -- Python 3.9.13, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1742 items / 1740 deselected / 2 selected

tests\component\_task_modules\channels\test_ai_channel.py .s                                                                                                                                   [100%]

=========================================================================== 1 passed, 1 skipped, 1740 deselected in 1.02s ===========================================================================
PS C:\dev\nidaqmx-python> poetry run pytest -k test___task___add_ai_pressure_bridge_table_chan___sets_channel_attributes     
======================================================================================== test session starts ========================================================================================
platform win32 -- Python 3.9.13, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.11.1
collected 1742 items / 1740 deselected / 2 selected

tests\component\_task_modules\channels\test_ai_channel.py .s                                                                                                                                   [100%]

=========================================================================== 1 passed, 1 skipped, 1740 deselected in 1.11s =========================================================================== 
```