### PR TITLE
return ascii encoding when locale is not set

### DIFF
--- a/generated/nidaqmx/_lib.py
+++ b/generated/nidaqmx/_lib.py
@@ -120,6 +120,14 @@ compatibility because uInt32 and void* are the same size for 32-bit applications
 """
 
 
+def get_encoding_from_locale():
+    """
+    Gets the current locale encoding handling cases where it is unset.
+    """
+    _, encoding = locale.getlocale()
+    return encoding or 'ascii'
+
+
 class DaqLibImporter:
     """
     Encapsulates NI-DAQmx library importing and handle type parsing logic.
@@ -157,7 +165,7 @@ class DaqLibImporter:
         if self._encoding is None:
             self._import_lib()
         return self._encoding
-        
+
     def _import_lib(self):
         """
         Determines the location of and loads the NI-DAQmx CAI DLL.
@@ -185,7 +193,7 @@ class DaqLibImporter:
                 try: 
                     if nidaqmx_c_library=="nicaiu":
                         windll, cdll = _load_lib("nicaiu")
-                        encoding = locale.getlocale()[1]
+                        encoding = get_encoding_from_locale()
                     elif nidaqmx_c_library=="nicai_utf8":
                         windll, cdll = _load_lib("nicai_utf8")
                         encoding = 'utf-8'  
@@ -201,7 +209,7 @@ class DaqLibImporter:
                     # Fallback to nicaiu.dll if nicai_utf8.dll cannot be loaded
                     try:
                         windll, cdll = _load_lib("nicaiu")
-                        encoding = locale.getlocale()[1]
+                        encoding = get_encoding_from_locale()
                     except (OSError, WindowsError) as e:
                         raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE) from e       
         elif sys.platform.startswith('linux'):
@@ -209,7 +217,7 @@ class DaqLibImporter:
             if library_path is not None:
                 cdll = ctypes.cdll.LoadLibrary(library_path)
                 windll = cdll
-                encoding = locale.getlocale()[1]
+                encoding = get_encoding_from_locale()
             else:
                 raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE)
         else:

--- a/src/handwritten/_lib.py
+++ b/src/handwritten/_lib.py
@@ -120,6 +120,14 @@ compatibility because uInt32 and void* are the same size for 32-bit applications
 """
 
 
+def get_encoding_from_locale():
+    """
+    Gets the current locale encoding handling cases where it is unset.
+    """
+    _, encoding = locale.getlocale()
+    return encoding or 'ascii'
+
+
 class DaqLibImporter:
     """
     Encapsulates NI-DAQmx library importing and handle type parsing logic.
@@ -157,7 +165,7 @@ class DaqLibImporter:
         if self._encoding is None:
             self._import_lib()
         return self._encoding
-        
+
     def _import_lib(self):
         """
         Determines the location of and loads the NI-DAQmx CAI DLL.
@@ -185,7 +193,7 @@ class DaqLibImporter:
                 try: 
                     if nidaqmx_c_library=="nicaiu":
                         windll, cdll = _load_lib("nicaiu")
-                        encoding = locale.getlocale()[1]
+                        encoding = get_encoding_from_locale()
                     elif nidaqmx_c_library=="nicai_utf8":
                         windll, cdll = _load_lib("nicai_utf8")
                         encoding = 'utf-8'  
@@ -201,7 +209,7 @@ class DaqLibImporter:
                     # Fallback to nicaiu.dll if nicai_utf8.dll cannot be loaded
                     try:
                         windll, cdll = _load_lib("nicaiu")
-                        encoding = locale.getlocale()[1]
+                        encoding = get_encoding_from_locale()
                     except (OSError, WindowsError) as e:
                         raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE) from e       
         elif sys.platform.startswith('linux'):
@@ -209,7 +217,7 @@ class DaqLibImporter:
             if library_path is not None:
                 cdll = ctypes.cdll.LoadLibrary(library_path)
                 windll = cdll
-                encoding = locale.getlocale()[1]
+                encoding = get_encoding_from_locale()
             else:
                 raise DaqNotFoundError(_DAQ_NOT_FOUND_MESSAGE)
         else:

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
-from nidaqmx._lib import lib_importer
+from nidaqmx._lib import lib_importer, get_encoding_from_locale
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.system import Device
@@ -20,7 +20,7 @@ def ai_task(task, sim_6363_device):
 def _get_encoding(obj: Union[Task, Dict[str, Any]]) -> Optional[str]:
     if getattr(obj, "_grpc_options", None) or (isinstance(obj, dict) and "grpc_options" in obj):
         # gRPC server limited to MBCS encoding
-        return locale.getlocale()[1]
+        return get_encoding_from_locale()
     else:
         return lib_importer.encoding
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fall back to "ascii" encoding if the locale isn't set (and we aren't using utf8 APIs)

### Why should this Pull Request be merged?

Closes #641 

### What testing has been done?

```
$ poetry run pytest -k internationalization
```