### PR TITLE
mypy: Enable --warn-unused-ignores and remove unused ignores

### DIFF
--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -5843,7 +5843,7 @@ class LibraryInterpreter(BaseInterpreter):
                         ctypes.POINTER(ctypes.c_void_p)]
 
         options = 0
-        callback_method_ptr = DAQmxDoneEventCallbackPtr()  # type: ignore  # typeshed is missing no-argument constructor overload
+        callback_method_ptr = DAQmxDoneEventCallbackPtr()
         callback_data = None
 
         error_code = cfunc(
@@ -5867,7 +5867,7 @@ class LibraryInterpreter(BaseInterpreter):
 
         n_samples = 0
         options = 0
-        callback_method_ptr = DAQmxEveryNSamplesEventCallbackPtr()  # type: ignore  # typeshed is missing no-argument constructor overload
+        callback_method_ptr = DAQmxEveryNSamplesEventCallbackPtr()
         callback_data = None
 
         error_code = cfunc(
@@ -5890,7 +5890,7 @@ class LibraryInterpreter(BaseInterpreter):
                         ctypes.POINTER(ctypes.c_void_p)]
 
         options = 0
-        callback_method_ptr = DAQmxSignalEventCallbackPtr()  # type: ignore  # typeshed is missing no-argument constructor overload
+        callback_method_ptr = DAQmxSignalEventCallbackPtr()
         callback_data = None
 
         error_code = cfunc(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ plugins = "numpy.typing.mypy_plugin"
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_configs = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = [
@@ -156,6 +157,11 @@ module = [
   "nidaqmx.*",
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# mypy-protobuf codegen has some unused ignores.
+module = ["nidaqmx._stubs.*"]
+warn_unused_ignores = false
 
 [tool.bandit]
 skips = [

--- a/src/codegen/templates/library_interpreter/event_function_call.py.mako
+++ b/src/codegen/templates/library_interpreter/event_function_call.py.mako
@@ -39,7 +39,7 @@
         n_samples = 0
     %endif
         options = 0
-        callback_method_ptr = ${callback_func_param.type}()  # type: ignore  # typeshed is missing no-argument constructor overload
+        callback_method_ptr = ${callback_func_param.type}()
         callback_data = None
 %endif
 

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -4,8 +4,7 @@ import pathlib
 from typing import Any
 
 import pytest
-
-from nidaqmx._lib import lib_importer, get_encoding_from_locale
+from nidaqmx._lib import get_encoding_from_locale, lib_importer
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError
 from nidaqmx.system import Device
@@ -63,7 +62,7 @@ def test___supported_encoding___logging_file_path___returns_assigned_value(
 ):
     if _get_encoding(ai_task) not in supported_encodings:
         pytest.skip("requires compatible encoding")
-    ai_task.in_stream.logging_file_path = file_path  # type: ignore[assignment] # https://github.com/ni/nidaqmx-python/issues/613
+    ai_task.in_stream.logging_file_path = file_path
 
     assert ai_task.in_stream.logging_file_path == pathlib.Path(file_path)
 

--- a/tests/acceptance/test_internationalization.py
+++ b/tests/acceptance/test_internationalization.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Any
 
 import pytest
+
 from nidaqmx._lib import get_encoding_from_locale, lib_importer
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.errors import DaqError

--- a/tests/component/task/test_in_stream_read_properties.py
+++ b/tests/component/task/test_in_stream_read_properties.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import pytest
+
 from nidaqmx.constants import OverwriteMode, ReadRelativeTo
 from nidaqmx.task import Task
 

--- a/tests/component/task/test_in_stream_read_properties.py
+++ b/tests/component/task/test_in_stream_read_properties.py
@@ -1,7 +1,6 @@
 import pathlib
 
 import pytest
-
 from nidaqmx.constants import OverwriteMode, ReadRelativeTo
 from nidaqmx.task import Task
 
@@ -127,7 +126,7 @@ def test___ai_task___get_string_property___returns_default_value(ai_task: Task):
 
 
 def test___ai_task___set_string_property___returns_assigned_value(ai_task: Task):
-    ai_task.in_stream.logging_file_path = "TestData.tdms"  # type: ignore[assignment] # https://github.com/ni/nidaqmx-python/issues/613
+    ai_task.in_stream.logging_file_path = "TestData.tdms"
 
     assert ai_task.in_stream.logging_file_path == pathlib.Path("TestData.tdms")
 
@@ -139,7 +138,7 @@ def test___ai_task___set_string_property_none___returns_default_value(ai_task: T
 
 
 def test___ai_task___reset_string_property___returns_default_value(ai_task: Task):
-    ai_task.in_stream.logging_file_path = "TestData.tdms"  # type: ignore[assignment] # https://github.com/ni/nidaqmx-python/issues/613
+    ai_task.in_stream.logging_file_path = "TestData.tdms"
 
     del ai_task.in_stream.logging_file_path
 

--- a/tests/component/test_watchdog.py
+++ b/tests/component/test_watchdog.py
@@ -4,6 +4,7 @@ import weakref
 from typing import Callable
 
 import pytest
+
 from nidaqmx.constants import WatchdogAOExpirState, WatchdogCOExpirState
 from nidaqmx.system import Device
 from nidaqmx.system.watchdog import (

--- a/tests/component/test_watchdog.py
+++ b/tests/component/test_watchdog.py
@@ -4,10 +4,14 @@ import weakref
 from typing import Callable
 
 import pytest
-
 from nidaqmx.constants import WatchdogAOExpirState, WatchdogCOExpirState
 from nidaqmx.system import Device
-from nidaqmx.system.watchdog import AOExpirationState, COExpirationState, WatchdogTask
+from nidaqmx.system.watchdog import (
+    AOExpirationState,
+    COExpirationState,
+    ExpirationState,
+    WatchdogTask,
+)
 
 
 def test___watchdog_task___cfg_watchdog_ao_expir_states___no_error(
@@ -129,8 +133,9 @@ def test___watchdog_expiration_states___set_nonexistent_property___raises_except
         )
     ]
     watchdog_task.cfg_watchdog_ao_expir_states(expir_states)
+    expir_state: ExpirationState = watchdog_task.expiration_states[
+        sim_9263_device.ao_physical_chans[0].name
+    ]
 
     with pytest.raises(AttributeError):
-        watchdog_task.expiration_states[
-            sim_9263_device.ao_physical_chans[0].name
-        ].nonexistent_property = "foo"  # type: ignore[attr-defined]
+        expir_state.nonexistent_property = "foo"  # type: ignore[attr-defined]

--- a/tests/unit/test_grpc_time.py
+++ b/tests/unit/test_grpc_time.py
@@ -120,7 +120,7 @@ def test___grpc_response_before_1970___convert_to_timestamp___succeeds(response_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # type: ignore # ZoneInfo is a concrete class that takes in abstract tzinfo
+    target_timezone = ZoneInfo("America/Los_Angeles")
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = grpc_time.convert_time_to_timestamp(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -5,8 +5,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from hightime import datetime as ht_datetime
-
 from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
+
 from tests.unit._time_utils import (
     JAN_01_1850_DATETIME,
     JAN_01_1850_HIGHTIME,
@@ -97,7 +97,7 @@ def test___utc_datetime_before_1904___convert_to_timestamp___is_reversible(from_
 )
 def test___utc_datetime___convert_to_timestamp_with_dst___is_reversible(date):
     # we use a location that has daylight savings date change on the dates above
-    target_timezone: ZoneInfo = ZoneInfo("America/Los_Angeles")  # type: ignore # ZoneInfo is a concrete class that takes in abstract tzinfo
+    target_timezone = ZoneInfo("America/Los_Angeles")
     astimezone_date = date.astimezone(target_timezone)
 
     to_ts = LibTimestamp.from_datetime(date)

--- a/tests/unit/test_lib_time.py
+++ b/tests/unit/test_lib_time.py
@@ -5,8 +5,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from hightime import datetime as ht_datetime
-from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
 
+from nidaqmx._lib_time import AbsoluteTime as LibTimestamp
 from tests.unit._time_utils import (
     JAN_01_1850_DATETIME,
     JAN_01_1850_HIGHTIME,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Configure mypy to `--warn-unused-ignores`, except for mypy-protobuf codegen.

Remove unused ignores:
- ctypes callback function with no arguments no longer warns.
- Properties can now have different get/set types, as of Mypy 1.16: https://mypy-lang.blogspot.com/2025/05/mypy-116-released.html
- ZoneInfo constructor type: ignore is no longer needed. This might have been for Python 3.8 timezone backports?
- Watchdog expiration states do not have enough type hints to generate the expected warnings.

### Why should this Pull Request be merged?

Closes #613 

### What testing has been done?

Ran mypy.