### PR TITLE
Add tests to verify closing task in event callback does not crash or error

### DIFF
--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -56,6 +56,9 @@ def test___done_event_registered___run_finite_acquisition___callback_invoked_onc
     assert all(e.status == 0 for e in event_observer.events)
 
 
+@pytest.mark.grpc_xfail(
+    reason="#559: Can't close tasks in an event callback when using gRPC", raises=AssertionError
+)
 def test___done_event_registered___call_clear_in_callback___stop_close_in_callback_with_success_status(
     sim_6363_device: nidaqmx.system.Device,
     init_kwargs: dict,
@@ -106,6 +109,9 @@ def test___done_event_registered___call_clear_in_callback___stop_close_in_callba
     assert len(warnings_record) == 1
 
 
+@pytest.mark.grpc_xfail(
+    reason="#559: Can't close tasks in an event callback when using gRPC", raises=AssertionError
+)
 def test___every_n_samples_event_registered___call_clear_in_callback___stop_close_in_callback_with_success_status(
     sim_6363_device: nidaqmx.system.Device,
     init_kwargs: dict,


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

DAQmx allows stopping and closing the task in an event callback. Test that is does not crash and behaves properly.

### Why should this Pull Request be merged?

Improve test coverage

### What testing has been done?

* Local tests pass
* PR