### PR TITLE
mypy: Ignore redef in importlib_metadata hack and run mypy --platform win32

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run mypy (Windows)
         run: |
           poetry run mypy generated/nidaqmx --platform win32
-          poetry run mypy tests --platform-win32
+          poetry run mypy tests --platform win32
       - name: Generate ni-daqmx files
         run: |
           rm -fr generated/nidaqmx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,14 @@ jobs:
       - name: Run linters
         run: |
           poetry run ni-python-styleguide lint
-      - name: Run mypy
+      - name: Run mypy (Linux)
         run: |
           poetry run mypy generated/nidaqmx
           poetry run mypy tests
+      - name: Run mypy (Windows)
+        run: |
+          poetry run mypy generated/nidaqmx --platform win32
+          poetry run mypy tests --platform-win32
       - name: Generate ni-daqmx files
         run: |
           rm -fr generated/nidaqmx

--- a/generated/nidaqmx/__init__.py
+++ b/generated/nidaqmx/__init__.py
@@ -7,7 +7,7 @@ from nidaqmx.types import CtrFreq, CtrTick, CtrTime
 try:
     from importlib.metadata import version
 except ImportError:
-    from importlib_metadata import version
+    from importlib_metadata import version  # type: ignore[no-redef]
 
 __version__ = version(__name__)
 

--- a/src/handwritten/__init__.py
+++ b/src/handwritten/__init__.py
@@ -7,7 +7,7 @@ from nidaqmx.types import CtrFreq, CtrTick, CtrTime
 try:
     from importlib.metadata import version
 except ImportError:
-    from importlib_metadata import version
+    from importlib_metadata import version  # type: ignore[no-redef]
 
 __version__ = version(__name__)
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix two mypy issues uncovered in #512 
- `nidaqmx/__init__.py` is failing with `error: Name "version" already defined (possibly by an import)  [no-redef]`
- The GitHub workflow is only running mypy for Linux, not Windows

I don't know why we haven't seen this in other PRs. I can reproduce it with the `master` branch as of commit a60f369a3a8e874f541a23e4d71e2efebfa5b3a0

### Why should this Pull Request be merged?

Fix mypy error.

### What testing has been done?

None