### PR TITLE
Allocate Buffer Size for Read/Write String Status Properties

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -997,7 +997,7 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_read_attribute_string(self, task, attribute):
+    def get_read_attribute_string(self, task, attribute, temp_size=0):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -1157,7 +1157,7 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_write_attribute_string(self, task, attribute):
+    def get_write_attribute_string(self, task, attribute, temp_size=0):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -997,7 +997,7 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_read_attribute_string(self, task, attribute, temp_size=0):
+    def get_read_attribute_string(self, task, attribute, size_hint=0):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -1157,7 +1157,7 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_write_attribute_string(self, task, attribute, temp_size=0):
+    def get_write_attribute_string(self, task, attribute, size_hint=0):
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -2031,7 +2031,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.GetReadAttributeInt32Request(task=task, attribute_raw=attribute))
         return response.value_raw
 
-    def get_read_attribute_string(self, task, attribute, temp_size=0):
+    def get_read_attribute_string(self, task, attribute, size_hint=0):
         response = self._invoke(
             self._client.GetReadAttributeString,
             grpc_types.GetReadAttributeStringRequest(task=task, attribute_raw=attribute))
@@ -2285,7 +2285,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.GetWriteAttributeInt32Request(task=task, attribute_raw=attribute))
         return response.value_raw
 
-    def get_write_attribute_string(self, task, attribute, temp_size=0):
+    def get_write_attribute_string(self, task, attribute, size_hint=0):
         response = self._invoke(
             self._client.GetWriteAttributeString,
             grpc_types.GetWriteAttributeStringRequest(task=task, attribute_raw=attribute))

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -2031,7 +2031,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.GetReadAttributeInt32Request(task=task, attribute_raw=attribute))
         return response.value_raw
 
-    def get_read_attribute_string(self, task, attribute):
+    def get_read_attribute_string(self, task, attribute, temp_size=0):
         response = self._invoke(
             self._client.GetReadAttributeString,
             grpc_types.GetReadAttributeStringRequest(task=task, attribute_raw=attribute))
@@ -2285,7 +2285,7 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.GetWriteAttributeInt32Request(task=task, attribute_raw=attribute))
         return response.value_raw
 
-    def get_write_attribute_string(self, task, attribute):
+    def get_write_attribute_string(self, task, attribute, temp_size=0):
         response = self._invoke(
             self._client.GetWriteAttributeString,
             grpc_types.GetWriteAttributeStringRequest(task=task, attribute_raw=attribute))

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -3230,7 +3230,7 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
         return value.value
 
-    def get_read_attribute_string(self, task, attribute, temp_size=0):
+    def get_read_attribute_string(self, task, attribute, size_hint=0):
         cfunc = lib_importer.cdll.DAQmxGetReadAttribute
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -3238,6 +3238,7 @@ class LibraryInterpreter(BaseInterpreter):
                     cfunc.argtypes = [
                         lib_importer.task_handle, ctypes.c_int32]
 
+        temp_size = size_hint
         while True:
             value = ctypes.create_string_buffer(temp_size)
             size_or_code = cfunc(
@@ -3950,7 +3951,7 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
         return value.value
 
-    def get_write_attribute_string(self, task, attribute, temp_size=0):
+    def get_write_attribute_string(self, task, attribute, size_hint=0):
         cfunc = lib_importer.cdll.DAQmxGetWriteAttribute
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -3958,6 +3959,7 @@ class LibraryInterpreter(BaseInterpreter):
                     cfunc.argtypes = [
                         lib_importer.task_handle, ctypes.c_int32]
 
+        temp_size = size_hint
         while True:
             value = ctypes.create_string_buffer(temp_size)
             size_or_code = cfunc(

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -3230,7 +3230,7 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
         return value.value
 
-    def get_read_attribute_string(self, task, attribute):
+    def get_read_attribute_string(self, task, attribute, temp_size=0):
         cfunc = lib_importer.cdll.DAQmxGetReadAttribute
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -3238,7 +3238,6 @@ class LibraryInterpreter(BaseInterpreter):
                     cfunc.argtypes = [
                         lib_importer.task_handle, ctypes.c_int32]
 
-        temp_size = 0
         while True:
             value = ctypes.create_string_buffer(temp_size)
             size_or_code = cfunc(
@@ -3951,7 +3950,7 @@ class LibraryInterpreter(BaseInterpreter):
         self.check_for_error(error_code)
         return value.value
 
-    def get_write_attribute_string(self, task, attribute):
+    def get_write_attribute_string(self, task, attribute, temp_size=0):
         cfunc = lib_importer.cdll.DAQmxGetWriteAttribute
         if cfunc.argtypes is None:
             with cfunc.arglock:
@@ -3959,7 +3958,6 @@ class LibraryInterpreter(BaseInterpreter):
                     cfunc.argtypes = [
                         lib_importer.task_handle, ctypes.c_int32]
 
-        temp_size = 0
         while True:
             value = ctypes.create_string_buffer(temp_size)
             size_or_code = cfunc(

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -972,9 +972,9 @@ class InStream:
     def wait_mode(self):
         self._interpreter.reset_read_attribute(self._handle, 0x2232)
 
-    def get_channels_buffer_size (self):
-        channels_to_read = self.channels_to_read
-        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+    def get_channels_buffer_size(self):
+        channel_names = self._task.channel_names
+        total_size = sum(len(name) for name in channel_names) + 1
         return total_size
         
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -111,7 +111,8 @@ class InStream:
             Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x31e0)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x31e0, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -180,7 +181,8 @@ class InStream:
             property. Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a99)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a99, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -220,7 +222,8 @@ class InStream:
             an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x2f71)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x2f71, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -244,7 +247,8 @@ class InStream:
             an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3089)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3089, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -292,7 +296,8 @@ class InStream:
             property. Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3190)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3190, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -544,7 +549,8 @@ class InStream:
             this property. Otherwise you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3101)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3101, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -555,7 +561,8 @@ class InStream:
             this property. Otherwise you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3102)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3102, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -582,7 +589,8 @@ class InStream:
             error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a0a)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a0a, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -609,7 +617,8 @@ class InStream:
             an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a97)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x2a97, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -637,7 +646,8 @@ class InStream:
             overcurrent channels to recover.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x29e7)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x29e7, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -662,7 +672,8 @@ class InStream:
             Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x2175)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x2175, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -687,7 +698,8 @@ class InStream:
             property. Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3082)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3082, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -729,7 +741,8 @@ class InStream:
         List[str]: Indicates the channels that had their PLLs unlock.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3119)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3119, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -753,7 +766,8 @@ class InStream:
             property. Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x3193)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x3193, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -838,7 +852,8 @@ class InStream:
             receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x31de)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x31de, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -865,7 +880,8 @@ class InStream:
             will receive an error.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x31e7)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x31e7, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -909,7 +925,8 @@ class InStream:
             target.
         """
 
-        val = self._interpreter.get_read_attribute_string(self._handle, 0x313e)
+        buffer_size = self.get_channels_buffer_size()
+        val = self._interpreter.get_read_attribute_string(self._handle, 0x313e, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -955,6 +972,11 @@ class InStream:
     def wait_mode(self):
         self._interpreter.reset_read_attribute(self._handle, 0x2232)
 
+    def get_channels_buffer_size (self):
+        channels_to_read = self.channels_to_read
+        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+        return total_size
+        
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):
         if num_samps_per_chan == -1:
             acq_type = self._task.timing.samp_quant_samp_mode

--- a/generated/nidaqmx/_task_modules/in_stream.py
+++ b/generated/nidaqmx/_task_modules/in_stream.py
@@ -974,7 +974,7 @@ class InStream:
 
     def get_channels_buffer_size(self):
         channel_names = self._task.channel_names
-        total_size = sum(len(name) for name in channel_names) + 1
+        total_size = sum(len(name) + 2 for name in channel_names) + 1
         return total_size
         
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -573,5 +573,5 @@ class OutStream:
 
     def get_channels_buffer_size(self):
         channel_names = self._task.channel_names
-        total_size = sum(len(name) for name in channel_names) + 1
+        total_size = sum(len(name) + 2 for name in channel_names) + 1
         return total_size

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -3,7 +3,6 @@
 from nidaqmx.utils import unflatten_channel_string
 from nidaqmx.constants import (
     RegenerationMode, ResolutionType, WaitMode, WriteRelativeTo)
-from nidaqmx._task_modules.in_stream import InStream
 
 class OutStream:
     """
@@ -572,8 +571,7 @@ class OutStream:
             self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)
 
-    def get_channels_buffer_size (self):
-        in_stream = InStream(self._task, self._interpreter) 
-        channels_to_read = in_stream.channels_to_read
-        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+    def get_channels_buffer_size(self):
+        channel_names = self._task.channel_names
+        total_size = sum(len(name) for name in channel_names) + 1
         return total_size

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -3,7 +3,7 @@
 from nidaqmx.utils import unflatten_channel_string
 from nidaqmx.constants import (
     RegenerationMode, ResolutionType, WaitMode, WriteRelativeTo)
-
+from nidaqmx._task_modules.in_stream import InStream
 
 class OutStream:
     """
@@ -116,7 +116,8 @@ class OutStream:
             an error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x3054)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x3054, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -142,7 +143,8 @@ class OutStream:
             an error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x30bc)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x30bc, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -198,7 +200,8 @@ class OutStream:
             error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x29eb)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x29eb, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -265,7 +268,8 @@ class OutStream:
             error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x29e9)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x29e9, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -290,7 +294,8 @@ class OutStream:
             Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x3085)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x3085, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -317,7 +322,8 @@ class OutStream:
             of the overtemperature.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x3083)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x3083, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -343,7 +349,8 @@ class OutStream:
             property. Otherwise, you will receive an error.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x29ed)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x29ed, buffer_size)
         return unflatten_channel_string(val)
 
     @property
@@ -446,7 +453,8 @@ class OutStream:
             target.
         """
 
-        val = self._interpreter.get_write_attribute_string(self._handle, 0x3140)
+        buffer_size = InStream.get_channels_buffer_size()
+        val = self._interpreter.get_write_attribute_string(self._handle, 0x3140, buffer_size)
         return unflatten_channel_string(val)
 
     @property

--- a/generated/nidaqmx/_task_modules/out_stream.py
+++ b/generated/nidaqmx/_task_modules/out_stream.py
@@ -116,7 +116,7 @@ class OutStream:
             an error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x3054, buffer_size)
         return unflatten_channel_string(val)
 
@@ -143,7 +143,7 @@ class OutStream:
             an error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x30bc, buffer_size)
         return unflatten_channel_string(val)
 
@@ -200,7 +200,7 @@ class OutStream:
             error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x29eb, buffer_size)
         return unflatten_channel_string(val)
 
@@ -268,7 +268,7 @@ class OutStream:
             error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x29e9, buffer_size)
         return unflatten_channel_string(val)
 
@@ -294,7 +294,7 @@ class OutStream:
             Otherwise, you will receive an error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x3085, buffer_size)
         return unflatten_channel_string(val)
 
@@ -322,7 +322,7 @@ class OutStream:
             of the overtemperature.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x3083, buffer_size)
         return unflatten_channel_string(val)
 
@@ -349,7 +349,7 @@ class OutStream:
             property. Otherwise, you will receive an error.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x29ed, buffer_size)
         return unflatten_channel_string(val)
 
@@ -453,7 +453,7 @@ class OutStream:
             target.
         """
 
-        buffer_size = InStream.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
         val = self._interpreter.get_write_attribute_string(self._handle, 0x3140, buffer_size)
         return unflatten_channel_string(val)
 
@@ -571,3 +571,9 @@ class OutStream:
         return self._interpreter.write_raw(
             self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)
+
+    def get_channels_buffer_size (self):
+        in_stream = InStream(self._task, self._interpreter) 
+        channels_to_read = in_stream.channels_to_read
+        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+        return total_size

--- a/src/codegen/templates/_base_interpreter.py.mako
+++ b/src/codegen/templates/_base_interpreter.py.mako
@@ -3,7 +3,7 @@
         get_interpreter_functions,
         get_interpreter_parameter_signature,
         get_params_for_function_signature,
-        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS
+        INCLUDE_SIZE_HINT_FUNCTIONS
     )
     from codegen.utilities.function_helpers import order_function_parameters_by_optional
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -39,8 +39,8 @@ class BaseInterpreter(abc.ABC):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
-    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
-        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
+    if func.function_name in INCLUDE_SIZE_HINT_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "size_hint=0"])
 %>\
     @abc.abstractmethod
 %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_base_interpreter.py.mako
+++ b/src/codegen/templates/_base_interpreter.py.mako
@@ -3,6 +3,7 @@
         get_interpreter_functions,
         get_interpreter_parameter_signature,
         get_params_for_function_signature,
+        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS
     )
     from codegen.utilities.function_helpers import order_function_parameters_by_optional
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -38,6 +39,8 @@ class BaseInterpreter(abc.ABC):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
+    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
 %>\
     @abc.abstractmethod
 %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -8,7 +8,7 @@
         get_response_parameters,
         is_event_register_function,
         GRPC_INTERPRETER_IGNORED_FUNCTIONS,
-        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
+        INCLUDE_SIZE_HINT_FUNCTIONS,
     )
     from codegen.utilities.function_helpers import order_function_parameters_by_optional
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -191,8 +191,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
-    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
-        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
+    if func.function_name in INCLUDE_SIZE_HINT_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "size_hint=0"])
     output_parameters = get_output_params(func)
 %>\
     %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -8,6 +8,7 @@
         get_response_parameters,
         is_event_register_function,
         GRPC_INTERPRETER_IGNORED_FUNCTIONS,
+        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
     )
     from codegen.utilities.function_helpers import order_function_parameters_by_optional
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -190,6 +191,8 @@ class GrpcStubInterpreter(BaseInterpreter):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
+    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
     output_parameters = get_output_params(func)
 %>\
     %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_library_interpreter.py.mako
+++ b/src/codegen/templates/_library_interpreter.py.mako
@@ -9,7 +9,7 @@
         get_return_values,
         is_event_register_function,
         LIBRARY_INTERPRETER_IGNORED_FUNCTIONS,
-        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
+        INCLUDE_SIZE_HINT_FUNCTIONS,
     )
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
 
@@ -69,8 +69,8 @@ class LibraryInterpreter(BaseInterpreter):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
-    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
-        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
+    if func.function_name in INCLUDE_SIZE_HINT_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "size_hint=0"])
     return_values = get_return_values(func)
 %>\
     %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_library_interpreter.py.mako
+++ b/src/codegen/templates/_library_interpreter.py.mako
@@ -9,6 +9,7 @@
         get_return_values,
         is_event_register_function,
         LIBRARY_INTERPRETER_IGNORED_FUNCTIONS,
+        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
     )
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
 
@@ -68,6 +69,8 @@ class LibraryInterpreter(BaseInterpreter):
     params = get_params_for_function_signature(func)
     sorted_params = order_function_parameters_by_optional(params)
     parameter_signature = get_interpreter_parameter_signature(is_python_factory, sorted_params)
+    if func.function_name in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
+        parameter_signature = ", ".join([parameter_signature, "temp_size=0"])
     return_values = get_return_values(func)
 %>\
     %if (len(func.function_name) + len(parameter_signature)) > 68:

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -78,7 +78,7 @@ ${property_template.script_property(attribute)}\
 \
     def get_channels_buffer_size(self):
         channel_names = self._task.channel_names
-        total_size = sum(len(name) for name in channel_names) + 1
+        total_size = sum(len(name) + 2 for name in channel_names) + 1
         return total_size
         
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -76,9 +76,9 @@ class InStream:
 ${property_template.script_property(attribute)}\
 %endfor
 \
-    def get_channels_buffer_size (self):
-        channels_to_read = self.channels_to_read
-        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+    def get_channels_buffer_size(self):
+        channel_names = self._task.channel_names
+        total_size = sum(len(name) for name in channel_names) + 1
         return total_size
         
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):

--- a/src/codegen/templates/_task_modules/in_stream.py.mako
+++ b/src/codegen/templates/_task_modules/in_stream.py.mako
@@ -76,6 +76,11 @@ class InStream:
 ${property_template.script_property(attribute)}\
 %endfor
 \
+    def get_channels_buffer_size (self):
+        channels_to_read = self.channels_to_read
+        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+        return total_size
+        
     def _calculate_num_samps_per_chan(self, num_samps_per_chan):
         if num_samps_per_chan == -1:
             acq_type = self._task.timing.samp_quant_samp_mode

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -167,5 +167,5 @@ ${property_template.script_property(attribute)}\
 
     def get_channels_buffer_size(self):
         channel_names = self._task.channel_names
-        total_size = sum(len(name) for name in channel_names) + 1
+        total_size = sum(len(name) + 2 for name in channel_names) + 1
         return total_size

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -165,3 +165,9 @@ ${property_template.script_property(attribute)}\
         return self._interpreter.write_raw(
             self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)
+
+    def get_channels_buffer_size (self):
+        in_stream = InStream(self._task, self._interpreter) 
+        channels_to_read = in_stream.channels_to_read
+        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+        return total_size

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -9,7 +9,7 @@
 from nidaqmx.utils import unflatten_channel_string
 from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
-
+from nidaqmx._task_modules.in_stream import InStream
 
 class OutStream:
     """

--- a/src/codegen/templates/_task_modules/out_stream.py.mako
+++ b/src/codegen/templates/_task_modules/out_stream.py.mako
@@ -9,7 +9,6 @@
 from nidaqmx.utils import unflatten_channel_string
 from nidaqmx.constants import (
     ${', '.join([c for c in enums_used]) | wrap(4, 4)})
-from nidaqmx._task_modules.in_stream import InStream
 
 class OutStream:
     """
@@ -166,8 +165,7 @@ ${property_template.script_property(attribute)}\
             self._handle, number_of_samples_per_channel,
             self.auto_start, self.timeout, numpy_array)
 
-    def get_channels_buffer_size (self):
-        in_stream = InStream(self._task, self._interpreter) 
-        channels_to_read = in_stream.channels_to_read
-        total_size = sum(len(name) for name in channels_to_read.channel_names) + 1
+    def get_channels_buffer_size(self):
+        channel_names = self._task.channel_names
+        total_size = sum(len(name) for name in channel_names) + 1
         return total_size

--- a/src/codegen/templates/library_interpreter/double_c_function_call.py.mako
+++ b/src/codegen/templates/library_interpreter/double_c_function_call.py.mako
@@ -5,6 +5,7 @@
         get_argument_types,
         get_output_param_with_ivi_dance_mechanism,
         get_output_params,
+        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
     )
     from codegen.utilities.function_helpers import instantiate_explicit_output_param
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -19,7 +20,9 @@
                     cfunc.argtypes = [
                         ${', '.join(get_argument_types(function)) | wrap(24, 24)}]
 
+%if function.function_name not in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
         temp_size = 0
+%endif
         while True:
             ${instantiate_explicit_output_param(explicit_output_param)}
             size_or_code = cfunc(

--- a/src/codegen/templates/library_interpreter/double_c_function_call.py.mako
+++ b/src/codegen/templates/library_interpreter/double_c_function_call.py.mako
@@ -5,7 +5,7 @@
         get_argument_types,
         get_output_param_with_ivi_dance_mechanism,
         get_output_params,
-        INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS,
+        INCLUDE_SIZE_HINT_FUNCTIONS,
     )
     from codegen.utilities.function_helpers import instantiate_explicit_output_param
     from codegen.utilities.text_wrappers import wrap, docstring_wrap
@@ -20,9 +20,7 @@
                     cfunc.argtypes = [
                         ${', '.join(get_argument_types(function)) | wrap(24, 24)}]
 
-%if function.function_name not in INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS:
-        temp_size = 0
-%endif
+        temp_size = ${'size_hint' if function.function_name in INCLUDE_SIZE_HINT_FUNCTIONS else '0'}
         while True:
             ${instantiate_explicit_output_param(explicit_output_param)}
             size_or_code = cfunc(

--- a/src/codegen/templates/property_getter_template.py.mako
+++ b/src/codegen/templates/property_getter_template.py.mako
@@ -31,7 +31,7 @@
 <%
         function_call_args.append("buffer_size")
 %>\
-        buffer_size = ${'self' if attribute.python_class_name ==  "InStream" else 'InStream'}.get_channels_buffer_size()
+        buffer_size = self.get_channels_buffer_size()
 \
         %endif
     %endif

--- a/src/codegen/templates/property_getter_template.py.mako
+++ b/src/codegen/templates/property_getter_template.py.mako
@@ -24,6 +24,18 @@
         function_call_args.append("\"\"")
     function_call_args.append(hex(attribute.id))
 %>
+## For read/write string attributes in InStream and OutStream, buffer_size is passed as an argument.
+%if attribute.access == "read" or attribute.access == "write":
+    %if attribute.ctypes_data_type == 'ctypes.c_char_p': 
+        %if attribute.python_class_name in ["InStream", "OutStream"]:
+<%
+        function_call_args.append("buffer_size")
+%>\
+        buffer_size = ${'self' if attribute.python_class_name ==  "InStream" else 'InStream'}.get_channels_buffer_size()
+\
+        %endif
+    %endif
+%endif
 \
         val = self._interpreter.get_${generic_attribute_func}(${', '.join(function_call_args)})
 \

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -80,7 +80,7 @@ INCLUDE_SIZE_PARAMETER_IN_SIGNATURE_FUNCTIONS = [
     "get_analog_power_up_states_with_output_type",
 ]
 
-INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS = [
+INCLUDE_SIZE_HINT_FUNCTIONS = [
     "get_read_attribute_string",
     "get_write_attribute_string",
 ]

--- a/src/codegen/utilities/interpreter_helpers.py
+++ b/src/codegen/utilities/interpreter_helpers.py
@@ -80,6 +80,11 @@ INCLUDE_SIZE_PARAMETER_IN_SIGNATURE_FUNCTIONS = [
     "get_analog_power_up_states_with_output_type",
 ]
 
+INCLUDE_STRING_BUFFER_SIZE_FUNCTIONS = [
+    "get_read_attribute_string",
+    "get_write_attribute_string",
+]
+
 MODIFIED_INTERPRETER_PARAMS = {
     "r_0": "r0",
     "r_1": "r1",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR aims to address issue mentioned in https://github.com/ni/nidaqmx-python/issues/189:
- Currently, buffer size is set to 0 initially [here](https://github.com/ni/nidaqmx-python/blob/0f65354421c5de8799eef8e1343db6f16af95524/generated/nidaqmx/_library_interpreter.py#L3241) and will return the actual buffer size needed after calling `xxx_chans` for the first time. Calling `xxx_chans` for the second time (with the actual buffer size) will return error -201194 due to [AB#2393824](https://dev.azure.com/ni/DevCentral/_workitems/edit/2393824).
- This PR is a temporary workaround to get the buffer size at `xxx_chans` property and passing the buffer size to `get_read_attribute_string` or `get_write_attribute_string` at `_library_interpreter` so that `xxx_chans` doesn't need to be called more than once. 

### Why should this Pull Request be merged?
In this PR to address https://github.com/ni/nidaqmx-python/issues/189, following changes have been made:
- Buffer size will be determined based on number of characters in `task.channel_names`.
- Buffer size will be allocated in `xxx_chans` property and passing it to `get_read_attribute_string` or `get_write_attribute_string` as `size_hint`.
- `size_hint=0` by default if buffer size is not assigned (for non `xxx_chans` method/property).

### What testing has been done?
Manually tested `overtemperature_chans` with overtemp real device TS-15200.
```
import pprint
import nidaqmx

with nidaqmx.Task() as task:
    # Channel Settings
    voltage_setpoint = 0
    current_setpoint = 0.03
    output_enable = True

    task.ai_channels.add_ai_power_chan(
        "TS1Mod1/power", voltage_setpoint, current_setpoint, output_enable
    )
    task.start()

    if task.in_stream.overtemperature_chans_exist:
        print(f"overtemperature chans: {task.in_stream.overtemperature_chans}")

    task.stop()
  ```
  
  Results: `overtemperature chans: ['TS1Mod1/power']`