### PR TITLE
Update DAQmx Installer Download Link

### DIFF
--- a/generated/nidaqmx/_installer_metadata.json
+++ b/generated/nidaqmx/_installer_metadata.json
@@ -1,9 +1,9 @@
 {
     "Windows": [
         {
-            "Version": "25.3.1",
-            "Release": "2025Q2 Patch 1",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.3/online/ni-daqmx_25.3_online.exe",
+            "Version": "25.5.0",
+            "Release": "2025Q3",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.5/online/ni-daqmx_25.5_online.exe",
             "supportedOS": [
                 "Windows 11",
                 "Windows Server 2022 64-bit",
@@ -15,10 +15,10 @@
     ],
     "Linux": [
         {
-            "Version": "25.3.0",
-            "Release": "2025Q2",
+            "Version": "25.5.0",
+            "Release": "2025Q3",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q2/NILinux2025Q2DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q3/NILinux2025Q3DeviceDrivers.zip",
             "supportedOS": [
                 "ubuntu 20.04",
                 "ubuntu 22.04",

--- a/src/handwritten/_installer_metadata.json
+++ b/src/handwritten/_installer_metadata.json
@@ -1,9 +1,9 @@
 {
     "Windows": [
         {
-            "Version": "25.3.1",
-            "Release": "2025Q2 Patch 1",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.3/online/ni-daqmx_25.3_online.exe",
+            "Version": "25.5.0",
+            "Release": "2025Q3",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.5/online/ni-daqmx_25.5_online.exe",
             "supportedOS": [
                 "Windows 11",
                 "Windows Server 2022 64-bit",
@@ -15,10 +15,10 @@
     ],
     "Linux": [
         {
-            "Version": "25.3.0",
-            "Release": "2025Q2",
+            "Version": "25.5.0",
+            "Release": "2025Q3",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q2/NILinux2025Q2DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q3/NILinux2025Q3DeviceDrivers.zip",
             "supportedOS": [
                 "ubuntu 20.04",
                 "ubuntu 22.04",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update driver installer download links for both Windows (2025 Q3) and Linux (2025 Q3).

### Why should this Pull Request be merged?

For DAQmx python 1.2.0 release.

### What testing has been done?

Ran `python -m nidaqmx installdriver`, able to upgrade to 25.5.
<img width="1105" height="50" alt="image" src="https://github.com/user-attachments/assets/f0a6cbb7-f8fb-479b-9c18-aa1c6b2b1535" />