### PR TITLE
Update pep8-naming and fix inconsistently named TypeVar

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1628,13 +1628,13 @@ setuptools = "*"
 
 [[package]]
 name = "pep8-naming"
-version = "0.14.1"
+version = "0.15.0"
 description = "Check PEP-8 naming conventions, plugin for flake8"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pep8-naming-0.14.1.tar.gz", hash = "sha256:1ef228ae80875557eb6c1549deafed4dabbf3261cfcafa12f773fe0db9be8a36"},
-    {file = "pep8_naming-0.14.1-py3-none-any.whl", hash = "sha256:63f514fc777d715f935faf185dedd679ab99526a7f2f503abb61587877f7b1c5"},
+    {file = "pep8_naming-0.15.0-py3-none-any.whl", hash = "sha256:2ce36937ff0421d871a634f4a0c2af06f994fe22c9055ea9813ca72d562754da"},
+    {file = "pep8_naming-0.15.0.tar.gz", hash = "sha256:a637ee5144f7585c800b1fc6eeb996fa35a2ef0f2690880a9e1b29cb9f6e8359"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1628,13 +1628,13 @@ setuptools = "*"
 
 [[package]]
 name = "pep8-naming"
-version = "0.15.0"
+version = "0.15.1"
 description = "Check PEP-8 naming conventions, plugin for flake8"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pep8_naming-0.15.0-py3-none-any.whl", hash = "sha256:2ce36937ff0421d871a634f4a0c2af06f994fe22c9055ea9813ca72d562754da"},
-    {file = "pep8_naming-0.15.0.tar.gz", hash = "sha256:a637ee5144f7585c800b1fc6eeb996fa35a2ef0f2690880a9e1b29cb9f6e8359"},
+    {file = "pep8_naming-0.15.1-py3-none-any.whl", hash = "sha256:eb63925e7fd9e028c7f7ee7b1e413ec03d1ee5de0e627012102ee0222c273c86"},
+    {file = "pep8_naming-0.15.1.tar.gz", hash = "sha256:f6f4a499aba2deeda93c1f26ccc02f3da32b035c8b2db9696b730ef2c9639d29"},
 ]
 
 [package.dependencies]

--- a/tests/component/test_stream_readers_di.py
+++ b/tests/component/test_stream_readers_di.py
@@ -179,7 +179,9 @@ def _bool_array_to_int(bool_array: numpy.typing.NDArray[numpy.bool_]) -> int:
     return result
 
 
-_D = TypeVar("_D", bound=numpy.generic, covariant=True)
+_D = TypeVar(  # noqa: N808 - https://github.com/PyCQA/pep8-naming/issues/245
+    "_D", bound=numpy.generic
+)
 
 
 def _read_and_copy(

--- a/tests/component/test_stream_readers_di.py
+++ b/tests/component/test_stream_readers_di.py
@@ -179,9 +179,7 @@ def _bool_array_to_int(bool_array: numpy.typing.NDArray[numpy.bool_]) -> int:
     return result
 
 
-_D = TypeVar(  # noqa: N808 - https://github.com/PyCQA/pep8-naming/issues/245
-    "_D", bound=numpy.generic
-)
+_D = TypeVar("_D", bound=numpy.generic)
 
 
 def _read_and_copy(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

`poetry update pep8-naming`

Resolve the following failure:
```
./tests/component/test_stream_readers_di.py:182:2: N808 type variable name '_D' should use CapWords convention and an optional '_co' or '_contra' suffix
```

pep8-naming is complaining that `_D` is covariant but it doesn't have a `_co` suffix. This particular type variable doesn't really need to be covariant because the `_read_and_copy` function return type has exactly the same data type as the argument, so I removed the `covariant=True`.

Originally, this also failed because pep8-naming 0.15.0 didn't allow typevars to start with an underscore, but this was fixed in pep8-naming 0.15.1.

### Why should this Pull Request be merged?

Fix an incorrect type variable.

### What testing has been done?

Ran `poetry run nps lint` and `poetry run mypy`