### PR TITLE
Replace FieldDAQ with cDAQ in tests

### DIFF
--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -8,9 +8,9 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_field_daq_task(task, sim_field_daq_device):
+def ai_voltage_field_daq_task(task, sim_time_aware_9215_device):
     """Gets AI voltage task."""
-    task.ai_channels.add_ai_voltage_chan(sim_field_daq_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_time_aware_9215_device.ai_physical_chans[0].name)
     yield task
 
 

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -18,9 +18,9 @@ def ai_voltage_task(task, sim_6363_device):
 
 
 @pytest.fixture()
-def ai_voltage_field_daq_task(task, sim_field_daq_device):
+def ai_voltage_field_daq_task(task, sim_time_aware_9215_device):
     """Gets AI voltage task."""
-    task.ai_channels.add_ai_voltage_chan(sim_field_daq_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_time_aware_9215_device.ai_physical_chans[0].name)
     yield task
 
 

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -257,27 +257,9 @@ DevIsSimulated = 1
 CompactDAQ.ChassisDevName = cdaqChassisTester
 CompactDAQ.SlotNum = 1
 
-[DAQmxFieldDAQ FieldDAQ1]
-ProductType = FD-11601
+[DAQmxCDAQModule cdaqTesterMod2]
+ProductType = NI 9215
 DevSerialNum = 0x0
 DevIsSimulated = 1
-BusType = TCP/IP
-TCPIP.Hostname = 
-TCPIP.EthernetIP = 0.0.0.0
-TCPIP.EthernetMAC = 00:00:00:00:00:00
-TCPIP.EthernetMDNSServiceInstance = 
-TCPIP.DevIsReserved = 0
-
-[DAQmxFieldDAQBank FieldDAQ1-Bank1]
-ProductType = FD-11601
-DevSerialNum = 0x0
-DevIsSimulated = 1
-FieldDAQ.BankNum = 1
-FieldDAQ.DevName = FieldDAQ1
-
-[DAQmxFieldDAQBank FieldDAQ1-Bank2]
-ProductType = FD-11601
-DevSerialNum = 0x0
-DevIsSimulated = 1
-FieldDAQ.BankNum = 2
-FieldDAQ.DevName = FieldDAQ1
+CompactDAQ.ChassisDevName = cdaqChassisTester
+CompactDAQ.SlotNum = 2


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Replaces FieldDAQ device usage with cDAQ in our tests.

### Why should this Pull Request be merged?

FieldDAQ isn't supported on Linux Desktop.

### What testing has been done?

```
$ poetry run ni-python-styleguide fix tests && poetry run ni-python-styleguide lint tests && poetry run pytest -rsP
...
============== 1483 passed, 187 skipped, 72 xfailed in 135.08s (0:02:15) ==============
```