### PR TITLE
Change ai_voltage_field_daq_task to ai_voltage_task

### DIFF
--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -8,22 +8,22 @@ from nidaqmx.task import Task
 
 
 @pytest.fixture()
-def ai_voltage_field_daq_task(task, sim_time_aware_9215_device):
+def ai_voltage_task(task, sim_time_aware_9215_device):
     """Gets AI voltage task."""
     task.ai_channels.add_ai_voltage_chan(sim_time_aware_9215_device.ai_physical_chans[0].name)
     yield task
 
 
 def test___default_arguments___cfg_time_start_trig___no_errors(
-    ai_voltage_field_daq_task: Task,
+    ai_voltage_task: Task,
 ):
-    ai_voltage_field_daq_task.timing.cfg_samp_clk_timing(1000)
+    ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     trigger_time = ht_datetime.now() + timedelta(seconds=10)
 
-    ai_voltage_field_daq_task.triggers.start_trigger.cfg_time_start_trig(trigger_time)
+    ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time)
 
-    when_value = ai_voltage_field_daq_task.triggers.start_trigger.trig_when
-    timescale_value = ai_voltage_field_daq_task.triggers.start_trigger.timestamp_timescale
+    when_value = ai_voltage_task.triggers.start_trigger.trig_when
+    timescale_value = ai_voltage_task.triggers.start_trigger.timestamp_timescale
     assert timescale_value == Timescale.USE_HOST
     assert when_value.year == trigger_time.year
     assert when_value.month == trigger_time.month
@@ -34,20 +34,20 @@ def test___default_arguments___cfg_time_start_trig___no_errors(
 
 
 def test___arguments_provided___cfg_time_start_trig___no_errors(
-    ai_voltage_field_daq_task: Task,
+    ai_voltage_task: Task,
 ):
-    ai_voltage_field_daq_task.timing.cfg_samp_clk_timing(1000)
+    ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     trigger_time = ht_datetime.now() + timedelta(seconds=10)
     # simulated devices don't support setting timescale to USE_IO_DEVICE
     timescale = Timescale.USE_HOST
 
-    ai_voltage_field_daq_task.triggers.start_trigger.cfg_time_start_trig(trigger_time, timescale)
+    ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time, timescale)
 
-    when_value = ai_voltage_field_daq_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_task.triggers.start_trigger.trig_when
     assert when_value.year == trigger_time.year
     assert when_value.month == trigger_time.month
     assert when_value.day == trigger_time.day
     assert when_value.hour == trigger_time.hour
     assert when_value.minute == trigger_time.minute
     assert when_value.second == trigger_time.second
-    assert ai_voltage_field_daq_task.triggers.start_trigger.timestamp_timescale == timescale
+    assert ai_voltage_task.triggers.start_trigger.timestamp_timescale == timescale

--- a/tests/component/_task_modules/test_triggers_properties.py
+++ b/tests/component/_task_modules/test_triggers_properties.py
@@ -18,7 +18,7 @@ def ai_voltage_task(task, sim_6363_device):
 
 
 @pytest.fixture()
-def ai_voltage_field_daq_task(task, sim_time_aware_9215_device):
+def ai_voltage_time_aware_task(task, sim_time_aware_9215_device):
     """Gets AI voltage task."""
     task.ai_channels.add_ai_voltage_chan(sim_time_aware_9215_device.ai_physical_chans[0].name)
     yield task
@@ -120,12 +120,12 @@ def test___ai_task___reset_uint32_property___returns_default_value(ai_voltage_ta
 
 
 @pytest.mark.xfail(reason="Timestamp conversion doesn't work on dates before 1970", raises=OSError)
-def test___ai_voltage_field_daq_task___get_timestamp_property___returns_default_value(
-    ai_voltage_field_daq_task: Task,
+def test___ai_voltage_time_aware_task___get_timestamp_property___returns_default_value(
+    ai_voltage_time_aware_task: Task,
 ):
-    ai_voltage_field_daq_task.timing.cfg_samp_clk_timing(1000)
+    ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
 
-    when_value = ai_voltage_field_daq_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
 
     localized_default_value = convert_to_local_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
@@ -136,15 +136,15 @@ def test___ai_voltage_field_daq_task___get_timestamp_property___returns_default_
     assert when_value.second == localized_default_value.second
 
 
-def test___ai_voltage_field_daq_task___set_timestamp_property___returns_assigned_value(
-    ai_voltage_field_daq_task: Task,
+def test___ai_voltage_time_aware_task___set_timestamp_property___returns_assigned_value(
+    ai_voltage_time_aware_task: Task,
 ):
     value_to_test = JAN_01_2002_HIGHTIME
-    ai_voltage_field_daq_task.timing.cfg_samp_clk_timing(1000)
+    ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
 
-    ai_voltage_field_daq_task.triggers.start_trigger.trig_when = value_to_test
+    ai_voltage_time_aware_task.triggers.start_trigger.trig_when = value_to_test
 
-    when_value = ai_voltage_field_daq_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
     localized_value_to_test = convert_to_local_timezone(value_to_test)
     assert when_value.year == localized_value_to_test.year
     assert when_value.month == localized_value_to_test.month
@@ -155,15 +155,15 @@ def test___ai_voltage_field_daq_task___set_timestamp_property___returns_assigned
 
 
 @pytest.mark.xfail(reason="Timestamp conversion doesn't work on dates before 1970", raises=OSError)
-def test___ai_voltage_field_daq_task___reset_timestamp_property___returns_default_value(
-    ai_voltage_field_daq_task: Task,
+def test___ai_voltage_time_aware_task___reset_timestamp_property___returns_default_value(
+    ai_voltage_time_aware_task: Task,
 ):
-    ai_voltage_field_daq_task.timing.cfg_samp_clk_timing(1000)
-    ai_voltage_field_daq_task.triggers.start_trigger.trig_when = JAN_01_2002_HIGHTIME
+    ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
+    ai_voltage_time_aware_task.triggers.start_trigger.trig_when = JAN_01_2002_HIGHTIME
 
-    del ai_voltage_field_daq_task.triggers.start_trigger.trig_when
+    del ai_voltage_time_aware_task.triggers.start_trigger.trig_when
 
-    when_value = ai_voltage_field_daq_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
     localized_default_value = convert_to_local_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
     assert when_value.month == localized_default_value.month


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adding changes on top of #513 . 
Changes `ai_voltage_field_daq_task `to `ai_voltage_task`, except in cases where there is a duplicate `ai_voltage_task`. In those cases, I changed it to be `ai_voltage_time_aware_task`

### Why should this Pull Request be merged?
Better naming in fixtures

### What testing has been done?
All tests passed successfully
![image](https://github.com/ni/nidaqmx-python/assets/74756143/6f8d37cc-a7a6-4d77-b773-61556aefcdfb)
