### PR TITLE
nidaqmx-python Reports Python as Runtime Environment

### DIFF
--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -1531,6 +1531,10 @@ class BaseInterpreter(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def set_runtime_environment(self, environment, environment_version):
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def set_scale_attribute_double(self, scale_name, attribute, value):
         raise NotImplementedError
 

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -3063,6 +3063,13 @@ class GrpcStubInterpreter(BaseInterpreter):
             grpc_types.SetReadAttributeUInt64Request(
                 task=task, attribute_raw=attribute, value=value))
 
+    def set_runtime_environment(self, environment, environment_version):
+        response = self._invoke(
+            self._client.SetRuntimeEnvironment,
+            grpc_types.SetRuntimeEnvironmentRequest(
+                environment=environment,
+                environment_version=environment_version))
+
     def set_scale_attribute_double(self, scale_name, attribute, value):
         response = self._invoke(
             self._client.SetScaleAttributeDouble,

--- a/src/codegen/metadata/functions.py
+++ b/src/codegen/metadata/functions.py
@@ -21934,6 +21934,27 @@ functions = {
         'python_codegen_method': 'CustomCode',
         'returns': 'int32'
     },
+    'SetRuntimeEnvironment': {
+        'calling_convention': 'StdCall',
+        'parameters': [
+            {
+                'ctypes_data_type': 'ctypes.c_char_p',
+                'direction': 'in',
+                'name': 'environment',
+                'python_data_type': 'str',
+                'type': 'const char[]'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_char_p',
+                'direction': 'in',
+                'name': 'environmentVersion',
+                'python_data_type': 'str',
+                'type': 'const char[]'
+            }
+        ],
+        'python_codegen_method': 'CustomCode',
+        'returns': 'int32'
+    },
     'SetScaleAttributeDouble': {
         'calling_convention': 'Cdecl',
         'cname': 'DAQmxSetScaleAttribute',

--- a/src/codegen/templates/_library_interpreter.py.mako
+++ b/src/codegen/templates/_library_interpreter.py.mako
@@ -19,6 +19,7 @@
 
 import ctypes
 import logging
+import platform
 import warnings
 from typing import Optional
 
@@ -33,6 +34,7 @@ from nidaqmx._lib_time import AbsoluteTime
 
 
 _logger = logging.getLogger(__name__)
+_was_runtime_environment_set = None
 
 
 class LibraryEventHandler(BaseEventHandler):
@@ -60,7 +62,15 @@ class LibraryInterpreter(BaseInterpreter):
     __slots__ = ()
 
     def __init__(self):
-        pass
+        global _was_runtime_environment_set 
+        if _was_runtime_environment_set is None:
+            runtime_env = platform.python_implementation()
+            version = platform.python_version()
+            self.set_runtime_environment(
+                runtime_env,
+                version
+            )
+            _was_runtime_environment_set = True
 
 % for func in functions:
 <%


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR aims to report Python and its version as runtime environment through DAQmxSetRuntimeEnvironment C API at initialization.

### Why should this Pull Request be merged?
In this PR, following implementations have been made:
- `DAQmxSetRuntimeEnvironment `added with metadata generated in https://github.com/ni/grpc-device-scrapigen/pull/229
- `set_runtime_environment` will be called at `__init__` in _library_interpreter.py to report Python and its version as runtime environment. 

### What testing has been done?
Tested locally with example code and verified Runtime Environment information is being logged correctly. 
![image](https://github.com/ni/nidaqmx-python/assets/55676809/85a34193-b262-49f5-a146-b11e11fa6fe8)