### PR TITLE
Fixing port logic family unit tests to skip on Linux

### DIFF
--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -82,13 +82,17 @@ def test___physical_channel_with_teds___get_uint32_property___returns_configured
     ) as phys_chan:
         assert phys_chan.teds_mfg_id == 17
 
-
+@pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="mioDAQ support Windows-only"
+)
 def test___physical_channel___get_int32_property___returns_value():
     phys_chans = PhysicalChannel("mioDAQ/port0")
 
     assert phys_chans.dig_port_logic_family in LogicFamily
 
-
+@pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="mioDAQ support Windows-only"
+)
 @pytest.mark.library_only(
     reason="AB#2375679: gRPC interpreter doesn't support setting physical channel property."
 )

--- a/tests/component/system/test_physical_channel_properties.py
+++ b/tests/component/system/test_physical_channel_properties.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy
 import pytest
 
@@ -82,17 +84,15 @@ def test___physical_channel_with_teds___get_uint32_property___returns_configured
     ) as phys_chan:
         assert phys_chan.teds_mfg_id == 17
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("win"), reason="mioDAQ support Windows-only"
-)
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="mioDAQ support Windows-only")
 def test___physical_channel___get_int32_property___returns_value():
     phys_chans = PhysicalChannel("mioDAQ/port0")
 
     assert phys_chans.dig_port_logic_family in LogicFamily
 
-@pytest.mark.skipif(
-    not sys.platform.startswith("win"), reason="mioDAQ support Windows-only"
-)
+
+@pytest.mark.skipif(not sys.platform.startswith("win"), reason="mioDAQ support Windows-only")
 @pytest.mark.library_only(
     reason="AB#2375679: gRPC interpreter doesn't support setting physical channel property."
 )


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

- [X] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.

~- [ ] I've added tests applicable for this pull request~

### What does this Pull Request accomplish?
This pull-request is to fix the port logic family unit tests on the test_physical_channel_properties.py. As of 25.3, the mioDAQ only support Windows and both get and set port logic family tests are trying to create a simulated device on Linux which causes the test to failed. Hence, I'm marking both of them to skip when it is not Windows.

### Why should this Pull Request be merged?

To fix [BUG 2955106](https://ni.visualstudio.com/DevCentral/_workitems/edit/2955106/)

### What testing has been done?
Successfully build locally:
![image](https://github.com/user-attachments/assets/5d89a85e-ca90-489b-9fca-ec8ec97dc848)

Used the CompTest-u2004 to perform the test on Ubuntu and the tests are passing now:
Before:
![image](https://github.com/user-attachments/assets/f03ddf99-4918-42f8-98bb-6001c60e4490)
After:
![image](https://github.com/user-attachments/assets/24fd6d41-d62f-4e1f-a217-5940a745be4b)