### PR TITLE
Add tests for reading and writing digital lines with varying lines pe…

### DIFF
--- a/tests/component/test_stream_readers_di.py
+++ b/tests/component/test_stream_readers_di.py
@@ -9,10 +9,7 @@ import pytest
 import nidaqmx
 import nidaqmx.system
 from nidaqmx.constants import LineGrouping
-from nidaqmx.stream_readers import (
-    DigitalMultiChannelReader,
-    DigitalSingleChannelReader,
-)
+from nidaqmx.stream_readers import DigitalMultiChannelReader, DigitalSingleChannelReader
 from nidaqmx.utils import flatten_channel_string
 
 
@@ -397,6 +394,25 @@ def test___digital_multi_channel_reader___read_one_sample_multi_line___returns_v
 
     assert [_bool_array_to_int(sample[:, 0]) for sample in data] == _get_expected_digital_data(
         num_channels, samples_to_read
+    )
+
+
+def test___digital_multi_channel_reader___read_one_sample_multi_line_jagged___returns_valid_samples(
+    di_multi_channel_port_uint32_task: nidaqmx.Task,
+) -> None:
+    reader = DigitalMultiChannelReader(di_multi_channel_port_uint32_task.in_stream)
+    num_channels = di_multi_channel_port_uint32_task.number_of_channels
+    samples_to_read = 256
+    sample = numpy.full((num_channels, 32), False, dtype=numpy.bool_)
+
+    data = [
+        _read_and_copy(reader.read_one_sample_multi_line, sample) for _ in range(samples_to_read)
+    ]
+
+    assert [
+        [_bool_array_to_int(sample[chan, :]) for chan in range(num_channels)] for sample in data
+    ] == _get_expected_digital_port_data_sample_major(
+        di_multi_channel_port_uint32_task, samples_to_read
     )
 
 

--- a/tests/component/test_stream_writers_do.py
+++ b/tests/component/test_stream_writers_do.py
@@ -445,7 +445,7 @@ def test___digital_multi_channel_writer___write_one_sample_multi_line_jagged___u
     _start_do_task(task, is_port=True, num_chans=task.number_of_channels)
     writer = DigitalMultiChannelWriter(task.out_stream)
     num_channels = task.number_of_channels
-    samples_to_write = 256
+    samples_to_write = 0xA5
 
     # "sweep" up to the final value, the only one we'll validate
     for datum in _get_digital_data(num_channels * 32, samples_to_write):


### PR DESCRIPTION
…r channel

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This pull request adds two tests that validate reading and writing digital lines when multiple ports are active with different line counts. The tests are written to work with a PXIe-6363 with 32 lines on port 0 and 8 lines on ports 1 and 2. The tests ensure that the reads and writes complete successfully and provide minimal data validation.

The linter also corrected one line with incorrect style which I included in the PR.

### Why should this Pull Request be merged?

Increase test coverage

### What testing has been done?

Tests were run locally and pass