### PR TITLE
GitHub: Upgrade to upload/download-artifact v4

### DIFF
--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: test_results
           path: test_results
+          pattern: test_results_*
+          merge-multiple: true
       - name: List downloaded files
         run: ls -lR
       - name: Publish test results

--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -38,8 +38,8 @@ jobs:
           done
         if: always() && runner.os != 'Windows'
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_results
+          name: test_results_system_${{ matrix.configuration }}
           path: test_results/*.xml
         if: always()

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Run unit tests
         run: poetry run pytest -v --cov=generated/nidaqmx --junitxml=test_results/unit-${{ matrix.os }}-py${{ matrix.python-version }}.xml tests/unit
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_results
+          name: test_results_unit_${{ matrix.os }}_py${{ matrix.python-version }}
           path: test_results/*.xml
         if: always()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Upgrade to `actions/upload-artifact@v4` and `actions/download-artifact@v4`.

### Why should this Pull Request be merged?

Fixes #464 

v3 will be deprecated later this year.

### What testing has been done?

PR build.