### PR TITLE
tests: Update cal date check to pass on older devices

### DIFF
--- a/tests/component/system/test_device_properties.py
+++ b/tests/component/system/test_device_properties.py
@@ -116,7 +116,7 @@ def test___ext_cal_last_date_and_time___no_errors(real_x_series_device: Device) 
     last_date_and_time = real_x_series_device.ext_cal_last_date_and_time
 
     assert type(last_date_and_time) is datetime
-    assert last_date_and_time.year > 2009
+    assert last_date_and_time.year >= 2009
     assert last_date_and_time.month >= 1
     assert last_date_and_time.day > 0
     assert last_date_and_time.hour >= 0
@@ -127,7 +127,7 @@ def test___self_cal_last_date_and_time___no_errors(real_x_series_device: Device)
     last_date_and_time = real_x_series_device.self_cal_last_date_and_time
 
     assert type(last_date_and_time) is datetime
-    assert last_date_and_time.year > 2009
+    assert last_date_and_time.year >= 2009
     assert last_date_and_time.month >= 1
     assert last_date_and_time.day > 0
     assert last_date_and_time.hour >= 0


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the cal date check in `test_device_properties.py` to accept 2009 as a valid date.

### Why should this Pull Request be merged?

X Series was released in 2009. My test machine has an X Series from 2009 that has never been recalibrated.

### What testing has been done?

Works on my machine.
