### PR TITLE
Update cfg analog multi edge trig APIs

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -65,8 +65,8 @@ class BaseInterpreter(abc.ABC):
 
     @abc.abstractmethod
     def cfg_anlg_multi_edge_ref_trig(
-            self, task, trigger_sources, trigger_slope_array,
-            trigger_level_array, pretrigger_samples):
+            self, task, trigger_sources, pretrigger_samples,
+            trigger_slope_array, trigger_level_array):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -232,15 +232,15 @@ class GrpcStubInterpreter(BaseInterpreter):
                 trigger_slope_raw=trigger_slope, trigger_level=trigger_level))
 
     def cfg_anlg_multi_edge_ref_trig(
-            self, task, trigger_sources, trigger_slope_array,
-            trigger_level_array, pretrigger_samples):
+            self, task, trigger_sources, pretrigger_samples,
+            trigger_slope_array, trigger_level_array):
         response = self._invoke(
             self._client.CfgAnlgMultiEdgeRefTrig,
             grpc_types.CfgAnlgMultiEdgeRefTrigRequest(
                 task=task, trigger_sources=trigger_sources,
+                pretrigger_samples=pretrigger_samples,
                 trigger_slope_array=trigger_slope_array,
-                trigger_level_array=trigger_level_array,
-                pretrigger_samples=pretrigger_samples))
+                trigger_level_array=trigger_level_array))
 
     def cfg_anlg_multi_edge_start_trig(
             self, task, trigger_sources, trigger_slope_array,

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -181,14 +181,40 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
 
     def cfg_anlg_multi_edge_ref_trig(
-            self, task, trigger_sources, trigger_slope_array,
-            trigger_level_array, pretrigger_samples):
-        raise NotImplementedError
+            self, task, trigger_sources, pretrigger_samples,
+            trigger_slope_array, trigger_level_array):
+        cfunc = lib_importer.windll.DAQmxCfgAnlgMultiEdgeRefTrig
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        wrapped_ndpointer(dtype=numpy.int32, flags=('C')),
+                        wrapped_ndpointer(dtype=numpy.float64, flags=('C')),
+                        ctypes.c_uint32, ctypes.c_uint]
+
+        error_code = cfunc(
+            task, trigger_sources, trigger_slope_array, trigger_level_array,
+            pretrigger_samples, len(trigger_level_array))
+        self.check_for_error(error_code)
 
     def cfg_anlg_multi_edge_start_trig(
             self, task, trigger_sources, trigger_slope_array,
             trigger_level_array):
-        raise NotImplementedError
+        cfunc = lib_importer.windll.DAQmxCfgAnlgMultiEdgeStartTrig
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        lib_importer.task_handle, ctypes_byte_str,
+                        wrapped_ndpointer(dtype=numpy.int32, flags=('C')),
+                        wrapped_ndpointer(dtype=numpy.float64, flags=('C')),
+                        ctypes.c_uint]
+
+        error_code = cfunc(
+            task, trigger_sources, trigger_slope_array, trigger_level_array,
+            len(trigger_level_array))
+        self.check_for_error(error_code)
 
     def cfg_anlg_window_ref_trig(
             self, task, trigger_source, window_top, window_bottom,

--- a/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
@@ -988,6 +988,51 @@ class ReferenceTrigger:
             self._handle, trigger_source, pretrigger_samples,
             trigger_slope.value, trigger_level)
 
+    def cfg_anlg_multi_edge_ref_trig(
+            self, trigger_sources, pretrigger_samples,
+            trigger_slope_array=None, trigger_level_array=None):
+        """
+        Configures the task to stop the acquisition when the device
+        acquires all pretrigger samples; any of the configured analog
+        signals cross the respective levels you specified; and the
+        device acquires all post-trigger samples. When you use a
+        Reference Trigger, the default for the read RelativeTo property
+        is First Pretrigger Sample with a read Offset of 0. Multi-edge
+        triggering treats the specified triggers as if a logical OR is
+        applied.
+
+        Args:
+            trigger_sources (str): Is the name of a virtual channel or
+                terminal where there is an analog signal to use as the
+                source of the trigger.
+            pretrigger_samples (int): Specifies the minimum number of
+                samples to acquire per channel before recognizing the
+                Reference Trigger. The number of post-trigger samples
+                per channel is equal to **number of samples per
+                channel** in the DAQmx Timing VI minus **pretrigger
+                samples per channel**.
+            trigger_slope_array (Optional[List[nidaqmx.constants.Slope]]): 
+                Specifies on which slope of the signal the Reference
+                Trigger occurs.
+            trigger_level_array (Optional[List[float]]): Specifies at
+                what threshold to trigger. Specify this value in the
+                units of the measurement or generation. Use **slope** to
+                specify on which slope to trigger at this threshold.
+        """
+        if trigger_slope_array is None:
+            trigger_slope_array = []
+
+        if trigger_level_array is None:
+            trigger_level_array = []
+
+        trigger_slope_array = numpy.int32([p.value for p in trigger_slope_array])
+        trigger_level_array = numpy.float64(trigger_level_array)
+
+
+        self._interpreter.cfg_anlg_multi_edge_ref_trig(
+            self._handle, trigger_sources, pretrigger_samples,
+            trigger_slope_array, trigger_level_array)
+
     def cfg_anlg_window_ref_trig(
             self, trigger_source, window_top, window_bottom,
             pretrigger_samples,

--- a/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/reference_trigger.py
@@ -1025,8 +1025,8 @@ class ReferenceTrigger:
         if trigger_level_array is None:
             trigger_level_array = []
 
-        trigger_slope_array = numpy.int32([p.value for p in trigger_slope_array])
-        trigger_level_array = numpy.float64(trigger_level_array)
+        trigger_slope_array = numpy.array([p.value for p in trigger_slope_array], dtype=numpy.int32)
+        trigger_level_array = numpy.array(trigger_level_array, dtype=numpy.float64)
 
 
         self._interpreter.cfg_anlg_multi_edge_ref_trig(

--- a/generated/nidaqmx/_task_modules/triggering/start_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/start_trigger.py
@@ -1016,8 +1016,8 @@ class StartTrigger:
         if trigger_level_array is None:
             trigger_level_array = []
 
-        trigger_slope_array = numpy.int32([p.value for p in trigger_slope_array])
-        trigger_level_array = numpy.float64(trigger_level_array)
+        trigger_slope_array = numpy.array([p.value for p in trigger_slope_array], dtype=numpy.int32)
+        trigger_level_array = numpy.array(trigger_level_array, dtype=numpy.float64)
 
 
         self._interpreter.cfg_anlg_multi_edge_start_trig(

--- a/generated/nidaqmx/_task_modules/triggering/start_trigger.py
+++ b/generated/nidaqmx/_task_modules/triggering/start_trigger.py
@@ -987,6 +987,43 @@ class StartTrigger:
         self._interpreter.cfg_anlg_edge_start_trig(
             self._handle, trigger_source, trigger_slope.value, trigger_level)
 
+    def cfg_anlg_multi_edge_start_trig(
+            self, trigger_sources, trigger_slope_array,
+            trigger_level_array=None):
+        """
+        Configures the task to start acquiring or generating samples
+        when any of the configured analog signals cross the respective
+        levels you specified. Multi-edge triggering treats the
+        configured triggers as if a logical OR is applied.
+
+        Args:
+            trigger_sources (str): Is the name of a virtual channel or
+                terminal where there is an analog signal to use as the
+                source of the trigger.
+            trigger_slope_array (List[nidaqmx.constants.Slope]): 
+                Specifies on which slope of the signal to start
+                acquiring or generating samples when the signal crosses
+                **level**.
+            trigger_level_array (Optional[List[float]]): Specifies at
+                what threshold to start acquiring or generating samples.
+                Specify this value in the units of the measurement or
+                generation. Use **slope** to specify on which slope to
+                trigger at this threshold.
+        """
+        if trigger_slope_array is None:
+            trigger_slope_array = []
+
+        if trigger_level_array is None:
+            trigger_level_array = []
+
+        trigger_slope_array = numpy.int32([p.value for p in trigger_slope_array])
+        trigger_level_array = numpy.float64(trigger_level_array)
+
+
+        self._interpreter.cfg_anlg_multi_edge_start_trig(
+            self._handle, trigger_sources, trigger_slope_array,
+            trigger_level_array)
+
     def cfg_anlg_window_start_trig(
             self, window_top, window_bottom, trigger_source="",
             trigger_when=WindowTriggerCondition1.ENTERING_WINDOW):

--- a/generated/nidaqmx/system/device.py
+++ b/generated/nidaqmx/system/device.py
@@ -1223,9 +1223,10 @@ class Device:
 
     def restore_last_ext_cal_const(self):
         """
-        This function nullifies any self-calibration you perform on the
-        device. If you have never performed a self-calibration on the
-        device, this function has no effect.
+        Sets the self-calibration constants of the device to the
+        external calibration constants. NI sets the external calibration
+        constants at the factory, and those constants remain in effect
+        until you perform a new external calibration on the device.
         """
 
         self._interpreter.restore_last_ext_cal_const(

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -20457,7 +20457,7 @@ functions = {
             }
         ],
         'python_class_name': 'Device',
-        'python_description': 'This function nullifies any self-calibration you perform on the device. If you have never performed a self-calibration on the device, this function has no effect.',
+        'python_description': 'Sets the self-calibration constants of the device to the external calibration constants. NI sets the external calibration constants at the factory, and those constants remain in effect until you perform a new external calibration on the device.',
         'returns': 'int32'
     },
     'SaveGlobalChan': {

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -411,20 +411,43 @@ functions = {
     },
     'CfgAnlgMultiEdgeRefTrig': {
         'calling_convention': 'StdCall',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
         'parameters': [
             {
+                'ctypes_data_type': 'ctypes.TaskHandle',
                 'direction': 'in',
+                'is_optional_in_python': False,
                 'name': 'task',
+                'python_data_type': 'TaskHandle',
+                'python_description': '',
+                'python_type_annotation': 'TaskHandle',
                 'type': 'TaskHandle'
             },
             {
+                'ctypes_data_type': 'ctypes.c_char_p',
                 'direction': 'in',
+                'is_optional_in_python': False,
                 'name': 'triggerSources',
+                'python_data_type': 'str',
+                'python_description': 'Is the name of a virtual channel or terminal where there is an analog signal to use as the source of the trigger.',
+                'python_type_annotation': 'str',
                 'type': 'const char[]'
             },
             {
+                'ctypes_data_type': 'numpy.int32',
                 'direction': 'in',
+                'enum': 'Slope1',
+                'is_list': True,
+                'is_optional_in_python': True,
                 'name': 'triggerSlopeArray',
+                'python_data_type': 'Slope',
+                'python_default_value': None,
+                'python_description': 'Specifies on which slope of the signal the Reference Trigger occurs.',
+                'python_type_annotation': 'Optional[List[nidaqmx.constants.Slope]]',
                 'size': {
                     'mechanism': 'len',
                     'value': 'arraySize'
@@ -432,8 +455,15 @@ functions = {
                 'type': 'const int32[]'
             },
             {
+                'ctypes_data_type': 'numpy.float64',
                 'direction': 'in',
+                'is_list': True,
+                'is_optional_in_python': True,
                 'name': 'triggerLevelArray',
+                'python_data_type': 'float',
+                'python_default_value': None,
+                'python_description': 'Specifies at what threshold to trigger. Specify this value in the units of the measurement or generation. Use **slope** to specify on which slope to trigger at this threshold.',
+                'python_type_annotation': 'Optional[List[float]]',
                 'size': {
                     'mechanism': 'len',
                     'value': 'arraySize'
@@ -441,35 +471,64 @@ functions = {
                 'type': 'const float64[]'
             },
             {
+                'ctypes_data_type': 'ctypes.c_uint32',
                 'direction': 'in',
+                'is_optional_in_python': False,
                 'name': 'pretriggerSamples',
+                'python_data_type': 'int',
+                'python_description': 'Specifies the minimum number of samples to acquire per channel before recognizing the Reference Trigger. The number of post-trigger samples per channel is equal to **number of samples per channel** in the DAQmx Timing VI minus **pretrigger samples per channel**.',
+                'python_type_annotation': 'int',
                 'type': 'uInt32'
             },
             {
                 'direction': 'in',
                 'name': 'arraySize',
-                'type': 'uInt32'
+                'type': 'uInt32',
+                'use_in_python_api': False
             }
         ],
-        'python_codegen_method': 'no',
+        'python_class_name': 'ReferenceTrigger',
+        'python_description': 'Configures the task to stop the acquisition when the device acquires all pretrigger samples; any of the configured analog signals cross the respective levels you specified; and the device acquires all post-trigger samples. When you use a Reference Trigger, the default for the read RelativeTo property is First Pretrigger Sample with a read Offset of 0. Multi-edge triggering treats the specified triggers as if a logical OR is applied.',
         'returns': 'int32'
     },
     'CfgAnlgMultiEdgeStartTrig': {
         'calling_convention': 'StdCall',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
         'parameters': [
             {
+                'ctypes_data_type': 'ctypes.TaskHandle',
                 'direction': 'in',
+                'is_optional_in_python': False,
                 'name': 'task',
+                'python_data_type': 'TaskHandle',
+                'python_description': '',
+                'python_type_annotation': 'TaskHandle',
                 'type': 'TaskHandle'
             },
             {
+                'ctypes_data_type': 'ctypes.c_char_p',
                 'direction': 'in',
+                'is_optional_in_python': False,
                 'name': 'triggerSources',
+                'python_data_type': 'str',
+                'python_description': 'Is the name of a virtual channel or terminal where there is an analog signal to use as the source of the trigger.',
+                'python_type_annotation': 'str',
                 'type': 'const char[]'
             },
             {
+                'ctypes_data_type': 'numpy.int32',
                 'direction': 'in',
+                'enum': 'Slope1',
+                'is_list': True,
+                'is_optional_in_python': False,
                 'name': 'triggerSlopeArray',
+                'python_data_type': 'Slope',
+                'python_description': 'Specifies on which slope of the signal to start acquiring or generating samples when the signal crosses **level**.',
+                'python_type_annotation': 'List[nidaqmx.constants.Slope]',
                 'size': {
                     'mechanism': 'len',
                     'value': 'arraySize'
@@ -477,8 +536,15 @@ functions = {
                 'type': 'const int32[]'
             },
             {
+                'ctypes_data_type': 'numpy.float64',
                 'direction': 'in',
+                'is_list': True,
+                'is_optional_in_python': True,
                 'name': 'triggerLevelArray',
+                'python_data_type': 'float',
+                'python_default_value': None,
+                'python_description': 'Specifies at what threshold to start acquiring or generating samples. Specify this value in the units of the measurement or generation. Use **slope** to specify on which slope to trigger at this threshold.',
+                'python_type_annotation': 'Optional[List[float]]',
                 'size': {
                     'mechanism': 'len',
                     'value': 'arraySize'
@@ -488,10 +554,12 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'arraySize',
-                'type': 'uInt32'
+                'type': 'uInt32',
+                'use_in_python_api': False
             }
         ],
-        'python_codegen_method': 'no',
+        'python_class_name': 'StartTrigger',
+        'python_description': 'Configures the task to start acquiring or generating samples when any of the configured analog signals cross the respective levels you specified. Multi-edge triggering treats the configured triggers as if a logical OR is applied.',
         'returns': 'int32'
     },
     'CfgAnlgWindowRefTrig': {

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -156,19 +156,20 @@ def test___start_trigger___cfg_anlg_edge_start_trig___no_errors(
     trig_level: float,
 ):
     device_name = sim_6363_ai_voltage_task.devices[0].name
+
     sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     sim_6363_ai_voltage_task.triggers.start_trigger.cfg_anlg_edge_start_trig(
         trigger_source=trig_src, trigger_slope=trig_slope, trigger_level=trig_level
     )
-
-    sim_6363_ai_voltage_task.start()
 
     assert (
         sim_6363_ai_voltage_task.triggers.start_trigger.anlg_edge_src
         == f"/{device_name}/{trig_src}"
     )
     assert sim_6363_ai_voltage_task.triggers.start_trigger.anlg_edge_slope == trig_slope
-    assert round(sim_6363_ai_voltage_task.triggers.start_trigger.anlg_edge_lvl, 1) == trig_level
+    assert sim_6363_ai_voltage_task.triggers.start_trigger.anlg_edge_lvl == pytest.approx(
+        trig_level, abs=0.001
+    )
 
 
 @pytest.mark.parametrize(
@@ -195,8 +196,6 @@ def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
         trigger_level_array=trig_levels,
     )
 
-    sim_9775_ai_voltage_multi_edge_task.start()
-
     assert (
         sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.anlg_multi_edge_srcs
         == flatten_trigger_sources
@@ -205,10 +204,10 @@ def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
         sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.anlg_multi_edge_slopes
         == trig_slopes
     )
-    assert [
-        round(v, 1)
-        for v in sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.anlg_multi_edge_lvls
-    ] == trig_levels
+    assert (
+        sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.anlg_multi_edge_lvls
+        == pytest.approx(trig_levels, abs=0.001)
+    )
 
 
 @pytest.mark.parametrize(
@@ -228,6 +227,7 @@ def test___reference_trigger___cfg_anlg_edge_ref_trig___no_errors(
     trig_level: float,
 ):
     device_name = sim_6363_ai_voltage_task.devices[0].name
+
     sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     sim_6363_ai_voltage_task.triggers.reference_trigger.cfg_anlg_edge_ref_trig(
         trigger_source=trig_src,
@@ -236,15 +236,15 @@ def test___reference_trigger___cfg_anlg_edge_ref_trig___no_errors(
         trigger_level=trig_level,
     )
 
-    sim_6363_ai_voltage_task.start()
-
     assert (
         sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_edge_src
         == f"/{device_name}/{trig_src}"
     )
     assert sim_6363_ai_voltage_task.triggers.reference_trigger.pretrig_samples == pretrig_samples
     assert sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_edge_slope == trig_slope
-    assert round(sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_edge_lvl, 1) == trig_level
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_edge_lvl == pytest.approx(
+        trig_level, abs=0.001
+    )
 
 
 @pytest.mark.parametrize(
@@ -273,8 +273,6 @@ def test___reference_trigger___cfg_anlg_multi_edge_ref_trig___no_errors(
         trigger_level_array=trig_levels,
     )
 
-    sim_9775_ai_voltage_multi_edge_task.start()
-
     assert (
         sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.anlg_multi_edge_srcs
         == flatten_trigger_sources
@@ -287,7 +285,7 @@ def test___reference_trigger___cfg_anlg_multi_edge_ref_trig___no_errors(
         sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.anlg_multi_edge_slopes
         == trig_slopes
     )
-    assert [
-        round(v, 1)
-        for v in sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.anlg_multi_edge_lvls
-    ] == trig_levels
+    assert (
+        sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.anlg_multi_edge_lvls
+        == pytest.approx(trig_levels, abs=0.001)
+    )

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -144,9 +144,7 @@ def test___start_trigger___cfg_anlg_edge_start_trig___no_errors(
 ):
     sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     sim_6363_ai_voltage_task.triggers.start_trigger.cfg_anlg_edge_start_trig(
-        trigger_source="APFI0",
-        trigger_slope=Slope.RISING,
-        trigger_level=2.0
+        trigger_source="APFI0", trigger_slope=Slope.RISING, trigger_level=2.0
     )
 
     sim_6363_ai_voltage_task.start()
@@ -159,16 +157,17 @@ def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
     trigger_sources = ["cdaqTesterMod3/ai0", "cdaqTesterMod3/ai1"]
     trigger_slope_array = [Slope.RISING, Slope.RISING]
     trigger_level_array = [2.0, 3.0]
-    flatten_trigger_sources = flatten_channel_string(
-        [s for s in trigger_sources]
-    )
+    flatten_trigger_sources = flatten_channel_string([s for s in trigger_sources])
 
     sim_9775_ai_voltage_multi_edge_task.timing.cfg_samp_clk_timing(1000)
     sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.cfg_anlg_multi_edge_start_trig(
-        # trigger_sources=trigger_sources, <-- ctypes.ArgumentError: argument 2: <class 'TypeError'>: bytes or integer address expected instead of list instance
+        # trigger_sources=trigger_sources, <-- ctypes.ArgumentError:
+        #                                       argument 2: <class 'TypeError'>:
+        #                                       bytes or integer address expected
+        #                                       instead of list instance
         trigger_sources=flatten_trigger_sources,
         trigger_slope_array=trigger_slope_array,
-        trigger_level_array=trigger_level_array
+        trigger_level_array=trigger_level_array,
     )
 
     sim_9775_ai_voltage_multi_edge_task.start()

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -4,9 +4,10 @@ import pytest
 from hightime import datetime as ht_datetime, timedelta as ht_timedelta
 
 import nidaqmx
-from nidaqmx.constants import Edge, Timescale, TimestampEvent, TriggerType
+from nidaqmx.constants import Edge, Slope, Timescale, TimestampEvent, TriggerType
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.task import Task
+from nidaqmx.utils import flatten_channel_string
 
 
 @pytest.fixture()
@@ -22,6 +23,21 @@ def ci_count_edges_task(task, sim_9185_device) -> nidaqmx.Task:
     chan.ci_count_edges_term = f"/{sim_9185_device.name}/te0/SampleClock"
     chan.ci_count_edges_active_edge = Edge.RISING
     return task
+
+
+@pytest.fixture()
+def sim_6363_ai_voltage_task(task, sim_6363_device):
+    """Gets AI voltage task."""
+    task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
+    yield task
+
+
+@pytest.fixture()
+def sim_9775_ai_voltage_multi_edge_task(task, sim_9775_device):
+    """Gets AI voltage multi edge task."""
+    task.ai_channels.add_ai_voltage_chan(sim_9775_device.ai_physical_chans[0].name)
+    task.ai_channels.add_ai_voltage_chan(sim_9775_device.ai_physical_chans[1].name)
+    yield task
 
 
 def test___default_arguments___cfg_time_start_trig___no_errors(
@@ -45,15 +61,15 @@ def test___default_arguments___cfg_time_start_trig___no_errors(
     assert when_value.second == trigger_time.second
 
 
+@pytest.mark.parametrize("timescale", [Timescale.USE_HOST, Timescale.USE_IO_DEVICE])
 def test___arguments_provided___cfg_time_start_trig___no_errors(
     ai_voltage_task: Task,
+    timescale: Timescale,
 ):
     ai_voltage_task.timing.cfg_samp_clk_timing(1000)
     utc_dt = ht_datetime.now(timezone.utc)  # UTC time
     dt_now = utc_dt.astimezone()  # local time
     trigger_time = dt_now + ht_timedelta(seconds=10)
-    # simulated devices don't support setting timescale to USE_IO_DEVICE
-    timescale = Timescale.USE_HOST
 
     ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time, timescale)
 
@@ -64,7 +80,7 @@ def test___arguments_provided___cfg_time_start_trig___no_errors(
     assert when_value.hour == trigger_time.hour
     assert when_value.minute == trigger_time.minute
     assert when_value.second == trigger_time.second
-    assert ai_voltage_task.triggers.start_trigger.timestamp_timescale == timescale
+    assert ai_voltage_task.triggers.start_trigger.time_timescale == timescale
 
 
 def test___start_trigger___wait_for_valid_timestamp___no_errors(
@@ -121,3 +137,39 @@ def test___timestamp_not_enabled___wait_for_valid_timestamp___throw_error(
         ai_voltage_task.wait_for_valid_timestamp(TimestampEvent.START_TRIGGER)
 
     assert exc_info.value.error_code == DAQmxErrors.TIMESTAMP_NOT_ENABLED
+
+
+def test___start_trigger___cfg_anlg_edge_start_trig___no_errors(
+    sim_6363_ai_voltage_task: Task,
+):
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.start_trigger.cfg_anlg_edge_start_trig(
+        trigger_source="APFI0",
+        trigger_slope=Slope.RISING,
+        trigger_level=2.0
+    )
+
+    sim_6363_ai_voltage_task.start()
+    sim_6363_ai_voltage_task.read()
+
+
+def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
+    sim_9775_ai_voltage_multi_edge_task: Task,
+):
+    trigger_sources = ["cdaqTesterMod3/ai0", "cdaqTesterMod3/ai1"]
+    trigger_slope_array = [Slope.RISING, Slope.RISING]
+    trigger_level_array = [2.0, 3.0]
+    flatten_trigger_sources = flatten_channel_string(
+        [s for s in trigger_sources]
+    )
+
+    sim_9775_ai_voltage_multi_edge_task.timing.cfg_samp_clk_timing(1000)
+    sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.cfg_anlg_multi_edge_start_trig(
+        # trigger_sources=trigger_sources, <-- ctypes.ArgumentError: argument 2: <class 'TypeError'>: bytes or integer address expected instead of list instance
+        trigger_sources=flatten_trigger_sources,
+        trigger_slope_array=trigger_slope_array,
+        trigger_level_array=trigger_level_array
+    )
+
+    sim_9775_ai_voltage_multi_edge_task.start()
+    sim_9775_ai_voltage_multi_edge_task.read()

--- a/tests/component/_task_modules/test_triggers.py
+++ b/tests/component/_task_modules/test_triggers.py
@@ -161,11 +161,39 @@ def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
 
     sim_9775_ai_voltage_multi_edge_task.timing.cfg_samp_clk_timing(1000)
     sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.cfg_anlg_multi_edge_start_trig(
-        # trigger_sources=trigger_sources, <-- ctypes.ArgumentError:
-        #                                       argument 2: <class 'TypeError'>:
-        #                                       bytes or integer address expected
-        #                                       instead of list instance
         trigger_sources=flatten_trigger_sources,
+        trigger_slope_array=trigger_slope_array,
+        trigger_level_array=trigger_level_array,
+    )
+
+    sim_9775_ai_voltage_multi_edge_task.start()
+    sim_9775_ai_voltage_multi_edge_task.read()
+
+
+def test___reference_trigger___cfg_anlg_edge_ref_trig___no_errors(
+    sim_6363_ai_voltage_task: Task,
+):
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.reference_trigger.cfg_anlg_edge_ref_trig(
+        trigger_source="APFI0", pretrigger_samples=10, trigger_slope=Slope.RISING, trigger_level=2.0
+    )
+
+    sim_6363_ai_voltage_task.start()
+    sim_6363_ai_voltage_task.read()
+
+
+def test___reference_trigger___cfg_anlg_multi_edge_ref_trig___no_errors(
+    sim_9775_ai_voltage_multi_edge_task: Task,
+):
+    trigger_sources = ["cdaqTesterMod3/ai0", "cdaqTesterMod3/ai1"]
+    trigger_slope_array = [Slope.RISING, Slope.RISING]
+    trigger_level_array = [2.0, 3.0]
+    flatten_trigger_sources = flatten_channel_string([s for s in trigger_sources])
+
+    sim_9775_ai_voltage_multi_edge_task.timing.cfg_samp_clk_timing(1000)
+    sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.cfg_anlg_multi_edge_ref_trig(
+        trigger_sources=flatten_trigger_sources,
+        pretrigger_samples=10,
         trigger_slope_array=trigger_slope_array,
         trigger_level_array=trigger_level_array,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,6 +205,12 @@ def sim_time_aware_9215_device(sim_9185_device: nidaqmx.system.Device) -> nidaqm
 
 
 @pytest.fixture(scope="function")
+def sim_9775_device(sim_9185_device: nidaqmx.system.Device) -> nidaqmx.system.Device:
+    """Gets device information for a simulated 9775 device within a 9185."""
+    return _cdaq_module_by_product_type("NI 9775", sim_9185_device)
+
+
+@pytest.fixture(scope="function")
 def sim_ts_chassis(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets simulated TestScale chassis information."""
     # Prefer tsChassisTester if available so that multi-module tests will use

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -47,7 +47,7 @@ AI.Max = 10
 AI.Min = -10
 ChanType = Analog Input
 PhysicalChanName = tsVoltageTester1/ai0
-Descr = 
+Descr =
 Author = "Test Author"
 AllowInteractiveEditing = True
 
@@ -79,7 +79,7 @@ SampClk.ActiveEdge = Rising
 SampQuant.SampPerChan = 100
 SampClk.Rate = 1000
 SampTimingType = Sample Clock
-SampClk.Src = 
+SampClk.Src =
 Author = Test Author
 AllowInteractiveEditing = True
 
@@ -87,7 +87,7 @@ AllowInteractiveEditing = True
 Lin.Slope = 2
 Lin.YIntercept = 0
 PreScaledUnits = Volts
-ScaledUnits = 
+ScaledUnits =
 ScaleType = Linear
 Author = Test Author
 AllowInteractiveEditing = True
@@ -97,14 +97,14 @@ Descr = Twice the gain
 Lin.Slope = 1
 Lin.YIntercept = 0
 PreScaledUnits = Volts
-ScaledUnits = 
+ScaledUnits =
 ScaleType = Linear
 
 [DAQmxScale polynomial_scale]
 Poly.ForwardCoeff = 0, 1
 Poly.ReverseCoeff = 0, 1
 PreScaledUnits = Volts
-ScaledUnits = 
+ScaledUnits =
 ScaleType = Polynomial
 
 [DAQmxScale degrees_scale]
@@ -244,10 +244,10 @@ ProductType = cDAQ-9185
 DevSerialNum = 0x0
 DevIsSimulated = 1
 BusType = TCP/IP
-TCPIP.Hostname = 
+TCPIP.Hostname =
 TCPIP.EthernetIP = 0.0.0.0
 TCPIP.EthernetMAC = 00:00:00:00:00:00
-TCPIP.EthernetMDNSServiceInstance = 
+TCPIP.EthernetMDNSServiceInstance =
 TCPIP.DevIsReserved = 0
 
 [DAQmxCDAQModule cdaqTesterMod1]
@@ -263,3 +263,10 @@ DevSerialNum = 0x0
 DevIsSimulated = 1
 CompactDAQ.ChassisDevName = cdaqChassisTester
 CompactDAQ.SlotNum = 2
+
+[DAQmxCDAQModule cdaqTesterMod3]
+ProductType = NI 9775
+DevSerialNum = 0x0
+DevIsSimulated = 1
+CompactDAQ.ChassisDevName = cdaqChassisTester
+CompactDAQ.SlotNum = 3


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updated `CfgAnlgMultiEdgeRefTrig` and `CfgAnlgMultiEdgeStartTrig` metadata and generated the APIs.

### Why should this Pull Request be merged?

Enable `CfgAnlgMultiEdgeRefTrig` and `CfgAnlgMultiEdgeStartTrig` APIs for the 1.0 release.

### What testing has been done?

Add test cases:
- [x] `cfg_anlg_edge_start_trig`
- [x] `cfg_anlg_edge_ref_trig`
- [x] `CfgAnlgMultiEdgeRefTrig`
- [x] `CfgAnlgMultiEdgeStartTrig`

![image](https://github.com/ni/nidaqmx-python/assets/27721199/c9537afd-0c6a-44a6-9888-58c570f03019)
![image](https://github.com/ni/nidaqmx-python/assets/27721199/89406c1b-9707-494b-bdf4-10c3ac94efd6)
![image](https://github.com/ni/nidaqmx-python/assets/27721199/9c078927-f254-43ec-94fa-621b4a5f5971)
![image](https://github.com/ni/nidaqmx-python/assets/27721199/63656798-afb5-440c-a1ee-b76efda7ea01)
