### PR TITLE
Remove all grpc_xfail for AB#2393811 and requiring newer gRPC Device …

### DIFF
--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -47,10 +47,6 @@ def test___supported_encoding___reset_nonexistent_device___returns_error_with_de
     assert exc_info.value.error_code == DAQmxErrors.INVALID_DEVICE_ID
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 @pytest.mark.parametrize(
     "file_path, supported_encodings",
     [
@@ -71,10 +67,6 @@ def test___supported_encoding___logging_file_path___returns_assigned_value(
     assert ai_task.in_stream.logging_file_path == pathlib.Path(file_path)
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 @pytest.mark.parametrize(
     "file_path, supported_encodings",
     [
@@ -96,10 +88,6 @@ def test___supported_encoding___configure_logging___returns_assigned_values(
     assert ai_task.in_stream.logging_file_path == pathlib.Path(file_path)
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 @pytest.mark.parametrize(
     "file_path, supported_encodings",
     [

--- a/tests/acceptance/test_multi_threading.py
+++ b/tests/acceptance/test_multi_threading.py
@@ -13,7 +13,6 @@ import pytest
 
 from nidaqmx import Task
 from nidaqmx.constants import AcquisitionType
-from nidaqmx.errors import RpcError
 from nidaqmx.system import Device, System
 from nidaqmx.task.channels import AIChannel
 from tests.helpers import generate_random_seed

--- a/tests/acceptance/test_multi_threading.py
+++ b/tests/acceptance/test_multi_threading.py
@@ -201,9 +201,6 @@ def test___shared_interpreter___run_multiple_acquisitions_with_events___callback
         assert all(status == 0 for status in done_statuses)
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___shared_interpreter___unregister_events_during_other_acquisitions_with_events___callbacks_invoked(
     init_kwargs,
     multi_threading_test_devices: Sequence[Device],

--- a/tests/component/system/test_device.py
+++ b/tests/component/system/test_device.py
@@ -38,9 +38,6 @@ def test___self_test_device___no_errors(sim_6363_device: Device) -> None:
     sim_6363_device.self_test_device()
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 def test___restore_last_ext_cal_const___no_errors(sim_6363_device: Device) -> None:
     sim_6363_device.restore_last_ext_cal_const()
 

--- a/tests/component/system/test_device.py
+++ b/tests/component/system/test_device.py
@@ -1,6 +1,3 @@
-import pytest
-
-from nidaqmx.errors import RpcError
 from nidaqmx.system import Device
 
 

--- a/tests/component/system/test_device_properties.py
+++ b/tests/component/system/test_device_properties.py
@@ -58,10 +58,6 @@ def test___device___list_of_float_property___returns_value(device):
     assert ai_bridge_ranges == [-0.025, 0.025, -0.1, 0.1]
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later",
-    raises=DaqError,
-)
 @pytest.mark.device_name("bridgeTester")
 def test___device___list_of_enum_property___returns_value(device):
     ai_trigger_usage = device.ai_trig_usage

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -42,7 +42,6 @@ def test___physical_channel_with_teds___get_bit_stream___returns_configured_valu
         assert (phys_chan.teds_bit_stream == expected_value).all()
 
 
-@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___physical_channel___get_int32_array_property___returns_default_value(
     sim_6363_device,
 ):

--- a/tests/component/task/test_in_stream.py
+++ b/tests/component/task/test_in_stream.py
@@ -7,7 +7,6 @@ import pytest
 import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import AcquisitionType, LoggingMode, LoggingOperation
-from nidaqmx.errors import DaqError
 
 # With a simulated X Series, setting ai_max/min to +/-2.5 V coerces the hardware range
 # to +/-5 V and generates a noisy sine wave with range +/-2.5 V (raw: about +/-16383).

--- a/tests/component/task/test_in_stream.py
+++ b/tests/component/task/test_in_stream.py
@@ -196,10 +196,6 @@ def test___odd_sized_array___read_into___returns_whole_samples_and_clears_paddin
     assert data[-1] == 0  # not FULLSCALE_RAW_MIN
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___valid_path___configure_logging___returns_assigned_values(ai_task: nidaqmx.Task):
     expected_file_path = "Testing File.tdms"
     expected_group_name = "Task"
@@ -219,10 +215,6 @@ def test___valid_path___configure_logging___returns_assigned_values(ai_task: nid
     assert ai_task.in_stream.logging_tdms_operation == expected_logging_operation
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___valid_path___start_new_file___returns_assigned_value(ai_task: nidaqmx.Task):
     expected_file_path = "Testing File.tdms"
     ai_task.in_stream.start_new_file(expected_file_path)

--- a/tests/component/task/test_in_stream_read_properties.py
+++ b/tests/component/task/test_in_stream_read_properties.py
@@ -123,38 +123,22 @@ def test___ai_task___reset_bool_property___returns_default_value(ai_task: Task):
     assert not ai_task.in_stream.logging_pause
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
     assert ai_task.in_stream.logging_file_path is None
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"  # type: ignore[assignment] # https://github.com/ni/nidaqmx-python/issues/613
 
     assert ai_task.in_stream.logging_file_path == pathlib.Path("TestData.tdms")
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___ai_task___set_string_property_none___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = None
 
     assert ai_task.in_stream.logging_file_path is None
 
 
-@pytest.mark.grpc_xfail(
-    reason="AB#2393811: DAQmxGetLoggingFilePath returns kErrorNULLPtr (-200604) when called from grpc-device.",
-    raises=DaqError,
-)
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
     ai_task.in_stream.logging_file_path = "TestData.tdms"  # type: ignore[assignment] # https://github.com/ni/nidaqmx-python/issues/613
 

--- a/tests/component/task/test_in_stream_read_properties.py
+++ b/tests/component/task/test_in_stream_read_properties.py
@@ -3,7 +3,6 @@ import pathlib
 import pytest
 
 from nidaqmx.constants import OverwriteMode, ReadRelativeTo
-from nidaqmx.errors import DaqError
 from nidaqmx.task import Task
 
 

--- a/tests/component/test_task.py
+++ b/tests/component/test_task.py
@@ -4,7 +4,6 @@ import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import ShuntCalSelect, ShuntCalSource, ShuntElementLocation
 from nidaqmx.error_codes import DAQmxErrors
-from nidaqmx.errors import RpcError
 from nidaqmx.system.storage import PersistedChannel
 
 

--- a/tests/component/test_task.py
+++ b/tests/component/test_task.py
@@ -61,9 +61,6 @@ def test___tasks_with_different_names___hash___not_equal(generate_task):
     assert hash(task1) != hash(task2)
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.device_name("bridgeTester")
 @pytest.mark.parametrize("skip_unsupported_channels", [True, False])
 def test___arguments_specified___perform_bridge_offset_nulling_cal___no_errors(
@@ -74,9 +71,6 @@ def test___arguments_specified___perform_bridge_offset_nulling_cal___no_errors(
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.device_name("bridgeTester")
 def test___default_arguments___perform_bridge_offset_nulling_cal___no_errors(
     ai_bridge_task: nidaqmx.Task,
@@ -85,9 +79,6 @@ def test___default_arguments___perform_bridge_offset_nulling_cal___no_errors(
 
 
 @pytest.mark.device_name("bridgeTester")
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.parametrize(
     "shunt_resistor_value, shunt_resistor_location, shunt_resistor_select, shunt_resistor_source, bridge_resistance, skip_unsupported_channels",
     [
@@ -122,9 +113,6 @@ def test___perform_bridge_shunt_cal___no_errors(
 
 
 @pytest.mark.device_name("bridgeTester")
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 def test___perform_bridge_shunt_cal_default___no_errors(
     ai_bridge_task: nidaqmx.Task,
 ) -> None:
@@ -136,9 +124,6 @@ def test___perform_bridge_shunt_cal_default___no_errors(
 
 
 @pytest.mark.device_name("bridgeTester")
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.parametrize(
     "shunt_resistor_value, shunt_resistor_location, shunt_resistor_select, shunt_resistor_source, skip_unsupported_channels",
     [
@@ -171,9 +156,6 @@ def test___perform_strain_shunt_cal___no_errors(
 
 
 @pytest.mark.device_name("bridgeTester")
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 def test___perform_strain_shunt_cal_default___no_errors(
     ai_strain_gage_task: nidaqmx.Task,
 ) -> None:
@@ -184,9 +166,6 @@ def test___perform_strain_shunt_cal_default___no_errors(
             raise
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.device_name("cDAQ1Mod2")
 @pytest.mark.parametrize("skip_unsupported_channels", [True, False])
 def test___arguments_specified___perform_thrmcpl_lead_offset_nulling_cal___no_errors(
@@ -197,9 +176,6 @@ def test___arguments_specified___perform_thrmcpl_lead_offset_nulling_cal___no_er
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.5 or later", raises=RpcError
-)
 @pytest.mark.device_name("cDAQ1Mod2")
 def test___default_arguments___perform_thrmcpl_lead_offset_nulling_cal___no_errors(
     ai_thermocouple_task: nidaqmx.Task,

--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -10,7 +10,7 @@ import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import AcquisitionType, EveryNSamplesEventType, Signal
 from nidaqmx.error_codes import DAQmxErrors
-from nidaqmx.errors import DaqResourceWarning, RpcError
+from nidaqmx.errors import DaqResourceWarning
 from nidaqmx.task import _TaskEventType
 from tests._event_utils import (
     DoneEventObserver,

--- a/tests/component/test_task_events.py
+++ b/tests/component/test_task_events.py
@@ -212,9 +212,6 @@ def test___signal_event_registered___run_finite_acquisition___callback_invoked_n
     assert all(e.signal_type == Signal.SAMPLE_COMPLETE.value for e in event_observer.events)
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___done_event_unregistered___run_finite_acquisition___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -233,9 +230,6 @@ def test___done_event_unregistered___run_finite_acquisition___callback_not_invok
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___every_n_samples_event_unregistered___run_finite_acquisition___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -256,9 +250,6 @@ def test___every_n_samples_event_unregistered___run_finite_acquisition___callbac
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___signal_event_unregistered___run_finite_acquisition___callback_not_invoked(
     ai_task_with_real_device: nidaqmx.Task,
 ) -> None:
@@ -326,9 +317,6 @@ def test___done_and_every_n_samples_events_registered___run_multiple_finite_acqu
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___ai_task____run_multiple_finite_acquisitions_with_varying_every_n_samples_event_interval___callbacks_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -361,9 +349,6 @@ def test___ai_task____run_multiple_finite_acquisitions_with_varying_every_n_samp
     ] == every_n_samples_event_counts
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=AssertionError
-)
 def test___done_event_registered___register_done_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -379,9 +364,6 @@ def test___done_event_registered___register_done_event___already_registered_erro
     assert exc_info.value.error_code == DAQmxErrors.DONE_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=AssertionError
-)
 def test___every_n_samples_acquired_into_buffer_event_registered___register_every_n_samples_acquired_into_buffer_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -404,9 +386,6 @@ def test___every_n_samples_acquired_into_buffer_event_registered___register_ever
     )
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=AssertionError
-)
 def test___every_n_samples_transferred_from_buffer_event_registered___register_every_n_samples_transferred_from_buffer_event___already_registered_error_raised(
     ao_task: nidaqmx.Task,
 ) -> None:
@@ -429,7 +408,6 @@ def test___every_n_samples_transferred_from_buffer_event_registered___register_e
     )
 
 
-@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___signal_event_registered___register_signal_event___already_registered_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -445,7 +423,6 @@ def test___signal_event_registered___register_signal_event___already_registered_
     assert exc_info.value.error_code == DAQmxErrors.SIGNAL_EVENT_ALREADY_REGISTERED
 
 
-@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -465,7 +442,6 @@ def test___ai_task___register_wrong_every_n_samples_event___not_supported_by_dev
     )
 
 
-@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___ao_task___register_wrong_every_n_samples_event___not_supported_by_device_error_raised(
     ao_task: nidaqmx.Task,
 ) -> None:
@@ -485,7 +461,6 @@ def test___ao_task___register_wrong_every_n_samples_event___not_supported_by_dev
     )
 
 
-@pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
 def test___task___register_unregister_done_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -498,9 +473,6 @@ def test___task___register_unregister_done_event___callback_not_invoked(
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___task___register_unregister_every_n_samples_acquired_into_buffer_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:
@@ -515,9 +487,6 @@ def test___task___register_unregister_every_n_samples_acquired_into_buffer_event
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___task___register_unregister_every_n_samples_transferred_from_buffer_event___callback_not_invoked(
     ao_task: nidaqmx.Task,
 ) -> None:
@@ -532,9 +501,6 @@ def test___task___register_unregister_every_n_samples_transferred_from_buffer_ev
     assert len(event_observer.events) == 0
 
 
-@pytest.mark.grpc_xfail(
-    reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-)
 def test___task___register_unregister_signal_event___callback_not_invoked(
     ai_task: nidaqmx.Task,
 ) -> None:

--- a/tests/legacy/test_events.py
+++ b/tests/legacy/test_events.py
@@ -16,9 +16,6 @@ class TestEvents:
     This validate the NI-DAQmx events functionality in the Python NI-DAQmx API.
     """
 
-    @pytest.mark.grpc_xfail(
-        reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-    )
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_every_n_samples_event(self, task, sim_6363_device, seed):
         """Test for validating every n samples event."""

--- a/tests/legacy/test_events.py
+++ b/tests/legacy/test_events.py
@@ -6,7 +6,6 @@ import time
 import pytest
 
 from nidaqmx.constants import AcquisitionType
-from nidaqmx.errors import RpcError
 from tests.helpers import generate_random_seed
 
 

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -7,7 +7,6 @@ import nidaqmx
 import nidaqmx.stream_readers
 from nidaqmx.constants import AcquisitionType, BusType, Level, TaskMode
 from nidaqmx.error_codes import DAQmxErrors
-from nidaqmx.errors import RpcError
 
 
 class TestReadExceptions:

--- a/tests/legacy/test_read_exceptions.py
+++ b/tests/legacy/test_read_exceptions.py
@@ -18,9 +18,6 @@ class TestReadExceptions:
     loopback routes on the device.
     """
 
-    @pytest.mark.grpc_xfail(
-        reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-    )
     def test_timeout(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.
@@ -77,9 +74,6 @@ class TestReadExceptions:
         number_of_samples_expected = clocks_to_give - samples_to_read
         assert timeout_exception.value.samps_per_chan_read == number_of_samples_expected
 
-    @pytest.mark.grpc_xfail(
-        reason="Requires NI gRPC Device Server version 2.2 or later", raises=RpcError
-    )
     def test_timeout_raw(self, generate_task, real_x_series_device):
         """Test for validating read timeout."""
         # USB streaming is very tricky.

--- a/tests/legacy/test_read_write.py
+++ b/tests/legacy/test_read_write.py
@@ -770,7 +770,6 @@ class TestPowerRead(TestDAQmxIOBase):
         # We aren't validating data, just assuring that it doesn't fail.
         values_read = task.read(number_of_samples_per_channel=10)  # noqa: F841
 
-    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
     @pytest.mark.parametrize("seed", [generate_random_seed()])
     def test_mixed_chans_with_power(self, task, sim_ts_power_device, sim_ts_voltage_device, seed):
         """Test to validate mixed channels with power."""

--- a/tests/legacy/test_write_exceptions.py
+++ b/tests/legacy/test_write_exceptions.py
@@ -17,7 +17,6 @@ class TestWriteExceptions:
     loopback routes on the device.
     """
 
-    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
     def test_overwrite(self, task, real_x_series_device):
         """Test to validate overwrite functionality."""
         # USB streaming is very tricky.
@@ -68,7 +67,6 @@ class TestWriteExceptions:
         # need to get into the nitty gritty device details on how much.
         assert timeout_exception.value.samps_per_chan_written > 0
 
-    @pytest.mark.grpc_xfail(reason="Requires NI gRPC Device Server version 2.2 or later")
     def test_overwrite_during_prime(self, task, real_x_series_device):
         """Test to validate overwrite functionality during prime."""
         # USB streaming is very tricky.


### PR DESCRIPTION
…Server

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Clean up tests to remove grpc_xfail marks that are now expected to pass.

### Why should this Pull Request be merged?

More accurately show expectations regarding which tests should pass.

### What testing has been done?

PR