### PR TITLE
nidaqmx: Add Python 3.13 trove classifier and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 * [1.1.0](#110)
+* [1.0.2](#102)
 * [1.0.1](#101)
 * [1.0.0](#100)
 * [0.9.0](#090)
@@ -27,6 +28,16 @@ All notable changes to this project will be documented in this file.
 
 * ### Resolved Issues
     * ...
+
+* ### Known Issues
+    * ...
+
+## 1.0.2
+* ### Merged Pull Requests
+    * [Full changelog: 1.0.1...1.0.2](https://github.com/ni/nidaqmx-python/compare/1.0.1...1.0.2)
+
+* ### Resolved Issues
+    * [644: nidaqmx doesn't support Python 3.13+](https://github.com/ni/nidaqmx-python/issues/644)
 
 * ### Known Issues
     * ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: System :: Hardware :: Hardware Drivers"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the Python 3.13 trove classifier.

Update changelog for 1.0.2.

### Why should this Pull Request be merged?

Show on PyPI that Python 3.13 is supported.

### What testing has been done?

None