### PR TITLE
github: Add `contents: read` to job permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,5 +29,6 @@ jobs:
     needs: [run_unit_tests, run_system_tests]
     if: always()
     permissions:
+      contents: read
       checks: write
       pull-requests: write

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -17,5 +17,6 @@ jobs:
     name: Run CI
     uses: ./.github/workflows/CI.yml
     permissions:
+      contents: read
       checks: write
       pull-requests: write

--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -9,6 +9,7 @@ jobs:
     name: Report test results
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
       pull-requests: write
     steps:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Add `contents: read` to jobs that specify permissions.

### Why should this Pull Request be merged?

Specifying `contents: read` is necessary for internal/private repos. nidaqmx-python is public, but there are a couple of situations that this affects:
- Bootstrapping a new internal/private repo by copying GHA workflows from nidaqmx-python. (Another team is currently doing this.)
- Private forks of nidaqmx-python for security patches

### What testing has been done?

None