### PR TITLE
pyproject.toml: Fix PEP 660 builds by setting build-system to use poetry-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
     * [Full changelog: 1.1.0...1.2.0](https://github.com/ni/nidaqmx-python/compare/1.1.0...1.2.0)
 
 * ### Resolved Issues
-    * ...
+    * Fix PEP 660 builds by setting `build-system` to use `poetry-core`
 
 * ### Major Changes
     * Removed the `docs` extra and converted it to a Poetry dependency group.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,8 +130,8 @@ markers = [
 ]
 
 [build-system]
-requires = ["poetry>=1.2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.8"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 files = "generated/,tests/"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicabl
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Change the build system from `poetry` to `poetry-core`.

### Why should this Pull Request be merged?

Enables clients to install the `nidaqmx` package in editable mode, outside of this project.

Without this, you get an error like:
```
pip install -e .
Obtaining file:///C:/dev/nidaqmx-python
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
ERROR: Project file:///C:/dev/nidaqmx-python has a 'pyproject.toml' and its build backend is missing the 'build_editable' hook. Since it does not have a 'setup.py' nor a 'setup.cfg', it cannot be installed in editable mode. Consider using a build backend that supports PEP 660.
```

### What testing has been done?

```powershell
cd $env:TEMP
python -m venv .edit_nidaqmx
.\.edit_nidaqmx\Scripts\pip.exe install -e C:\dev\nidaqmx-python\
```