### PR TITLE
GitHub: Auto-cancel PR builds when new changes are pushed

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -7,6 +7,11 @@ on:
       - 'releases/**'
   workflow_call:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_ci:
     name: Run CI


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable `concurrency.cancel-in-progress` for PR.yml, like @maxxboehme did in https://github.com/ni/grpc-device/pull/1104

### Why should this Pull Request be merged?

Minimize resource usage when pushing multiple changes.

### What testing has been done?

Tested cancellation behavior by pushing multiple updates to https://github.com/ni/measurement-plugin-python/pull/972