### PR TITLE
Improve error reporting in some cases

### DIFF
--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -54,12 +54,12 @@ class DaqError(Error):
 
         # If message is empty, we try to put at least some information in it
         if not message and self._error_type != DAQmxErrors.UNKNOWN:
-            message = f'{self._error_type.name} occurred. Error code: {self._error_code}.'
-        elif not message:
-            message = f'Error code: {self._error_code}.'
+            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nError {self._error_type.name}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'
+            
+        message = f'{message}\n\nStatus Code: {self._error_code}'
 
         super().__init__(message)
 

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -65,7 +65,6 @@ class DaqError(Error):
 
         super().__init__(message)
 
-
     @property
     def error_code(self):
         """

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -54,7 +54,7 @@ class DaqError(Error):
 
         # If message is empty, we try to put at least some information in it
         if not message:
-            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nStatus Code: {self._error_code}'
+            message = f'Description could not be found for the status code.\n\nStatus Code: {self._error_code}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -53,15 +53,18 @@ class DaqError(Error):
             self._error_type = DAQmxErrors.UNKNOWN
 
         # If message is empty, we try to put at least some information in it
-        if not message and self._error_type != DAQmxErrors.UNKNOWN:
-            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nError {self._error_type.name}'
+        if not message:
+            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nStatus Code: {self._error_code}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'
             
-        message = f'{message}\n\nStatus Code: {self._error_code}'
+        # We do not know where the error description came from, so we add the status code if it is not already in the message
+        if str(self._error_code) not in message:
+            message = f'{message}\n\nStatus Code: {self._error_code}'
 
         super().__init__(message)
+
 
     @property
     def error_code(self):

--- a/generated/nidaqmx/errors.py
+++ b/generated/nidaqmx/errors.py
@@ -45,17 +45,23 @@ class DaqError(Error):
             message (string): Specifies the error message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
-        super().__init__(message)
-
         self._error_code = int(error_code)
 
         try:
             self._error_type = DAQmxErrors(self._error_code)
         except ValueError:
             self._error_type = DAQmxErrors.UNKNOWN
+
+        # If message is empty, we try to put at least some information in it
+        if not message and self._error_type != DAQmxErrors.UNKNOWN:
+            message = f'{self._error_type.name} occurred. Error code: {self._error_code}.'
+        elif not message:
+            message = f'Error code: {self._error_code}.'
+
+        if task_name:
+            message = f'{message}\n\nTask Name: {task_name}'
+
+        super().__init__(message)
 
     @property
     def error_code(self):
@@ -84,18 +90,9 @@ class DaqReadError(DaqError):
             message (string): Specifies the error message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
         super().__init__(message, error_code, task_name)
 
-        self._error_code = int(error_code)
         self._samps_per_chan_read = samps_per_chan_read
-
-        try:
-            self._error_type = DAQmxErrors(self._error_code)
-        except ValueError:
-            self._error_type = DAQmxErrors.UNKNOWN
 
     @property
     def samps_per_chan_read(self):
@@ -117,18 +114,9 @@ class DaqWriteError(DaqError):
             error_code (int): Specifies the NI-DAQmx error code.
             samps_per_chan_written (int): Specifies the number of samples written.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
         super().__init__(message, error_code, task_name)
 
-        self._error_code = int(error_code)
         self._samps_per_chan_written = samps_per_chan_written
-
-        try:
-            self._error_type = DAQmxErrors(self._error_code)
-        except ValueError:
-            self._error_type = DAQmxErrors.UNKNOWN
 
     @property
     def samps_per_chan_written(self):

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -54,12 +54,12 @@ class DaqError(Error):
 
         # If message is empty, we try to put at least some information in it
         if not message and self._error_type != DAQmxErrors.UNKNOWN:
-            message = f'{self._error_type.name} occurred. Error code: {self._error_code}.'
-        elif not message:
-            message = f'Error code: {self._error_code}.'
+            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nError {self._error_type.name}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'
+            
+        message = f'{message}\n\nStatus Code: {self._error_code}'
 
         super().__init__(message)
 

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -54,7 +54,7 @@ class DaqError(Error):
 
         # If message is empty, we try to put at least some information in it
         if not message:
-            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nStatus Code: {self._error_code}'
+            message = f'Description could not be found for the status code.\n\nStatus Code: {self._error_code}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -53,13 +53,15 @@ class DaqError(Error):
             self._error_type = DAQmxErrors.UNKNOWN
 
         # If message is empty, we try to put at least some information in it
-        if not message and self._error_type != DAQmxErrors.UNKNOWN:
-            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nError {self._error_type.name}'
+        if not message:
+            message = f'Explanation could not be found for the requested status code.\n\nVerify that the requested status code is correct.\n\nStatus Code: {self._error_code}'
 
         if task_name:
             message = f'{message}\n\nTask Name: {task_name}'
             
-        message = f'{message}\n\nStatus Code: {self._error_code}'
+        # We do not know where the error description came from, so we add the status code if it is not already in the message
+        if str(self._error_code) not in message:
+            message = f'{message}\n\nStatus Code: {self._error_code}'
 
         super().__init__(message)
 

--- a/src/handwritten/errors.py
+++ b/src/handwritten/errors.py
@@ -45,17 +45,23 @@ class DaqError(Error):
             message (string): Specifies the error message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
-        super().__init__(message)
-
         self._error_code = int(error_code)
 
         try:
             self._error_type = DAQmxErrors(self._error_code)
         except ValueError:
             self._error_type = DAQmxErrors.UNKNOWN
+
+        # If message is empty, we try to put at least some information in it
+        if not message and self._error_type != DAQmxErrors.UNKNOWN:
+            message = f'{self._error_type.name} occurred. Error code: {self._error_code}.'
+        elif not message:
+            message = f'Error code: {self._error_code}.'
+
+        if task_name:
+            message = f'{message}\n\nTask Name: {task_name}'
+
+        super().__init__(message)
 
     @property
     def error_code(self):
@@ -84,18 +90,9 @@ class DaqReadError(DaqError):
             message (string): Specifies the error message.
             error_code (int): Specifies the NI-DAQmx error code.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
         super().__init__(message, error_code, task_name)
 
-        self._error_code = int(error_code)
         self._samps_per_chan_read = samps_per_chan_read
-
-        try:
-            self._error_type = DAQmxErrors(self._error_code)
-        except ValueError:
-            self._error_type = DAQmxErrors.UNKNOWN
 
     @property
     def samps_per_chan_read(self):
@@ -117,18 +114,9 @@ class DaqWriteError(DaqError):
             error_code (int): Specifies the NI-DAQmx error code.
             samps_per_chan_written (int): Specifies the number of samples written.
         """
-        if task_name:
-            message = f'{message}\n\nTask Name: {task_name}'
-
         super().__init__(message, error_code, task_name)
 
-        self._error_code = int(error_code)
         self._samps_per_chan_written = samps_per_chan_written
-
-        try:
-            self._error_type = DAQmxErrors(self._error_code)
-        except ValueError:
-            self._error_type = DAQmxErrors.UNKNOWN
 
     @property
     def samps_per_chan_written(self):


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

If for some reason the extended error message is blank, the `DaqError` ends up not showing any output when it is printed. This can happen if the DLL doesn't properly load plugins. If message is blank, try to put at least something in to the message that is then given to the parent Error class.

Changed `DaqReadError` and `DaqWriteError` to let `DaqError` handle setting the message

### Why should this Pull Request be merged?

Improves error reporting

### What testing has been done?

Local testing