### PR TITLE
add tests for trigger APIs

### DIFF
--- a/tests/component/task/test_triggers.py
+++ b/tests/component/task/test_triggers.py
@@ -5,7 +5,7 @@ import pytest
 from hightime import datetime as ht_datetime, timedelta as ht_timedelta
 
 import nidaqmx
-from nidaqmx.constants import Edge, Slope, Timescale, TimestampEvent, TriggerType
+from nidaqmx.constants import DigitalPatternCondition, Edge, LineGrouping, Slope, Timescale, TimestampEvent, TriggerType, WindowTriggerCondition1
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.task import Task
 from nidaqmx.utils import flatten_channel_string
@@ -32,6 +32,12 @@ def sim_6363_ai_voltage_task(task, sim_6363_device) -> Task:
     task.ai_channels.add_ai_voltage_chan(sim_6363_device.ai_physical_chans[0].name)
     return task
 
+
+@pytest.fixture()
+def sim_6535_di_single_line_task(task, sim_6535_device) -> Task:
+    """Gets DI task."""
+    task.di_channels.add_di_chan(sim_6535_device.di_lines[0].name, line_grouping=LineGrouping.CHAN_FOR_ALL_LINES)
+    return task
 
 @pytest.fixture()
 def sim_9775_ai_voltage_multi_edge_task(task, sim_9775_device) -> Task:
@@ -180,6 +186,90 @@ def test___start_trigger___cfg_anlg_edge_start_trig___no_errors(
 
 
 @pytest.mark.parametrize(
+    "window_top, window_bottom, trig_src, trig_when",
+    [
+        (8.456, 3.9, "APFI0", WindowTriggerCondition1.ENTERING_WINDOW),
+        (8.456, 3.9, "APFI1", WindowTriggerCondition1.LEAVING_WINDOW),
+    ],
+)
+def test___start_trigger___cfg_anlg_window_start_trig___no_errors(
+    sim_6363_ai_voltage_task: Task,
+    window_top: float,
+    window_bottom: float,
+    trig_src: str,
+    trig_when: int,
+):
+    device_name = sim_6363_ai_voltage_task.devices[0].name
+
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.start_trigger.cfg_anlg_window_start_trig(
+        window_top=window_top, window_bottom=window_bottom, trigger_source=trig_src, trigger_when=trig_when
+    )
+
+    assert (
+        sim_6363_ai_voltage_task.triggers.start_trigger.anlg_win_src
+        == f"/{device_name}/{trig_src}"
+    )
+    assert sim_6363_ai_voltage_task.triggers.start_trigger.anlg_win_top == pytest.approx(window_top, abs=0.001)
+    assert sim_6363_ai_voltage_task.triggers.start_trigger.anlg_win_btm == pytest.approx(window_bottom, abs=0.001)
+    assert sim_6363_ai_voltage_task.triggers.start_trigger.anlg_win_trig_when ==trig_when
+
+
+def test___start_trigger___disable___no_errors(
+    sim_6363_ai_voltage_task: Task,
+):
+    device_name = sim_6363_ai_voltage_task.devices[0].name
+
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.start_trigger.disable_start_trig()
+
+    assert sim_6363_ai_voltage_task.triggers.start_trigger.trig_type == TriggerType.NONE
+
+
+def test___reference_trigger___disable___no_errors(
+    sim_6363_ai_voltage_task: Task,
+):
+    device_name = sim_6363_ai_voltage_task.devices[0].name
+
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.reference_trigger.disable_ref_trig()
+
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.trig_type == TriggerType.NONE
+
+
+@pytest.mark.parametrize(
+    "window_top, window_bottom, pretrigger_samples, trig_src, trig_when",
+    [
+        (8.456, 3.9, 6, "APFI0", WindowTriggerCondition1.ENTERING_WINDOW),
+        (8.456, 3.9, 6, "APFI1", WindowTriggerCondition1.LEAVING_WINDOW),
+    ],
+)
+def test___reference_trigger___cfg_anlg_window_ref_trig___no_errors(
+    sim_6363_ai_voltage_task: Task,
+    window_top: float,
+    window_bottom: float,
+    pretrigger_samples: int,
+    trig_src: str,
+    trig_when: int,
+):
+    device_name = sim_6363_ai_voltage_task.devices[0].name
+
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.reference_trigger.cfg_anlg_window_ref_trig(
+        window_top=window_top, window_bottom=window_bottom, pretrigger_samples=pretrigger_samples, trigger_source=trig_src, trigger_when=trig_when
+    )
+
+    assert (
+        sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_win_src
+        == f"/{device_name}/{trig_src}"
+    )
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_win_top == pytest.approx(window_top, abs=0.001)
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_win_btm == pytest.approx(window_bottom, abs=0.001)
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.pretrig_samples == pretrigger_samples
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.anlg_win_trig_when ==trig_when
+
+
+@pytest.mark.parametrize(
     "trig_slopes, trig_levels",
     [
         ([Slope.RISING, Slope.RISING], [2.0, 2.0]),
@@ -216,6 +306,34 @@ def test___start_trigger___cfg_anlg_multi_edge_start_trig___no_errors(
         sim_9775_ai_voltage_multi_edge_task.triggers.start_trigger.anlg_multi_edge_lvls
         == pytest.approx(trig_levels, abs=0.001)
     )
+
+
+@pytest.mark.parametrize(
+    "trig_src, trig_pattern, trig_when",
+    [
+        ("port1/line2, port1/line4", "XX", DigitalPatternCondition.PATTERN_MATCHES),
+        ("port1/line2, port1/line3, port1/line4", "XXX", DigitalPatternCondition.PATTERN_DOES_NOT_MATCH),
+    ],
+)
+def test___start_trigger__cfg_dig_pattern_start_trig___no_errors(
+    sim_6535_di_single_line_task: Task,
+    trig_src: str,
+    trig_pattern: str,
+    trig_when: int,
+):
+    sim_6535_di_single_line_task.timing.cfg_samp_clk_timing(1000)
+    sim_6535_di_single_line_task.triggers.start_trigger.cfg_dig_pattern_start_trig(
+        trigger_source=trig_src,
+        trigger_pattern=trig_pattern,
+        trigger_when=trig_when,
+    )
+
+    assert (
+        sim_6535_di_single_line_task.triggers.start_trigger.dig_pattern_src.name
+        == f"{trig_src}"
+    )
+    assert sim_6535_di_single_line_task.triggers.start_trigger.dig_pattern_pattern == trig_pattern
+    assert sim_6535_di_single_line_task.triggers.start_trigger.dig_pattern_trig_when == trig_when
 
 
 @pytest.mark.parametrize(
@@ -298,3 +416,64 @@ def test___reference_trigger___cfg_anlg_multi_edge_ref_trig___no_errors(
         sim_9775_ai_voltage_multi_edge_task.triggers.reference_trigger.anlg_multi_edge_lvls
         == pytest.approx(trig_levels, abs=0.001)
     )
+
+
+@pytest.mark.parametrize(
+    "trig_src, pretrig_samples, trig_edge",
+    [
+        ("APFI0", 10, Edge.RISING),
+        ("APFI1", 20, Edge.FALLING),
+    ],
+)
+def test___reference_trigger___cfg_dig_edge_ref_trig___no_errors(
+    sim_6363_ai_voltage_task: Task,
+    trig_src: str,
+    pretrig_samples: int,
+    trig_edge: Edge,
+):
+    device_name = sim_6363_ai_voltage_task.devices[0].name
+
+    sim_6363_ai_voltage_task.timing.cfg_samp_clk_timing(1000)
+    sim_6363_ai_voltage_task.triggers.reference_trigger.cfg_dig_edge_ref_trig(
+        trigger_source=trig_src,
+        pretrigger_samples=pretrig_samples,
+        trigger_edge=trig_edge,
+    )
+
+    assert (
+        sim_6363_ai_voltage_task.triggers.reference_trigger.dig_edge_src
+        == f"/{device_name}/{trig_src}"
+    )
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.pretrig_samples == pretrig_samples
+    assert sim_6363_ai_voltage_task.triggers.reference_trigger.dig_edge_edge == trig_edge
+
+
+@pytest.mark.parametrize(
+    "trig_src, trig_pattern, pretrig_samples, trig_when",
+    [
+        ("port1/line2, port1/line4", "XX", 10, DigitalPatternCondition.PATTERN_MATCHES),
+        ("port1/line2, port1/line3, port1/line4", "XXX", 20, DigitalPatternCondition.PATTERN_DOES_NOT_MATCH),
+    ],
+)
+def test___reference_trigger__cfg_dig_pattern_ref_trig___no_errors(
+    sim_6535_di_single_line_task: Task,
+    trig_src: str,
+    trig_pattern: str,
+    pretrig_samples: int,
+    trig_when: int,
+):
+    sim_6535_di_single_line_task.timing.cfg_samp_clk_timing(1000)
+    sim_6535_di_single_line_task.triggers.reference_trigger.cfg_dig_pattern_ref_trig(
+        trigger_source=trig_src,
+        trigger_pattern=trig_pattern,
+        pretrigger_samples=pretrig_samples,
+        trigger_when=trig_when,
+    )
+
+    assert (
+        sim_6535_di_single_line_task.triggers.reference_trigger.dig_pattern_src.name
+        == f"{trig_src}"
+    )
+    assert sim_6535_di_single_line_task.triggers.reference_trigger.dig_pattern_pattern == trig_pattern
+    assert sim_6535_di_single_line_task.triggers.reference_trigger.pretrig_samples == pretrig_samples
+    assert sim_6535_di_single_line_task.triggers.reference_trigger.dig_pattern_trig_when == trig_when

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,12 @@ def sim_6363_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
 
 
 @pytest.fixture(scope="function")
+def sim_6535_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
+    """Gets simulated 6535 device information."""
+    return _device_by_product_type("PCIe-6535", DeviceType.SIMULATED, system)
+
+
+@pytest.fixture(scope="function")
 def sim_9189_device(system: nidaqmx.system.System) -> nidaqmx.system.Device:
     """Gets simulated 9185 device information."""
     return _device_by_product_type("cDAQ-9189", DeviceType.SIMULATED, system)

--- a/tests/max_config/linux/nidaqmxMaxConfig.ini
+++ b/tests/max_config/linux/nidaqmxMaxConfig.ini
@@ -188,6 +188,15 @@ BusType = PCIe
 PCI.BusNum = 0x0
 PCI.DevNum = 0x0
 
+[DAQmxDevice digitalPatternTester]
+ProductType = PCIe-6535
+DevSerialNum = 0x0
+DevIsSimulated = 1
+ProductNum = 0x719F
+BusType = PCIe
+PCI.BusNum = 0x0
+PCI.DevNum = 0x0
+
 [DAQmxDevice positionTester]
 ProductType = PXIe-4340
 DevSerialNum = 0x0

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -195,6 +195,15 @@ BusType = PCIe
 PCI.BusNum = 0x0
 PCI.DevNum = 0x0
 
+[DAQmxDevice digitalPatternTester]
+ProductType = PCIe-6535
+DevSerialNum = 0x0
+DevIsSimulated = 1
+ProductNum = 0x719F
+BusType = PCIe
+PCI.BusNum = 0x0
+PCI.DevNum = 0x0
+
 [DAQmxDevice positionTester]
 ProductType = PXIe-4340
 DevSerialNum = 0x0


### PR DESCRIPTION
- [ x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

add python test for trigger APIs

### Why should this Pull Request be merged?

several trigger C APIs are not tested by python test, add test to set appropriate trigger attribute, read back and check attribute values, also add 6535 simulated device for digital pattern.

### What testing has been done?

poetry run pytest .\tests\component\task\test_triggers.py