### PR TITLE
Add unit test cases for physical property access using mioDAQ

### DIFF
--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -90,7 +90,7 @@ def test___physical_channel___get_int32_property___returns_value():
 
 
 @pytest.mark.library_only(
-    reason="gRPC interpreter doesn't support setting physical channel property."
+    reason="AB#2375679: gRPC interpreter doesn't support setting physical channel property."
 )
 def test___physical_channel___set_int32_property___success():
     phys_chans = PhysicalChannel("mioDAQ/port0")

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -2,7 +2,7 @@ import numpy
 import pytest
 
 from nidaqmx import DaqError
-from nidaqmx.constants import TerminalConfiguration, UsageTypeAI
+from nidaqmx.constants import LogicFamily, TerminalConfiguration, UsageTypeAI
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.system import PhysicalChannel
 from tests.helpers import configure_teds
@@ -81,6 +81,21 @@ def test___physical_channel_with_teds___get_uint32_property___returns_configured
         sim_6363_device.ai_physical_chans["ai0"], voltage_teds_file_path
     ) as phys_chan:
         assert phys_chan.teds_mfg_id == 17
+
+
+def test___physical_channel___get_int32_property___returns_value():
+    phys_chans = PhysicalChannel("mioDAQ/port0")
+
+    assert phys_chans.dig_port_logic_family in LogicFamily
+
+
+@pytest.mark.library_only(
+    reason="gRPC interpreter doesn't support setting physical channel property."
+)
+def test___physical_channel___set_int32_property___success():
+    phys_chans = PhysicalChannel("mioDAQ/port0")
+
+    phys_chans.dig_port_logic_family = LogicFamily.ONE_POINT_EIGHT_V
 
 
 VALUES_IN_TED = [

--- a/tests/max_config/nidaqmxMaxConfig.ini
+++ b/tests/max_config/nidaqmxMaxConfig.ini
@@ -293,3 +293,10 @@ DevSerialNum = 0x0
 DevIsSimulated = 1
 CompactDAQ.ChassisDevName = cdaqChassisTester
 CompactDAQ.SlotNum = 5
+
+[DAQmxDevice mioDAQ]
+ProductType = USB-6423
+DevSerialNum = 0x0
+DevIsSimulated = 1
+ProductNum = 0x7B40
+BusType = USB


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~ Not applicable.

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

I notice that there is no test case to test setting of physical property, this PR is trying to add new unit test case for that using mioDAQ. It was supposed to be added in https://github.com/ni/nidaqmx-python/pull/653, however the configurable digital voltage physical property is not supported in simulated device at that time. Now that the property is supported with simulated mioDAQ device, adding test via the property.   

### Why should this Pull Request be merged?

Increase test coverage.

### What testing has been done?

Ran the test with a latest 25.0 DAQmx stack locally (the version that this configurable digital voltage feature is going to be released)  
![image](https://github.com/user-attachments/assets/c0c34210-18a3-4ae5-a98e-b3000408896b)
All other test still passed. 
![image](https://github.com/user-attachments/assets/38cd7a77-f0b2-48d2-965f-d7c898417882)
