### PR TITLE
Add Tox Env for Internationalization Testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{38,39,310,311,312}-base, py{38,39,310,311,312}-grpc, nicaiu, nicai_utf8, report, docs
+envlist = clean, py{38,39,310,311,312}-base, py{38,39,310,311,312}-grpc, py39-base-nicaiu, py39-base-nicai_utf8, report, docs
 
 [testenv]
 skip_install = true
@@ -15,18 +15,16 @@ setenv =
    grpc: INSTALL_OPTS=--only main,test --extras grpc
    base: PYTEST_OPTS=-k "not grpc"
    grpc: PYTEST_OPTS=
+   nicaiu: NIDAQMX_C_LIBRARY=nicaiu
+   nicai_utf8: NIDAQMX_C_LIBRARY=nicai_utf8
+platform = 
+   nicaiu: win32
+   nicai_utf8: win32
 commands =
    poetry run python --version
    poetry install -v {env:INSTALL_OPTS}
+   poetry run python -c "from nidaqmx._lib import lib_importer; print(f'Library: {lib_importer.windll._library._name}\nLibrary encoding: {lib_importer.encoding}')"
    poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=test_results/system-{envname}.xml {env:PYTEST_OPTS} {posargs}
-
-[testenv:nicaiu]
-setenv =
-   NIDAQMX_C_LIBRARY = nicaiu
-
-[testenv:nicai_utf8]
-setenv =
-   NIDAQMX_C_LIBRARY = nicai_utf8
 
 [testenv:clean]
 commands = poetry run coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = clean, py{38,39,310,311,312}-base, py{38,39,310,311,312}-grpc, report, docs
+envlist = clean, py{38,39,310,311,312}-base, py{38,39,310,311,312}-grpc, nicaiu, nicai_utf8, report, docs
 
 [testenv]
 skip_install = true
@@ -19,6 +19,14 @@ commands =
    poetry run python --version
    poetry install -v {env:INSTALL_OPTS}
    poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=test_results/system-{envname}.xml {env:PYTEST_OPTS} {posargs}
+
+[testenv:nicaiu]
+setenv =
+   NIDAQMX_C_LIBRARY = nicaiu
+
+[testenv:nicai_utf8]
+setenv =
+   NIDAQMX_C_LIBRARY = nicai_utf8
 
 [testenv:clean]
 commands = poetry run coverage erase


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Added new Tox env for different NIDAQMX_C_LIBRARY (nicaiu and nicai_utf8) for Internationalization testing

### What testing has been done?
Ran `poetry run tox` on local machine and below are the results:
```
  clean: OK (1.39=setup[0.11]+cmd[1.28] seconds)
  py38-base: OK (62.70=setup[0.08]+cmd[1.03,1.91,2.14,57.55] seconds)
  py39-base: OK (60.09=setup[0.02]+cmd[0.95,1.69,1.74,55.70] seconds)
  py310-base: OK (61.81=setup[0.11]+cmd[1.00,1.67,2.08,56.95] seconds)
  py311-base: SKIP (0.20 seconds)
  py312-base: SKIP (0.03 seconds)
  py38-grpc: OK (111.03=setup[0.01]+cmd[0.94,1.78,1.77,106.53] seconds)
  py39-grpc: OK (108.47=setup[0.02]+cmd[0.92,1.70,1.78,104.05] seconds)
  py310-grpc: OK (114.56=setup[0.03]+cmd[0.92,1.69,1.80,110.12] seconds)
  py311-grpc: SKIP (0.02 seconds)
  py312-grpc: SKIP (0.03 seconds)
  py39-base-nicaiu: OK (59.25=setup[0.05]+cmd[0.92,1.70,1.38,55.20] seconds)
  py39-base-nicai_utf8: OK (59.30=setup[0.02]+cmd[0.91,1.75,1.36,55.27] seconds)
  report: OK (6.86=setup[0.03]+cmd[3.62,3.20] seconds)
  docs: OK (29.86=setup[0.05]+cmd[1.05,1.75,27.02] seconds)
  congratulations :) (675.92 seconds)
```