### PR TITLE
Add AnalogMultiChannelReader.read_waveforms()

### DIFF
--- a/examples/analog_in/voltage_acq_int_clk_wfm.py
+++ b/examples/analog_in/voltage_acq_int_clk_wfm.py
@@ -9,17 +9,42 @@ import os
 os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
 
 import nidaqmx  # noqa: E402 # Must import after setting environment variable
-from nidaqmx.constants import AcquisitionType, READ_ALL_AVAILABLE  # noqa: E402
-from nidaqmx.stream_readers import AnalogSingleChannelReader  # noqa: E402
+from nidaqmx.constants import READ_ALL_AVAILABLE, AcquisitionType  # noqa: E402
+from nidaqmx.stream_readers import (  # noqa: E402
+    AnalogMultiChannelReader,
+    AnalogSingleChannelReader,
+)
 
-with nidaqmx.Task() as task:
-    task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
-    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
+with nidaqmx.Task() as single_channel_task:
+    single_channel_task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
+    single_channel_task.timing.cfg_samp_clk_timing(
+        1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50
+    )
 
-    reader = AnalogSingleChannelReader(task.in_stream)
-    waveform = reader.read_waveform(READ_ALL_AVAILABLE)
+    single_channel_reader = AnalogSingleChannelReader(single_channel_task.in_stream)
+    waveform = single_channel_reader.read_waveform(READ_ALL_AVAILABLE)
+    print("--- Single Channel ---")
     print(f"Acquired data: {waveform.scaled_data}")
     print(f"Channel name: {waveform.channel_name}")
     print(f"Unit description: {waveform.unit_description}")
     print(f"t0: {waveform.timing.start_time}")
     print(f"dt: {waveform.timing.sample_interval}")
+
+with nidaqmx.Task() as multi_channel_task:
+    multi_channel_task.ai_channels.add_ai_voltage_chan("Dev1/ai1")
+    multi_channel_task.ai_channels.add_ai_voltage_chan("Dev1/ai2")
+    multi_channel_task.ai_channels.add_ai_voltage_chan("Dev1/ai3")
+    multi_channel_task.timing.cfg_samp_clk_timing(
+        1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50
+    )
+
+    multi_channel_reader = AnalogMultiChannelReader(multi_channel_task.in_stream)
+    waveforms = multi_channel_reader.read_waveforms(READ_ALL_AVAILABLE)
+    print("")
+    print("--- Multi Channel ---")
+    for waveform in waveforms:
+        print(f"Acquired data: {waveform.scaled_data}")
+        print(f"Channel name: {waveform.channel_name}")
+        print(f"Unit description: {waveform.unit_description}")
+        print(f"t0: {waveform.timing.start_time}")
+        print(f"dt: {waveform.timing.sample_interval}")

--- a/generated/nidaqmx/_base_interpreter.py
+++ b/generated/nidaqmx/_base_interpreter.py
@@ -2,6 +2,7 @@
 import abc
 import numpy
 from nitypes.waveform import AnalogWaveform
+from typing import Sequence
 
 
 class BaseEventHandler(abc.ABC):
@@ -1855,5 +1856,15 @@ class BaseInterpreter(abc.ABC):
         number_of_samples_per_channel: int,
         timeout: float,
         waveform: AnalogWaveform[numpy.float64]
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def read_analog_waveforms(
+        self,
+        task_handle: object,
+        number_of_samples_per_channel: int,
+        timeout: float,
+        waveforms: Sequence[AnalogWaveform[numpy.float64]]
     ) -> None:
         raise NotImplementedError

--- a/generated/nidaqmx/_grpc_interpreter.py
+++ b/generated/nidaqmx/_grpc_interpreter.py
@@ -6,7 +6,7 @@ import threading
 import typing
 import warnings
 from nitypes.waveform import AnalogWaveform
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, Sequence, TypeVar
 
 import google.protobuf.message
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
@@ -3607,6 +3607,15 @@ class GrpcStubInterpreter(BaseInterpreter):
         number_of_samples_per_channel: int,
         timeout: float,
         waveform: AnalogWaveform[numpy.float64]
+    ) -> None:
+        raise NotImplementedError
+
+    def read_analog_waveforms(
+        self,
+        task_handle: object,
+        number_of_samples_per_channel: int,
+        timeout: float,
+        waveforms: Sequence[AnalogWaveform[numpy.float64]]
     ) -> None:
         raise NotImplementedError
 

--- a/generated/nidaqmx/_library_interpreter.py
+++ b/generated/nidaqmx/_library_interpreter.py
@@ -6398,6 +6398,32 @@ class LibraryInterpreter(BaseInterpreter):
         # TODO: AB#3228924 - if the read was short, set waveform.sample_count before throwing the exception
         self.check_for_error(error_code, samps_per_chan_read=samples_read)
 
+    def read_analog_waveforms(
+        self,
+        task_handle: object,
+        number_of_samples_per_channel: int,
+        timeout: float,
+        waveforms: Sequence[AnalogWaveform[numpy.float64]]
+    ) -> None:
+        """Read a set of analog waveforms with timing and attributes. All of the waveforms must be the same size."""
+        error_code, samples_read, timestamps, sample_intervals = self.internal_read_analog_waveform_per_chan(
+            task_handle,
+            number_of_samples_per_channel,
+            timeout,
+            [waveform.raw_data for waveform in waveforms],
+            [waveform.extended_properties for waveform in waveforms]
+        )
+
+        for i, waveform in enumerate(waveforms):
+            waveform.timing = Timing(
+                sample_interval_mode=SampleIntervalMode.REGULAR,
+                timestamp=timestamps[i],
+                sample_interval=sample_intervals[i],
+            )
+
+        # TODO: AB#3228924 - if the read was short, set waveform.sample_count before throwing the exception
+        self.check_for_error(error_code, samps_per_chan_read=samples_read)
+
     def _internal_read_analog_waveform_ex(
         self,
         task_handle: object,
@@ -6469,6 +6495,87 @@ class LibraryInterpreter(BaseInterpreter):
         sample_intervals = [ht_timedelta(seconds=dt * _INT64_WFM_SEC_PER_TICK) for dt in dt_array]
 
         return error_code, samps_per_chan_read.value, timestamps, sample_intervals
+
+    def internal_read_analog_waveform_per_chan(
+        self,
+        task_handle: object,
+        num_samps_per_chan: int,
+        timeout: float,
+        read_arrays: Sequence[numpy.typing.NDArray[numpy.float64]],
+        properties: Sequence[ExtendedPropertyDictionary]
+    ) -> Tuple[
+        int, # error code
+        int, # The number of samples per channel that were read
+        Sequence[ht_datetime], # The timestamps for each sample, indexed by channel
+        Sequence[ht_timedelta], # The sample intervals, indexed by channel
+    ]:
+        assert isinstance(task_handle, TaskHandle)
+        samps_per_chan_read = ctypes.c_int()
+
+        channel_count = len(read_arrays)
+        assert channel_count > 0
+        array_size = read_arrays[0].size
+        assert all(read_array.size == array_size for read_array in read_arrays)
+
+        cfunc = lib_importer.windll.DAQmxInternalReadAnalogWaveformPerChan
+        if cfunc.argtypes is None:
+            with cfunc.arglock:
+                if cfunc.argtypes is None:
+                    cfunc.argtypes = [
+                        TaskHandle,
+                        ctypes.c_int,
+                        ctypes.c_double,
+                        wrapped_ndpointer(dtype=numpy.int64, flags=("C", "W")),
+                        wrapped_ndpointer(dtype=numpy.int64, flags=("C", "W")),
+                        ctypes.c_uint,
+                        CSetWfmAttrCallbackPtr,
+                        ctypes.c_void_p,
+                        ctypes.POINTER(ctypes.POINTER(ctypes.c_double)),
+                        ctypes.c_uint,
+                        ctypes.c_uint,
+                        ctypes.POINTER(ctypes.c_int),
+                        ctypes.POINTER(c_bool32),
+                    ]
+
+        t0_array = numpy.zeros(channel_count, dtype=numpy.int64)
+        dt_array = numpy.zeros(channel_count, dtype=numpy.int64)
+
+        read_array_ptrs = (ctypes.POINTER(ctypes.c_double) * channel_count)()
+        for i, read_array in enumerate(read_arrays):
+            read_array_ptrs[i] = read_array.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+
+        def set_wfm_attr_callback(
+            channel_index: int,
+            attribute_name: str,
+            attribute_type: WfmAttrType,
+            value: ExtendedPropertyValue,
+            callback_data: object,
+        ) -> int:
+            properties[channel_index][attribute_name] = value
+            return 0
+
+        error_code = cfunc(
+            task_handle,
+            num_samps_per_chan,
+            timeout,
+            t0_array,
+            dt_array,
+            0 if t0_array is None else t0_array.size,
+            self._get_wfm_attr_callback_ptr(set_wfm_attr_callback),
+            None,
+            read_array_ptrs,
+            channel_count,
+            array_size,
+            ctypes.byref(samps_per_chan_read),
+            None,
+        )
+        self.check_for_error(error_code, samps_per_chan_read=samps_per_chan_read.value)
+
+        timestamps = [_T0_EPOCH + ht_timedelta(seconds=t0 * _INT64_WFM_SEC_PER_TICK) for t0 in t0_array]
+        sample_intervals = [ht_timedelta(seconds=dt * _INT64_WFM_SEC_PER_TICK) for dt in dt_array]
+
+        return error_code, samps_per_chan_read.value, timestamps, sample_intervals
+
 
     def _get_wfm_attr_value(
         self, attribute_type: int, value: ctypes.c_void_p, value_size_in_bytes: int

--- a/generated/nidaqmx/stream_readers.py
+++ b/generated/nidaqmx/stream_readers.py
@@ -449,6 +449,105 @@ class AnalogMultiChannelReader(ChannelReaderBase):
 
         self._interpreter.read_analog_f64(self._handle, 1, timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
+    @requires_feature(WAVEFORM_SUPPORT)
+    def read_waveforms(
+        self,
+        number_of_samples_per_channel: int = READ_ALL_AVAILABLE,
+        timeout: int = 10,
+        waveforms: list[AnalogWaveform[numpy.float64]] | None = None
+    ) -> list[AnalogWaveform[numpy.float64]]:
+        """
+        Reads one or more floating-point samples from one or more analog
+        input channels into a list of waveforms.
+
+        This read method optionally accepts a preallocated list of waveforms to hold
+        the samples requested, which can be advantageous for performance and
+        interoperability with NumPy and SciPy.
+
+        Passing in a preallocated list of waveforms is valuable in continuous
+        acquisition scenarios, where the same waveforms can be used
+        repeatedly in each call to the method.
+
+        Args:
+            number_of_samples_per_channel (Optional[int]): Specifies the
+                number of samples to read.
+
+                If you set this input to nidaqmx.constants.
+                READ_ALL_AVAILABLE, NI-DAQmx determines how many samples
+                to read based on if the task acquires samples
+                continuously or acquires a finite number of samples.
+
+                If the task acquires samples continuously and you set
+                this input to nidaqmx.constants.READ_ALL_AVAILABLE, this
+                method reads all the samples currently available in the
+                buffer.
+
+                If the task acquires a finite number of samples and you
+                set this input to nidaqmx.constants.READ_ALL_AVAILABLE,
+                the method waits for the task to acquire all requested
+                samples, then reads those samples. If you set the
+                "read_all_avail_samp" property to True, the method reads
+                the samples currently available in the buffer and does
+                not wait for the task to acquire all requested samples.
+            timeout (Optional[float]): Specifies the amount of time in
+                seconds to wait for samples to become available. If the
+                time elapses, the method returns an error and any
+                samples read before the timeout elapsed. The default
+                timeout is 10 seconds. If you set timeout to
+                nidaqmx.constants.WAIT_INFINITELY, the method waits
+                indefinitely. If you set timeout to 0, the method tries
+                once to read the requested samples and returns an error
+                if it is unable to.
+            waveforms (Optional[list[AnalogWaveform]]): Specifies an existing
+                list of AnalogWaveform objects to use for reading samples into.
+                If provided, the raw_data array of each waveform will be
+                used to store the samples. The list must contain one waveform
+                for each channel in the task. If not provided, new
+                AnalogWaveform objects will be created.
+        Returns:
+            list[AnalogWaveform]:
+
+            A list of waveform objects containing the acquired samples,
+            one for each channel in the task.
+        """
+        number_of_samples_per_channel = (
+            self._task._calculate_num_samps_per_chan(
+                number_of_samples_per_channel))
+
+        channels_to_read = self._in_stream.channels_to_read
+        number_of_channels = len(channels_to_read.channel_names)
+
+        if waveforms is None:
+            waveforms = [
+                AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                for _ in range(number_of_channels)
+            ]
+        else:
+            if len(waveforms) != number_of_channels:
+                raise DaqError(
+                    f'The number of waveforms provided ({len(waveforms)}) does not match '
+                    f'the number of channels in the task ({number_of_channels}). Please provide '
+                    'one waveform for each channel.',
+                    DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
+            
+            for i, waveform in enumerate(waveforms):
+                if number_of_samples_per_channel > waveform.sample_count:
+                    # TODO: AB#3228924 - if allowed by the caller, increase the sample count of the waveform
+                    raise DaqError(
+                        f'The waveform at index {i} does not have enough space ({waveform.sample_count}) to hold '
+                        f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
+                        'waveforms or adjust the number of samples requested.',
+                        DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)
+
+        self._interpreter.read_analog_waveforms(
+            self._handle,
+            number_of_samples_per_channel,
+            timeout,
+            waveforms,
+        )
+
+        return waveforms
+
 
 class AnalogUnscaledReader(ChannelReaderBase):
     """

--- a/src/codegen/templates/_base_interpreter.py.mako
+++ b/src/codegen/templates/_base_interpreter.py.mako
@@ -13,6 +13,7 @@
 import abc
 import numpy
 from nitypes.waveform import AnalogWaveform
+from typing import Sequence
 
 
 class BaseEventHandler(abc.ABC):
@@ -64,5 +65,15 @@ class BaseInterpreter(abc.ABC):
         number_of_samples_per_channel: int,
         timeout: float,
         waveform: AnalogWaveform[numpy.float64]
+    ) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def read_analog_waveforms(
+        self,
+        task_handle: object,
+        number_of_samples_per_channel: int,
+        timeout: float,
+        waveforms: Sequence[AnalogWaveform[numpy.float64]]
     ) -> None:
         raise NotImplementedError

--- a/src/codegen/templates/_grpc_interpreter.py.mako
+++ b/src/codegen/templates/_grpc_interpreter.py.mako
@@ -23,7 +23,7 @@ import threading
 import typing
 import warnings
 from nitypes.waveform import AnalogWaveform
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, Sequence, TypeVar
 
 import google.protobuf.message
 from google.protobuf.timestamp_pb2 import Timestamp as GrpcTimestamp
@@ -252,6 +252,15 @@ class GrpcStubInterpreter(BaseInterpreter):
         number_of_samples_per_channel: int,
         timeout: float,
         waveform: AnalogWaveform[numpy.float64]
+    ) -> None:
+        raise NotImplementedError
+
+    def read_analog_waveforms(
+        self,
+        task_handle: object,
+        number_of_samples_per_channel: int,
+        timeout: float,
+        waveforms: Sequence[AnalogWaveform[numpy.float64]]
     ) -> None:
         raise NotImplementedError
 

--- a/src/handwritten/stream_readers.py
+++ b/src/handwritten/stream_readers.py
@@ -449,6 +449,105 @@ class AnalogMultiChannelReader(ChannelReaderBase):
 
         self._interpreter.read_analog_f64(self._handle, 1, timeout, FillMode.GROUP_BY_CHANNEL.value, data)
 
+    @requires_feature(WAVEFORM_SUPPORT)
+    def read_waveforms(
+        self,
+        number_of_samples_per_channel: int = READ_ALL_AVAILABLE,
+        timeout: int = 10,
+        waveforms: list[AnalogWaveform[numpy.float64]] | None = None
+    ) -> list[AnalogWaveform[numpy.float64]]:
+        """
+        Reads one or more floating-point samples from one or more analog
+        input channels into a list of waveforms.
+
+        This read method optionally accepts a preallocated list of waveforms to hold
+        the samples requested, which can be advantageous for performance and
+        interoperability with NumPy and SciPy.
+
+        Passing in a preallocated list of waveforms is valuable in continuous
+        acquisition scenarios, where the same waveforms can be used
+        repeatedly in each call to the method.
+
+        Args:
+            number_of_samples_per_channel (Optional[int]): Specifies the
+                number of samples to read.
+
+                If you set this input to nidaqmx.constants.
+                READ_ALL_AVAILABLE, NI-DAQmx determines how many samples
+                to read based on if the task acquires samples
+                continuously or acquires a finite number of samples.
+
+                If the task acquires samples continuously and you set
+                this input to nidaqmx.constants.READ_ALL_AVAILABLE, this
+                method reads all the samples currently available in the
+                buffer.
+
+                If the task acquires a finite number of samples and you
+                set this input to nidaqmx.constants.READ_ALL_AVAILABLE,
+                the method waits for the task to acquire all requested
+                samples, then reads those samples. If you set the
+                "read_all_avail_samp" property to True, the method reads
+                the samples currently available in the buffer and does
+                not wait for the task to acquire all requested samples.
+            timeout (Optional[float]): Specifies the amount of time in
+                seconds to wait for samples to become available. If the
+                time elapses, the method returns an error and any
+                samples read before the timeout elapsed. The default
+                timeout is 10 seconds. If you set timeout to
+                nidaqmx.constants.WAIT_INFINITELY, the method waits
+                indefinitely. If you set timeout to 0, the method tries
+                once to read the requested samples and returns an error
+                if it is unable to.
+            waveforms (Optional[list[AnalogWaveform]]): Specifies an existing
+                list of AnalogWaveform objects to use for reading samples into.
+                If provided, the raw_data array of each waveform will be
+                used to store the samples. The list must contain one waveform
+                for each channel in the task. If not provided, new
+                AnalogWaveform objects will be created.
+        Returns:
+            list[AnalogWaveform]:
+
+            A list of waveform objects containing the acquired samples,
+            one for each channel in the task.
+        """
+        number_of_samples_per_channel = (
+            self._task._calculate_num_samps_per_chan(
+                number_of_samples_per_channel))
+
+        channels_to_read = self._in_stream.channels_to_read
+        number_of_channels = len(channels_to_read.channel_names)
+
+        if waveforms is None:
+            waveforms = [
+                AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                for _ in range(number_of_channels)
+            ]
+        else:
+            if len(waveforms) != number_of_channels:
+                raise DaqError(
+                    f'The number of waveforms provided ({len(waveforms)}) does not match '
+                    f'the number of channels in the task ({number_of_channels}). Please provide '
+                    'one waveform for each channel.',
+                    DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
+            
+            for i, waveform in enumerate(waveforms):
+                if number_of_samples_per_channel > waveform.sample_count:
+                    # TODO: AB#3228924 - if allowed by the caller, increase the sample count of the waveform
+                    raise DaqError(
+                        f'The waveform at index {i} does not have enough space ({waveform.sample_count}) to hold '
+                        f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
+                        'waveforms or adjust the number of samples requested.',
+                        DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)
+
+        self._interpreter.read_analog_waveforms(
+            self._handle,
+            number_of_samples_per_channel,
+            timeout,
+            waveforms,
+        )
+
+        return waveforms
+
 
 class AnalogUnscaledReader(ChannelReaderBase):
     """

--- a/tests/component/test_stream_readers_ai.py
+++ b/tests/component/test_stream_readers_ai.py
@@ -13,7 +13,7 @@ from nitypes.waveform import AnalogWaveform
 
 import nidaqmx
 import nidaqmx.system
-from nidaqmx._feature_toggles import FeatureNotSupportedError, WAVEFORM_SUPPORT
+from nidaqmx._feature_toggles import WAVEFORM_SUPPORT, FeatureNotSupportedError
 from nidaqmx.constants import AcquisitionType
 from nidaqmx.error_codes import DAQmxErrors
 from nidaqmx.stream_readers import (
@@ -114,6 +114,27 @@ def ai_multi_channel_task(
         chan.ai_rng_high = 10
         chan.ai_rng_low = -10
 
+    return task
+
+
+@pytest.fixture
+def ai_multi_channel_task_with_timing(
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    for chan_index in range(3):
+        offset = _get_voltage_offset_for_chan(chan_index)
+        chan = task.ai_channels.add_ai_voltage_chan(
+            sim_6363_device.ai_physical_chans[chan_index].name,
+            min_val=offset,
+            # min and max must be different, so add a small epsilon
+            max_val=offset + VOLTAGE_EPSILON,
+        )
+        # forcing the maximum range for binary read scaling to be predictable
+        chan.ai_rng_high = 10
+        chan.ai_rng_low = -10
+
+    # Configure timing for waveform reading
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
     return task
 
 
@@ -350,6 +371,142 @@ def test___analog_multi_channel_reader___read_many_sample_with_wrong_dtype___rai
         _ = reader.read_many_sample(data, samples_to_read)
 
     assert "float64" in exc_info.value.args[0]
+
+
+@pytest.mark.disable_feature_toggle(WAVEFORM_SUPPORT)
+def test___analog_multi_channel_reader___read_waveforms_feature_disabled___raises_feature_not_supported_error(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+
+    with pytest.raises(FeatureNotSupportedError) as exc_info:
+        reader.read_waveforms()
+
+    error_message = str(exc_info.value)
+    assert "WAVEFORM_SUPPORT feature is not supported" in error_message
+    assert "NIDAQMX_ENABLE_WAVEFORM_SUPPORT" in error_message
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveforms not implemented in GRPC")
+def test___analog_multi_channel_reader___read_waveforms___returns_valid_waveforms(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+    num_channels = ai_multi_channel_task_with_timing.number_of_channels
+    samples_to_read = 10
+
+    waveforms = reader.read_waveforms(number_of_samples_per_channel=samples_to_read)
+
+    assert num_channels == 3
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    for chan_index, waveform in enumerate(waveforms):
+        assert isinstance(waveform, AnalogWaveform)
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+        assert isinstance(waveform.timing.timestamp, ht_datetime)
+        assert _is_timestamp_close_to_now(waveform.timing.timestamp)
+        assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
+        assert (
+            waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
+        )
+        assert waveform.unit_description == "Volts"
+        assert waveform.sample_count == samples_to_read
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveforms not implemented in GRPC")
+def test___analog_multi_channel_reader___read_waveforms_no_args___returns_valid_waveforms(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+    num_channels = ai_multi_channel_task_with_timing.number_of_channels
+
+    waveforms = reader.read_waveforms()
+
+    assert num_channels == 3
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    for chan_index, waveform in enumerate(waveforms):
+        assert isinstance(waveform, AnalogWaveform)
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+        assert isinstance(waveform.timing.timestamp, ht_datetime)
+        assert _is_timestamp_close_to_now(waveform.timing.timestamp)
+        assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
+        assert (
+            waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
+        )
+        assert waveform.unit_description == "Volts"
+        assert waveform.sample_count == 50
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveforms not implemented in GRPC")
+def test___analog_multi_channel_reader___read_waveforms_in_place___populates_valid_waveforms(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+    num_channels = ai_multi_channel_task_with_timing.number_of_channels
+    samples_to_read = 10
+
+    waveforms = [
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+    ]
+    reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)
+
+    assert num_channels == 3
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    for chan_index, waveform in enumerate(waveforms):
+        assert isinstance(waveform, AnalogWaveform)
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+        assert isinstance(waveform.timing.timestamp, ht_datetime)
+        assert _is_timestamp_close_to_now(waveform.timing.timestamp)
+        assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
+        assert (
+            waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
+        )
+        assert waveform.unit_description == "Volts"
+        assert waveform.sample_count == samples_to_read
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveforms not implemented in GRPC")
+def test___analog_multi_channel_reader___read_into_undersized_waveforms___throws_exception(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+    samples_to_read = 10
+
+    waveforms = [
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read - 1, dtype=numpy.float64)),
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+    ]
+    with pytest.raises(DaqError) as exc_info:
+        reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)
+
+    assert exc_info.value.error_code == DAQmxErrors.READ_BUFFER_TOO_SMALL
+    assert exc_info.value.args[0].startswith("The waveform at index 1 does not have enough space")
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveforms not implemented in GRPC")
+def test___analog_multi_channel_reader___read_with_wrong_number_of_waveforms___throws_exception(
+    ai_multi_channel_task_with_timing: nidaqmx.Task,
+) -> None:
+    reader = AnalogMultiChannelReader(ai_multi_channel_task_with_timing.in_stream)
+    samples_to_read = 10
+
+    waveforms = [
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+    ]
+    with pytest.raises(DaqError) as exc_info:
+        reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)
+
+    assert exc_info.value.error_code == DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES
+    assert "does not match the number of channels" in exc_info.value.args[0]
 
 
 def test___analog_unscaled_reader___read_int16___returns_valid_samples(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

- Adds `AnalogMultiChannelReader.read_waveforms()`
- Adds `LibraryInterpreter.read_analog_waveforms()` and `.internal_read_analog_waveform_per_chan()`

### Why should this Pull Request be merged?

Users want to be able to read multiple waveforms at once.

### What testing has been done?

```
test___analog_multi_channel_reader___read_waveforms_feature_disabled___raises_feature_not_supported_error
test___analog_multi_channel_reader___read_waveforms___returns_valid_waveforms
test___analog_multi_channel_reader___read_waveforms_no_args___returns_valid_waveforms
test___analog_multi_channel_reader___read_waveforms_in_place___populates_valid_waveforms
test___analog_multi_channel_reader___read_into_undersized_waveforms___throws_exception
test___analog_multi_channel_reader___read_with_wrong_number_of_waveforms___throws_exception
```
