### PR TITLE
Add Functional Tests for Internationalization

### DIFF
--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -37,6 +37,7 @@ def test___supported_encoding___reset_nonexistent_device___returns_error_with_de
     assert f"Device Specified: {device_name}\n" in exc_info.value.args[0]
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
 
+
 @pytest.mark.grpc_xfail(
     reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
     raises=DaqError,

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List
+
 import pytest
 
 from nidaqmx._lib import lib_importer
@@ -23,14 +25,15 @@ def ai_task(task, sim_6363_device):
         ("设备", ["utf-8", "gbk"]),
     ],
 )
-def test___reset_device_with_nonexistent_device_name_supports_expected_encodings___returns_error(
-    init_kwargs, device_name, supported_encodings
+def test___supported_encoding___reset_nonexistent_device___returns_error_with_device_name(
+    init_kwargs: Dict[str, Any], device_name: str, supported_encodings: List[str]
 ):
     if lib_importer.encoding not in supported_encodings:
         pytest.skip("requires compatible encoding")
     with pytest.raises(DaqError) as exc_info:
         Device(device_name, **init_kwargs).reset_device()
 
+    assert f"Device Specified: {device_name}\n" in exc_info.value.args[0]
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
 
 
@@ -49,7 +52,7 @@ def test___reset_device_with_nonexistent_device_name_supports_expected_encodings
     ],
 )
 def test___logging_file_path_supports_expected_encodings___returns_assigned_value(
-    ai_task: Task, file_path, supported_encodings
+    ai_task: Task, file_path: str, supported_encodings: List[str]
 ):
     if lib_importer.encoding not in supported_encodings:
         pytest.skip("requires compatible encoding")

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -15,6 +15,7 @@ def ai_task(task, sim_6363_device):
     return task
 
 
+@pytest.mark.library_only(reason="gRPC server limited to MBCS encoding")
 @pytest.mark.parametrize(
     "device_name, supported_encodings",
     [
@@ -36,11 +37,11 @@ def test___supported_encoding___reset_nonexistent_device___returns_error_with_de
     assert f"Device Specified: {device_name}\n" in exc_info.value.args[0]
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
 
-
 @pytest.mark.grpc_xfail(
     reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
     raises=DaqError,
 )
+@pytest.mark.library_only(reason="gRPC server limited to MBCS encoding")
 @pytest.mark.parametrize(
     "file_path, supported_encodings",
     [

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -1,5 +1,5 @@
 import locale
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
@@ -16,7 +16,7 @@ def ai_task(task, sim_6363_device):
     return task
 
 
-def _get_encoding(obj: Union[Task, Dict[str, Any]]) -> str:
+def _get_encoding(obj: Union[Task, Dict[str, Any]]) -> Optional[str]:
     if getattr(obj, "_grpc_options", None) or (isinstance(obj, dict) and "grpc_options" in obj):
         # gRPC server limited to MBCS encoding
         return locale.getlocale()[1]

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -51,7 +51,7 @@ def test___supported_encoding___reset_nonexistent_device___returns_error_with_de
         ("测试数据.tdms", ["utf-8", "gbk"]),
     ],
 )
-def test___logging_file_path_supports_expected_encodings___returns_assigned_value(
+def test___supported_encoding___logging_file_path___returns_assigned_value(
     ai_task: Task, file_path: str, supported_encodings: List[str]
 ):
     if lib_importer.encoding not in supported_encodings:

--- a/tests/component/test_internalization.py
+++ b/tests/component/test_internalization.py
@@ -1,0 +1,51 @@
+import pytest
+
+from nidaqmx.error_codes import DAQmxErrors
+from nidaqmx.system import Device
+from nidaqmx.task import Task
+from nidaqmx._lib import lib_importer
+
+
+@pytest.fixture()
+def ai_task(task, sim_6363_device):
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
+    return task
+
+
+@pytest.mark.parametrize(
+    "device_name, supported_encodings",
+    [
+        ("Gerät", ["1252", "iso-8859-1", "utf-8"]),
+        ("l' appareil", ["1252", "iso-8859-1", "utf-8"]),
+        ("デバイス", ["932", "shift-jis", "utf-8"]),
+        ("장치", ["utf-8", "euc-kr"]),
+        ("设备", ["utf-8", "gbk"]),
+    ],
+)
+def test___reset_device_with_nonexistent_device_name_supports_expected_encodings___returns_error(
+    init_kwargs, device_name, supported_encodings
+):
+    if lib_importer.encoding not in supported_encodings:
+        pytest.skip("requires compatible encoding")
+    with pytest.raises(Exception) as exc_info:
+        Device(device_name, **init_kwargs).reset_device()
+
+    assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
+
+
+@pytest.mark.parametrize(
+    "file_path, supported_encodings",
+    [
+        ("Testdaten.tdms", ["1252", "iso-8859-1", "utf-8"]),
+        ("Données de test.tdms", ["1252", "iso-8859-1", "utf-8"]),
+        ("テストデータ.tdms", ["932", "shift-jis", "utf-8"]),
+        ("테스트 데이터.tdms", ["utf-8", "euc-kr"]),
+        ("测试数据.tdms", ["utf-8", "gbk"]),
+    ],
+)
+def test___logging_file_path_supports_expected_encodings___returns_assigned_value(ai_task: Task, file_path, supported_encodings):
+    if lib_importer.encoding not in supported_encodings:
+        pytest.skip("requires compatible encoding")
+    ai_task.in_stream.logging_file_path = file_path
+
+    assert ai_task.in_stream.logging_file_path == file_path

--- a/tests/component/test_internalization.py
+++ b/tests/component/test_internalization.py
@@ -2,8 +2,8 @@ import pytest
 
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import Device
-from nidaqmx.task import Task
 from nidaqmx._lib import lib_importer
+from nidaqmx.task import Task
 
 
 @pytest.fixture()
@@ -43,7 +43,9 @@ def test___reset_device_with_nonexistent_device_name_supports_expected_encodings
         ("测试数据.tdms", ["utf-8", "gbk"]),
     ],
 )
-def test___logging_file_path_supports_expected_encodings___returns_assigned_value(ai_task: Task, file_path, supported_encodings):
+def test___logging_file_path_supports_expected_encodings___returns_assigned_value(
+    ai_task: Task, file_path, supported_encodings
+):
     if lib_importer.encoding not in supported_encodings:
         pytest.skip("requires compatible encoding")
     ai_task.in_stream.logging_file_path = file_path

--- a/tests/component/test_internalization.py
+++ b/tests/component/test_internalization.py
@@ -1,8 +1,8 @@
 import pytest
 
+from nidaqmx._lib import lib_importer
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import Device
-from nidaqmx._lib import lib_importer
 from nidaqmx.task import Task
 
 

--- a/tests/component/test_internalization.py
+++ b/tests/component/test_internalization.py
@@ -1,8 +1,8 @@
 import pytest
 
-import nidaqmx
 from nidaqmx._lib import lib_importer
 from nidaqmx.error_codes import DAQmxErrors
+from nidaqmx.errors import DaqError
 from nidaqmx.system import Device
 from nidaqmx.task import Task
 
@@ -28,12 +28,16 @@ def test___reset_device_with_nonexistent_device_name_supports_expected_encodings
 ):
     if lib_importer.encoding not in supported_encodings:
         pytest.skip("requires compatible encoding")
-    with pytest.raises(nidaqmx.DaqError) as exc_info:
+    with pytest.raises(DaqError) as exc_info:
         Device(device_name, **init_kwargs).reset_device()
 
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
 
 
+@pytest.mark.grpc_xfail(
+    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
+    raises=DaqError,
+)
 @pytest.mark.parametrize(
     "file_path, supported_encodings",
     [

--- a/tests/component/test_internalization.py
+++ b/tests/component/test_internalization.py
@@ -1,5 +1,6 @@
 import pytest
 
+import nidaqmx
 from nidaqmx._lib import lib_importer
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import Device
@@ -27,7 +28,7 @@ def test___reset_device_with_nonexistent_device_name_supports_expected_encodings
 ):
     if lib_importer.encoding not in supported_encodings:
         pytest.skip("requires compatible encoding")
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(nidaqmx.DaqError) as exc_info:
         Device(device_name, **init_kwargs).reset_device()
 
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Add test coverage to support internationalization for user provided strings (Implemented in https://github.com/ni/nidaqmx-python/pull/518)

### Why should this Pull Request be merged?

- Internationalization tests for user provided strings covered in the following languages: 
  * German
  * French
  * Japanese
  * Korean
  * Chinese

### What testing has been done?
```
PS C:\dev\nidaqmx-python> poetry run pytest -k test_internationalization
========================================================================================= test session starts ==========================================================================================
platform win32 -- Python 3.9.13, pytest-8.0.2, pluggy-1.4.0
rootdir: C:\dev\nidaqmx-python
configfile: pyproject.toml
testpaths: tests
plugins: cov-4.1.0, mock-3.12.0
collected 1887 items / 1867 deselected / 20 selected

tests\acceptance\test_internationalization.py .....sssss.....sssss                                                                                                                                [100%]

=========================================================================== 10 passed, 10 skipped, 1867 deselected in 1.17s ============================================================================  
```