### PR TITLE
github: Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,98 @@
+name: Publish nidaqmx
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: The environment to publish to.
+        default: 'none'
+        required: true
+        type: choice
+        options:
+          - none
+          - pypi
+          - testpypi
+
+env:
+  dist-artifact-name: nidaqmx-distribution-packages
+  environment: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+  environment-info: |
+    {
+      "pypi": {
+        "base-url": "https://pypi.org",
+        "upload-url": "https://upload.pypi.org/legacy/"
+      },
+      "testpypi": {
+        "base-url": "https://test.pypi.org",
+        "upload-url": "https://test.pypi.org/legacy/"
+      }
+    }
+
+jobs:
+  check_nidaqmx:
+    name: Check nidaqmx
+    uses: ./.github/workflows/build.yml
+  check_docs:
+    name: Check docs
+    uses: ./.github/workflows/generate_docs.yml
+  build_nidaqmx:
+    name: Build nidaqmx
+    runs-on: ubuntu-latest
+    needs: [check_nidaqmx, check_docs]
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
+      - name: Check project version
+        if: github.event_name == 'release'
+        uses: ni/python-actions/check-project-version@275868c1620d0343a006472f6300bd80f76bbd92 # users/bkeryan/update-project-version
+      - name: Build distribution packages
+        run: poetry build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.dist-artifact-name }}
+          path: dist/*
+  publish_to_pypi:
+    name: Publish nidaqmx to PyPI
+    if: github.event_name == 'release' || inputs.environment != 'none'
+    runs-on: ubuntu-latest
+    needs: [build_nidaqmx]
+    environment:
+      # This logic is duplicated because `name` doesn't support the `env` context.
+      name: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+      url: ${{ fromJson(env.environment-info)[env.environment].base-url }}/p/nidaqmx
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: ${{ env.dist-artifact-name }}
+        path: dist/
+    - run: ls -lR
+    - name: Upload to ${{ env.environment }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ fromJson(env.environment-info)[env.environment].upload-url }} 
+  update_version:
+    name: Update nidaqmx version
+    runs-on: ubuntu-latest
+    needs: [build_nidaqmx]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
+      - name: Update project version
+        uses: ni/python-actions/update-project-version@275868c1620d0343a006472f6300bd80f76bbd92 # users/bkeryan/update-project-version


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Add a GitHub Actions workflow to publish the `nidaqmx` package to PyPI using GitHub as a PyPI "Trusted Publisher".

### Why should this Pull Request be merged?

Enable publishing the package more easily.

### What testing has been done?

Tested in https://github.com/ni/nitypes-python repo. It works when run manually via `workflow_dispatch`. I am trying to work out the remaining bugs with handling of the `github.event_name == 'release'` case, which is easiest to test by creating an actual release of **something**.