### PR TITLE
Add continuous acquisition examples for thrmcpl and digital trigger

### DIFF
--- a/examples/analog_in/cont_thrmcpl_samples_int_clk.py
+++ b/examples/analog_in/cont_thrmcpl_samples_int_clk.py
@@ -5,20 +5,29 @@ temperature measurement using a thermocouple.
 """
 
 import nidaqmx
-from nidaqmx.constants import AcquisitionType, ThermocoupleType, TemperatureUnits
+from nidaqmx.constants import (
+    AcquisitionType,
+    CJCSource,
+    TemperatureUnits,
+    ThermocoupleType,
+)
 
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_thrmcpl_chan(
-        "Dev1/ai0", units=TemperatureUnits.DEG_C, thermocouple_type=ThermocoupleType.K
+        "Dev1/ai0",
+        units=TemperatureUnits.DEG_C,
+        thermocouple_type=ThermocoupleType.K,
+        cjc_source=CJCSource.CONSTANT_USER_VALUE,
+        cjc_val=25.0,
     )
-    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.CONTINUOUS)
+    task.timing.cfg_samp_clk_timing(10.0, sample_mode=AcquisitionType.CONTINUOUS)
     task.start()
     print("Acquiring samples continuously. Press Ctrl+C to stop.")
 
     try:
         total_read = 0
         while True:
-            data = task.read(number_of_samples_per_channel=1000)
+            data = task.read(number_of_samples_per_channel=50)
             read = len(data)
             total_read += read
             print(f"Acquired data: {read} samples. Total {total_read}.", end="\r")

--- a/examples/analog_in/cont_thrmcpl_samples_int_clk.py
+++ b/examples/analog_in/cont_thrmcpl_samples_int_clk.py
@@ -1,0 +1,29 @@
+﻿"""Example of continuous temperature acquisition.
+
+This example demonstrates how to make continuous, hardware-timed
+temperature measurement using a thermocouple.
+"""
+
+import nidaqmx
+from nidaqmx.constants import AcquisitionType, ThermocoupleType, TemperatureUnits
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_thrmcpl_chan(
+        "Dev1/ai0", units=TemperatureUnits.DEG_C, thermocouple_type=ThermocoupleType.K
+    )
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.CONTINUOUS)
+    task.start()
+    print("Acquiring samples continuously. Press Ctrl+C to stop.")
+
+    try:
+        total_read = 0
+        while True:
+            data = task.read(number_of_samples_per_channel=1000)
+            read = len(data)
+            total_read += read
+            print(f"Acquired data: {read} samples. Total {total_read}.", end="\r")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        task.stop()
+        print(f"\nAcquired {total_read} total samples.")

--- a/examples/analog_in/cont_voltage_acq_int_clk_dig_start.py
+++ b/examples/analog_in/cont_voltage_acq_int_clk_dig_start.py
@@ -1,0 +1,39 @@
+﻿"""Example of analog input voltage acquisition is triggered by a digital edge.
+
+This example demonstrates how to acquire a continuous amount of
+data using an external sample clock, started by a digital edge.
+"""
+
+import nidaqmx
+from nidaqmx.constants import AcquisitionType
+
+
+def main():
+    """Continuously acquires data started by a digital edge."""
+    total_read = 0
+    with nidaqmx.Task() as task:
+
+        def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
+            """Callback function for reading singals."""
+            nonlocal total_read
+            read = len(task.read(number_of_samples_per_channel=number_of_samples))
+            total_read += read
+            print(f"Acquired data: {read} samples. Total {total_read}.", end="\r")
+
+            return 0
+
+        task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
+        task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.CONTINUOUS)
+        task.triggers.start_trigger.cfg_dig_edge_start_trig("/Dev1/PFI0")
+
+        task.register_every_n_samples_acquired_into_buffer_event(1000, callback)
+        task.start()
+
+        input("Acquiring samples continuously. Press Enter to stop.\n")
+
+        task.stop()
+        print(f"\nAcquired {total_read} total samples.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/analog_in/cont_voltage_acq_int_clk_dig_start.py
+++ b/examples/analog_in/cont_voltage_acq_int_clk_dig_start.py
@@ -1,4 +1,4 @@
-﻿"""Example of analog input voltage acquisition is triggered by a digital edge.
+﻿"""Example of analog input voltage acquisition with a digital start trigger.
 
 This example demonstrates how to acquire a continuous amount of
 data using an external sample clock, started by a digital edge.
@@ -14,7 +14,7 @@ def main():
     with nidaqmx.Task() as task:
 
         def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
-            """Callback function for reading singals."""
+            """Callback function for reading signals."""
             nonlocal total_read
             read = len(task.read(number_of_samples_per_channel=number_of_samples))
             total_read += read

--- a/examples/analog_in/cont_voltage_acq_int_clk_dig_start_retrig.py
+++ b/examples/analog_in/cont_voltage_acq_int_clk_dig_start_retrig.py
@@ -1,4 +1,4 @@
-﻿"""Example of analog input voltage acquisition on each digital trigger.
+﻿"""Example of analog input voltage acquisition with retriggering.
 
 This example demonstrates how to acquire finite amounts of data
 on each digital trigger.
@@ -14,7 +14,7 @@ def main():
     with nidaqmx.Task() as task:
 
         def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
-            """Callback function for reading singals."""
+            """Callback function for reading signals."""
             nonlocal total_read
             read = len(task.read(number_of_samples_per_channel=number_of_samples))
             total_read += read

--- a/examples/analog_in/cont_voltage_acq_int_clk_dig_start_retrig.py
+++ b/examples/analog_in/cont_voltage_acq_int_clk_dig_start_retrig.py
@@ -1,0 +1,42 @@
+﻿"""Example of analog input voltage acquisition on each digital trigger.
+
+This example demonstrates how to acquire finite amounts of data
+on each digital trigger.
+"""
+
+import nidaqmx
+from nidaqmx.constants import AcquisitionType
+
+
+def main():
+    """Acquires data on each digital trigger."""
+    total_read = 0
+    with nidaqmx.Task() as task:
+
+        def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
+            """Callback function for reading singals."""
+            nonlocal total_read
+            read = len(task.read(number_of_samples_per_channel=number_of_samples))
+            total_read += read
+            print(f"Acquired data: {read} samples. Total {total_read}.", end="\r")
+
+            return 0
+
+        task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
+        task.timing.cfg_samp_clk_timing(
+            1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=1000
+        )
+        task.triggers.start_trigger.cfg_dig_edge_start_trig("/Dev1/PFI0")
+        task.triggers.start_trigger.retriggerable = True
+
+        task.register_every_n_samples_acquired_into_buffer_event(1000, callback)
+        task.start()
+
+        input("Acquiring samples continuously. Press Enter to stop.\n")
+
+        task.stop()
+        print(f"\nAcquired {total_read} total samples.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/analog_in/cont_voltage_acq_int_clk_every_n_samples_event.py
+++ b/examples/analog_in/cont_voltage_acq_int_clk_every_n_samples_event.py
@@ -16,7 +16,7 @@ def main():
     with nidaqmx.Task() as task:
 
         def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
-            """Callback function for reading singals."""
+            """Callback function for reading signals."""
             nonlocal total_read
             read = len(task.read(number_of_samples_per_channel=number_of_samples))
             total_read += read

--- a/examples/analog_in/voltage_acq_int_clk_dig_start_ref.py
+++ b/examples/analog_in/voltage_acq_int_clk_dig_start_ref.py
@@ -1,0 +1,20 @@
+﻿"""Example of analog input voltage acquisition with digital start and reference trigger.
+
+This example demonstrates how to acquire a finite amount of data
+using an internal clock and a digital start and reference
+trigger.
+"""
+
+import nidaqmx
+from nidaqmx.constants import READ_ALL_AVAILABLE, AcquisitionType
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=100)
+    task.triggers.start_trigger.cfg_dig_edge_start_trig("/Dev1/PFI0")
+    task.triggers.reference_trigger.cfg_dig_edge_ref_trig("/Dev1/PFI8", pretrigger_samples=50)
+
+    task.start()
+    data = task.read(READ_ALL_AVAILABLE)
+    print("Acquired data: [" + ", ".join(f"{value:f}" for value in data) + "]")
+    task.stop()

--- a/examples/every_n_samples_event.py
+++ b/examples/every_n_samples_event.py
@@ -1,4 +1,4 @@
-"""Example for reading singals for every n samples."""
+"""Example for reading signals for every n samples."""
 
 import pprint
 
@@ -16,7 +16,7 @@ with nidaqmx.Task() as task:
     samples = []
 
     def callback(task_handle, every_n_samples_event_type, number_of_samples, callback_data):
-        """Callback function for reading singals."""
+        """Callback function for reading signals."""
         print("Every N Samples callback invoked.")
 
         samples.extend(task.read(number_of_samples_per_channel=1000))

--- a/tests/acceptance/test_examples.py
+++ b/tests/acceptance/test_examples.py
@@ -29,6 +29,8 @@ def test___shipping_example___run___no_errors(example_path: Path, system):
                 )
     if example_path.name == "read_pulse_freq.py":
         pytest.skip("Example times out if there is no signal.")
+    if example_path.name == "voltage_acq_int_clk_dig_start_ref.py":
+        pytest.skip("Example times out if there is no trigger signal.")
     if re.search(r"\binput\(|\bKeyboardInterrupt\b", example_source):
         pytest.skip("Example waits for keyboard input.")
     if example_path.name == "nidaqmx_warnings.py":


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- add continuous thrmcpl samples acquisition example.
- add digital start, digital start ref, digital start retrigger examples.

### Why should this Pull Request be merged?

These AI examples are requested in the feature scope to be released in version 1.0.

### What testing has been done?

run `poetry run pytest tests/ -q` - pass
![image](https://github.com/ni/nidaqmx-python/assets/27721199/ef575f60-11f5-4829-9265-9d3966b78310)


Validated on physical device PXIe-6363 - okay
```
C:\dev\repo2\nidaqmx-python>poetry run python examples\analog_in\cont_thrmcpl_samples_int_clk.py       
Acquiring samples continuously. Press Ctrl+C to stop.
Acquired data: 1000 samples. Total 4000.
Acquired 4000 total samples.

C:\dev\repo2\nidaqmx-python>poetry run python examples\analog_in\cont_voltage_acq_int_clk_dig_start.py
Acquiring samples continuously. Press Enter to stop.
Acquired data: 1000 samples. Total 3000.

Acquired 3000 total samples.

C:\dev\repo2\nidaqmx-python>poetry run python examples\analog_in\voltage_acq_int_clk_dig_start_ref.py      
Acquired data: [0.721807, 0.721807, 0.722129, 0.722290, 0.721968, 0.721968, 0.721968, 0.721807, 0.721485, 0.721163, 0.721163, 0.721002, 0.720680, 0.720841, 0.720680, 0.720841, 0.720680, 0.720841, 0.721002, 0.721324, 0.721163, 0.721163, 0.721485, 0.721485, 0.721485, 0.721646, 0.721324, 0.721485, 0.721324, 0.720841, 0.720680, 0.720196, 0.720518, 0.720518, 0.720196, 0.720196, 0.720357, 0.720518, 0.721002, 0.721002, 0.720841, 0.721163, 0.721485, 0.721163, 0.721002, 0.721163, 0.720841, 0.721163, 0.721163, 0.720518, 0.720357, 0.720196, 0.720357, 0.720196, 0.720035, 0.719874, 0.720196, 0.720196, 0.720518, 0.720518, 0.720680, 0.720680, 0.720841, 0.720680, 0.721163, 0.721002, 0.721002, 0.720518, 0.720841, 0.720518, 0.720035, 0.720196, 0.719874, 0.719552, 0.719874, 0.719713, 0.720035, 0.719713, 0.720196, 0.720035, 0.720518, 0.720680, 0.720680, 0.720841, 0.720680, 0.720680, 0.720680, 0.720196, 0.720196, 0.720035, 0.720035, 0.719874, 0.719552, 0.719874, 0.719391, 0.719552, 0.719874, 0.719874, 0.720035, 0.720196]

C:\dev\repo2\nidaqmx-python>poetry run python examples\analog_in\cont_voltage_acq_int_clk_dig_start_retrig.py
Acquiring samples continuously. Press Enter to stop.
Acquired data: 1000 samples. Total 7000.

Acquired 7000 total samples.
```