### PR TITLE
Use invalid value for done status

### DIFF
--- a/tests/acceptance/test_multi_threading.py
+++ b/tests/acceptance/test_multi_threading.py
@@ -267,7 +267,7 @@ def _configure_events(
 
     samples_acquired = [0 for _ in tasks]
     done_events = [threading.Event() for _ in tasks]
-    done_statuses = [0 for _ in tasks]
+    done_statuses = [-1 for _ in tasks]
 
     for i in range(len(tasks)):
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

In the multi-threading tests, the initial value of done_statuses is set to the expected value. This means we do not know whether the done event was called or not. Instead, set the initial value to an invalid value.

### Why should this Pull Request be merged?

It ensures the done event is called correctly during the multi-threading tests.

### What testing has been done?

PR