### PR TITLE
github: Specify required permissions for each job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,3 +28,6 @@ jobs:
     uses: ./.github/workflows/report_test_results.yml
     needs: [run_unit_tests, run_system_tests]
     if: always()
+    permissions:
+      checks: write
+      pull-requests: write

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -16,3 +16,6 @@ jobs:
   run_ci:
     name: Run CI
     uses: ./.github/workflows/CI.yml
+    permissions:
+      checks: write
+      pull-requests: write

--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -4,14 +4,13 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  checks: write
-  pull-requests: write
-
 jobs:
   report_test_results:
     name: Report test results
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Currently, this repo's **Workflow permissions** setting is set to **Read and write permissions** (Workflows have read and write permissions in the repository for all scopes.). We should change it to **Read repository contents and packages permissions** (Workflows have read permissions in the repository for the contents and packages scopes only.) to reduce the privileges of jobs that run test code.

Specify permissions on the job level, not the workflow level. Specifying permissions on the workflow level grants the specified permissions to all jobs in the workflow, which gives some jobs permissions that they don't need.

CI.yml has multiple jobs, and only one needs additional privileges. I also updated workflows that have only one job.

### Why should this Pull Request be merged?

Principle of least privilege

### What testing has been done?

Tested the same change in other repos. I won't flip the settings switch until this PR is merged, to avoid affecting other PRs.