### PR TITLE
Pick up trigger attributes changes from scrapigen

### DIFF
--- a/generated/nidaqmx/task/triggering/_arm_start_trigger.py
+++ b/generated/nidaqmx/task/triggering/_arm_start_trigger.py
@@ -172,6 +172,23 @@ class ArmStartTrigger:
         self._interpreter.reset_trig_attribute(self._handle, 0x3132)
 
     @property
+    def time_when(self):
+        """
+        datetime: Specifies when to trigger the arm start trigger.
+        """
+
+        val = self._interpreter.get_trig_attribute_timestamp(self._handle, 0x3131)
+        return val
+
+    @time_when.setter
+    def time_when(self, val):
+        self._interpreter.set_trig_attribute_timestamp(self._handle, 0x3131, val)
+
+    @time_when.deleter
+    def time_when(self):
+        self._interpreter.reset_trig_attribute(self._handle, 0x3131)
+
+    @property
     def timestamp_enable(self):
         """
         bool: Specifies whether the arm start trigger timestamp is
@@ -230,21 +247,4 @@ class ArmStartTrigger:
     @trig_type.deleter
     def trig_type(self):
         self._interpreter.reset_trig_attribute(self._handle, 0x1414)
-
-    @property
-    def trig_when(self):
-        """
-        datetime: Specifies when to trigger the arm start trigger.
-        """
-
-        val = self._interpreter.get_trig_attribute_timestamp(self._handle, 0x3131)
-        return val
-
-    @trig_when.setter
-    def trig_when(self, val):
-        self._interpreter.set_trig_attribute_timestamp(self._handle, 0x3131, val)
-
-    @trig_when.deleter
-    def trig_when(self):
-        self._interpreter.reset_trig_attribute(self._handle, 0x3131)
 

--- a/generated/nidaqmx/task/triggering/_start_trigger.py
+++ b/generated/nidaqmx/task/triggering/_start_trigger.py
@@ -863,6 +863,23 @@ class StartTrigger:
         self._interpreter.reset_trig_attribute(self._handle, 0x3036)
 
     @property
+    def time_when(self):
+        """
+        datetime: Specifies when to trigger the start trigger.
+        """
+
+        val = self._interpreter.get_trig_attribute_timestamp(self._handle, 0x304d)
+        return val
+
+    @time_when.setter
+    def time_when(self, val):
+        self._interpreter.set_trig_attribute_timestamp(self._handle, 0x304d, val)
+
+    @time_when.deleter
+    def time_when(self):
+        self._interpreter.reset_trig_attribute(self._handle, 0x304d)
+
+    @property
     def timestamp_enable(self):
         """
         bool: Specifies whether the start trigger timestamp is enabled.
@@ -918,23 +935,6 @@ class StartTrigger:
     @trig_type.deleter
     def trig_type(self):
         self._interpreter.reset_trig_attribute(self._handle, 0x1393)
-
-    @property
-    def trig_when(self):
-        """
-        datetime: Specifies when to trigger the start trigger.
-        """
-
-        val = self._interpreter.get_trig_attribute_timestamp(self._handle, 0x304d)
-        return val
-
-    @trig_when.setter
-    def trig_when(self, val):
-        self._interpreter.set_trig_attribute_timestamp(self._handle, 0x304d, val)
-
-    @trig_when.deleter
-    def trig_when(self):
-        self._interpreter.reset_trig_attribute(self._handle, 0x304d)
 
     @property
     def trig_win(self):

--- a/src/codegen/metadata/attributes.py
+++ b/src/codegen/metadata/attributes.py
@@ -29014,7 +29014,7 @@ attributes = {
             'python_class_name': 'StartTrigger',
             'python_data_type': 'datetime',
             'python_description': 'Specifies when to trigger the start trigger.',
-            'python_name': 'trig_when',
+            'python_name': 'time_when',
             'resettable': True,
             'type': 'CVIAbsoluteTime'
         },
@@ -29548,7 +29548,7 @@ attributes = {
             'python_class_name': 'ArmStartTrigger',
             'python_data_type': 'datetime',
             'python_description': 'Specifies when to trigger the arm start trigger.',
-            'python_name': 'trig_when',
+            'python_name': 'time_when',
             'resettable': True,
             'type': 'CVIAbsoluteTime'
         },

--- a/tests/component/task/test_triggers.py
+++ b/tests/component/task/test_triggers.py
@@ -51,7 +51,7 @@ def test___default_arguments___cfg_time_start_trig___no_errors(
 
     ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time)
 
-    when_value = ai_voltage_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_task.triggers.start_trigger.time_when
     timescale_value = ai_voltage_task.triggers.start_trigger.timestamp_timescale
     assert timescale_value == Timescale.USE_HOST
     assert when_value.year == trigger_time.year
@@ -74,7 +74,7 @@ def test___arguments_provided___cfg_time_start_trig___no_errors(
 
     ai_voltage_task.triggers.start_trigger.cfg_time_start_trig(trigger_time, timescale)
 
-    when_value = ai_voltage_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_task.triggers.start_trigger.time_when
     assert when_value.year == trigger_time.year
     assert when_value.month == trigger_time.month
     assert when_value.day == trigger_time.day

--- a/tests/component/task/test_triggers_properties.py
+++ b/tests/component/task/test_triggers_properties.py
@@ -115,7 +115,7 @@ def test___ai_voltage_time_aware_task___get_timestamp_property___returns_default
 ):
     ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
 
-    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.time_when
 
     localized_default_value = _convert_to_desired_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
@@ -132,9 +132,9 @@ def test___ai_voltage_time_aware_task___set_timestamp_property___returns_assigne
     value_to_test = JAN_01_2002_HIGHTIME
     ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
 
-    ai_voltage_time_aware_task.triggers.start_trigger.trig_when = value_to_test
+    ai_voltage_time_aware_task.triggers.start_trigger.time_when = value_to_test
 
-    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.time_when
     localized_value_to_test = _convert_to_desired_timezone(value_to_test)
     assert when_value.year == localized_value_to_test.year
     assert when_value.month == localized_value_to_test.month
@@ -148,11 +148,11 @@ def test___ai_voltage_time_aware_task___reset_timestamp_property___returns_defau
     ai_voltage_time_aware_task: Task,
 ):
     ai_voltage_time_aware_task.timing.cfg_samp_clk_timing(1000)
-    ai_voltage_time_aware_task.triggers.start_trigger.trig_when = JAN_01_2002_HIGHTIME
+    ai_voltage_time_aware_task.triggers.start_trigger.time_when = JAN_01_2002_HIGHTIME
 
-    del ai_voltage_time_aware_task.triggers.start_trigger.trig_when
+    del ai_voltage_time_aware_task.triggers.start_trigger.time_when
 
-    when_value = ai_voltage_time_aware_task.triggers.start_trigger.trig_when
+    when_value = ai_voltage_time_aware_task.triggers.start_trigger.time_when
     localized_default_value = _convert_to_desired_timezone(JAN_01_1904_HIGHTIME)
     assert when_value.year == localized_default_value.year
     assert when_value.month == localized_default_value.month


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updated `trigger` attributes from `trig_when` to `time_when`.
Updated test cases.

### Why should this Pull Request be merged?

This PR picks up updated `trigger` attributes from [Rename trig_when to time_when](https://github.com/ni/grpc-device-scrapigen/pull/216)

### What testing has been done?

`poetry run pytest` - pass