### PR TITLE
tests: Improve _bool_array_to_int in DI reader test

### DIFF
--- a/tests/component/test_stream_readers_di.py
+++ b/tests/component/test_stream_readers_di.py
@@ -174,8 +174,8 @@ def _get_expected_digital_port_data_sample_major(
 def _bool_array_to_int(bool_array: numpy.typing.NDArray[numpy.bool_]) -> int:
     result = 0
     # Simulated data is little-endian
-    for bit in reversed(bool_array):
-        result = (result << 1) | bit
+    for bit in bool_array[::-1]:
+        result = (result << 1) | int(bit)
     return result
 
 
@@ -394,7 +394,7 @@ def test___digital_multi_channel_reader___read_one_sample_multi_line___returns_v
         _read_and_copy(reader.read_one_sample_multi_line, sample) for _ in range(samples_to_read)
     ]
 
-    assert [_bool_array_to_int(sample) for sample in data] == _get_expected_digital_data(
+    assert [_bool_array_to_int(sample[:, 0]) for sample in data] == _get_expected_digital_data(
         num_channels, samples_to_read
     )
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Use NumPy slicing instead of `reversed(...)` to reverse the bool array.
- Use `int(bit)` to explicitly convert the NumPy array element to a Python `int`, which prevents setting the sign bit with large ports and returning negative numbers.
- In one test case, slice a 2D bool array into a 1D bool array view in order to avoid `DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`

### Why should this Pull Request be merged?

Fix issues I discovered when writing another test. 

### What testing has been done?

`poetry run pytest -v .\tests\component\test_stream_readers_di.py` passes with LibraryInterpreter. (I don't currently have NI gRPC Device Server installed.)