### PR TITLE
tests: Fix tests that relied on NumPy 1.x integer promotion

### DIFF
--- a/tests/component/test_stream_readers_ai.py
+++ b/tests/component/test_stream_readers_ai.py
@@ -212,7 +212,8 @@ def test___analog_unscaled_reader___read_uint16___returns_valid_samples(
     expected_vals = [
         _get_voltage_code_offset_for_chan(chan_index) for chan_index in range(num_channels)
     ]
-    assert data == pytest.approx(expected_vals, abs=VOLTAGE_CODE_EPSILON)
+    # Promote to larger signed type to avoid overflow w/NumPy 2.0+.
+    assert data.astype(numpy.int32) == pytest.approx(expected_vals, abs=VOLTAGE_CODE_EPSILON)
 
 
 def test___analog_unscaled_reader___read_uint16___raises_error_with_correct_dtype(
@@ -278,7 +279,8 @@ def test___analog_unscaled_reader___read_uint32___returns_valid_samples(
     expected_vals = [
         _get_voltage_code_offset_for_chan(chan_index) for chan_index in range(num_channels)
     ]
-    assert data == pytest.approx(expected_vals, abs=VOLTAGE_CODE_EPSILON)
+    # Promote to larger signed type to avoid overflow w/NumPy 2.0+.
+    assert data.astype(numpy.int64) == pytest.approx(expected_vals, abs=VOLTAGE_CODE_EPSILON)
 
 
 def test___analog_unscaled_reader___read_uint32___raises_error_with_correct_dtype(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change `AnalogUnscaledReader` unsigned data type tests to explicitly promote to a larger signed type before comparing to `pytest.approx`. NumPy 1.x did this promotion automatically, but NumPy 2.x preserves the unsigned data type, leading to integer overflows.

### Why should this Pull Request be merged?

Fixes #600 

### What testing has been done?

Ran updated tests with Python 3.9 64-bit on Windows, with both NumPy 1.26 and NumPy 2.0.