### PR TITLE
Add task.read_waveform() for analog inputs

### DIFF
--- a/examples/analog_in/voltage_acq_int_clk_wfm.py
+++ b/examples/analog_in/voltage_acq_int_clk_wfm.py
@@ -15,7 +15,6 @@ with nidaqmx.Task() as task:
     task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
     task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
 
-    task.start()
     waveform = task.read_waveform()
     print(f"Acquired data: {waveform.scaled_data}")
     print(f"Channel name: {waveform.channel_name}")

--- a/examples/analog_in/voltage_acq_int_clk_wfm.py
+++ b/examples/analog_in/voltage_acq_int_clk_wfm.py
@@ -9,15 +9,14 @@ import os
 os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
 
 import nidaqmx  # noqa: E402 # Must import after setting environment variable
-from nidaqmx.constants import AcquisitionType, READ_ALL_AVAILABLE  # noqa: E402
-from nidaqmx.stream_readers import AnalogSingleChannelReader  # noqa: E402
+from nidaqmx.constants import AcquisitionType  # noqa: E402
 
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
     task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
 
-    reader = AnalogSingleChannelReader(task.in_stream)
-    waveform = reader.read_waveform(READ_ALL_AVAILABLE)
+    task.start()
+    waveform = task.read_waveform()
     print(f"Acquired data: {waveform.scaled_data}")
     print(f"Channel name: {waveform.channel_name}")
     print(f"Unit description: {waveform.unit_description}")

--- a/generated/nidaqmx/stream_readers.py
+++ b/generated/nidaqmx/stream_readers.py
@@ -303,7 +303,7 @@ class AnalogSingleChannelReader(ChannelReaderBase):
                 number_of_samples_per_channel))
 
         if waveform is None:
-            waveform = AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+            waveform = AnalogWaveform(number_of_samples_per_channel)
         elif number_of_samples_per_channel > waveform.sample_count:
             # TODO: AB#3228924 - if allowed by the caller, increase the sample count of the waveform
             raise DaqError(
@@ -519,7 +519,7 @@ class AnalogMultiChannelReader(ChannelReaderBase):
 
         if waveforms is None:
             waveforms = [
-                AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                AnalogWaveform(number_of_samples_per_channel)
                 for _ in range(number_of_channels)
             ]
         else:

--- a/generated/nidaqmx/task/_task.py
+++ b/generated/nidaqmx/task/_task.py
@@ -7,6 +7,7 @@ from enum import Enum
 import numpy
 from nitypes.waveform import AnalogWaveform
 from nidaqmx import utils
+from nidaqmx._feature_toggles import WAVEFORM_SUPPORT, requires_feature
 from nidaqmx.task.channels._channel import Channel
 from nidaqmx.task._export_signals import ExportSignals
 from nidaqmx.task._in_stream import InStream
@@ -516,6 +517,7 @@ class Task:
 
         This read method is dynamic, and is capable of inferring an appropriate
         return type based on these factors:
+
         - The channel type of the task.
         - The number of channels to read.
         - The number of samples per channel.
@@ -768,6 +770,7 @@ class Task:
                     for v, i in zip(voltages, currents)
                 ][:samples_read]
 
+    @requires_feature(WAVEFORM_SUPPORT)
     def read_waveform(self, number_of_samples_per_channel=READ_ALL_AVAILABLE,
              timeout=10.0):
         """
@@ -775,6 +778,7 @@ class Task:
 
         This read method is dynamic, and is capable of inferring an appropriate
         return type based on these factors:
+
         - The channel type of the task.
         - The number of channels to read.
         - The number of samples per channel.
@@ -843,7 +847,7 @@ class Task:
 
         if read_chan_type == ChannelType.ANALOG_INPUT:
             if number_of_channels == 1:
-                waveform = AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                waveform = AnalogWaveform(number_of_samples_per_channel)
                 self._interpreter.read_analog_waveform(
                     self._handle,
                     number_of_samples_per_channel,
@@ -854,7 +858,7 @@ class Task:
                 return waveform
             else:
                 waveforms = [
-                    AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                    AnalogWaveform(number_of_samples_per_channel)
                     for _ in range(number_of_channels)
                 ]
                 self._interpreter.read_analog_waveforms(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ reportArgumentType = false
 reportAttributeAccessIssue = false
 reportInvalidTypeForm = false
 reportOperatorIssue = false
+reportOptionalIterable = false
 reportOptionalMemberAccess = false
 reportReturnType = false
 

--- a/src/handwritten/stream_readers.py
+++ b/src/handwritten/stream_readers.py
@@ -303,7 +303,7 @@ class AnalogSingleChannelReader(ChannelReaderBase):
                 number_of_samples_per_channel))
 
         if waveform is None:
-            waveform = AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+            waveform = AnalogWaveform(number_of_samples_per_channel)
         elif number_of_samples_per_channel > waveform.sample_count:
             # TODO: AB#3228924 - if allowed by the caller, increase the sample count of the waveform
             raise DaqError(
@@ -519,7 +519,7 @@ class AnalogMultiChannelReader(ChannelReaderBase):
 
         if waveforms is None:
             waveforms = [
-                AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                AnalogWaveform(number_of_samples_per_channel)
                 for _ in range(number_of_channels)
             ]
         else:

--- a/src/handwritten/task/_task.py
+++ b/src/handwritten/task/_task.py
@@ -7,6 +7,7 @@ from enum import Enum
 import numpy
 from nitypes.waveform import AnalogWaveform
 from nidaqmx import utils
+from nidaqmx._feature_toggles import WAVEFORM_SUPPORT, requires_feature
 from nidaqmx.task.channels._channel import Channel
 from nidaqmx.task._export_signals import ExportSignals
 from nidaqmx.task._in_stream import InStream
@@ -516,6 +517,7 @@ class Task:
 
         This read method is dynamic, and is capable of inferring an appropriate
         return type based on these factors:
+
         - The channel type of the task.
         - The number of channels to read.
         - The number of samples per channel.
@@ -768,6 +770,7 @@ class Task:
                     for v, i in zip(voltages, currents)
                 ][:samples_read]
 
+    @requires_feature(WAVEFORM_SUPPORT)
     def read_waveform(self, number_of_samples_per_channel=READ_ALL_AVAILABLE,
              timeout=10.0):
         """
@@ -775,6 +778,7 @@ class Task:
 
         This read method is dynamic, and is capable of inferring an appropriate
         return type based on these factors:
+
         - The channel type of the task.
         - The number of channels to read.
         - The number of samples per channel.
@@ -843,7 +847,7 @@ class Task:
 
         if read_chan_type == ChannelType.ANALOG_INPUT:
             if number_of_channels == 1:
-                waveform = AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                waveform = AnalogWaveform(number_of_samples_per_channel)
                 self._interpreter.read_analog_waveform(
                     self._handle,
                     number_of_samples_per_channel,
@@ -854,7 +858,7 @@ class Task:
                 return waveform
             else:
                 waveforms = [
-                    AnalogWaveform(raw_data=numpy.zeros(number_of_samples_per_channel, dtype=numpy.float64))
+                    AnalogWaveform(number_of_samples_per_channel)
                     for _ in range(number_of_channels)
                 ]
                 self._interpreter.read_analog_waveforms(

--- a/tests/component/test_stream_readers_ai.py
+++ b/tests/component/test_stream_readers_ai.py
@@ -222,7 +222,7 @@ def test___analog_single_channel_reader___read_waveform_in_place___populates_val
     reader = AnalogSingleChannelReader(ai_single_channel_task_with_timing.in_stream)
     samples_to_read = 10
 
-    waveform = AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64))
+    waveform = AnalogWaveform(samples_to_read)
     reader.read_waveform(number_of_samples_per_channel=samples_to_read, waveform=waveform)
 
     assert isinstance(waveform, AnalogWaveform)
@@ -252,7 +252,7 @@ def test___analog_single_channel_reader___reuse_waveform_in_place___overwrites_d
 
     reader0 = _make_single_channel_reader(chan_index=0, offset=0, rate=1000.0)
     reader1 = _make_single_channel_reader(chan_index=1, offset=1, rate=2000.0)
-    waveform = AnalogWaveform(raw_data=numpy.zeros(10, dtype=numpy.float64))
+    waveform = AnalogWaveform(10)
 
     reader0.read_waveform(number_of_samples_per_channel=10, waveform=waveform)
     timestamp1 = waveform.timing.timestamp
@@ -276,7 +276,7 @@ def test___analog_single_channel_reader___read_into_undersized_waveform___throws
     reader = AnalogSingleChannelReader(ai_single_channel_task_with_timing.in_stream)
     samples_to_read = 10
 
-    waveform = AnalogWaveform(raw_data=numpy.zeros(samples_to_read - 1, dtype=numpy.float64))
+    waveform = AnalogWaveform(samples_to_read - 1)
     with pytest.raises(DaqError) as exc_info:
         reader.read_waveform(number_of_samples_per_channel=samples_to_read, waveform=waveform)
 
@@ -523,9 +523,9 @@ def test___analog_multi_channel_reader___read_waveforms_in_place___populates_val
     samples_to_read = 10
 
     waveforms = [
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(samples_to_read),
+        AnalogWaveform(samples_to_read),
+        AnalogWaveform(samples_to_read),
     ]
     reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)
 
@@ -554,9 +554,9 @@ def test___analog_multi_channel_reader___read_into_undersized_waveforms___throws
     samples_to_read = 10
 
     waveforms = [
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read - 1, dtype=numpy.float64)),
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(samples_to_read),
+        AnalogWaveform(samples_to_read - 1),
+        AnalogWaveform(samples_to_read),
     ]
     with pytest.raises(DaqError) as exc_info:
         reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)
@@ -573,8 +573,8 @@ def test___analog_multi_channel_reader___read_with_wrong_number_of_waveforms___t
     samples_to_read = 10
 
     waveforms = [
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
-        AnalogWaveform(raw_data=numpy.zeros(samples_to_read, dtype=numpy.float64)),
+        AnalogWaveform(samples_to_read),
+        AnalogWaveform(samples_to_read),
     ]
     with pytest.raises(DaqError) as exc_info:
         reader.read_waveforms(number_of_samples_per_channel=samples_to_read, waveforms=waveforms)

--- a/tests/component/test_task_read_waveform_ai.py
+++ b/tests/component/test_task_read_waveform_ai.py
@@ -158,3 +158,25 @@ def test___analog_multi_channel___read_waveform_many_samples___returns_waveforms
         expected = _get_voltage_offset_for_chan(chan_index)
         assert waveform.sample_count == samples_to_read
         assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.xfail(
+    reason="Task.read_waveform doesn't handle short reads yet - TODO: AB#3228924",
+    raises=AssertionError,
+)
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_multi_channel_finite___read_waveform_too_many_samples___returns_waveforms_with_correct_number_of_samples(
+    ai_multi_channel_task: nidaqmx.Task,
+) -> None:
+    samples_to_read = 100
+    samples_available = 50
+
+    waveforms = ai_multi_channel_task.read_waveform(samples_to_read)
+
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == ai_multi_channel_task.number_of_channels
+    assert all(isinstance(waveform, AnalogWaveform) for waveform in waveforms)
+    for chan_index, waveform in enumerate(waveforms):
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.sample_count == samples_available
+        assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)

--- a/tests/component/test_task_read_waveform_ai.py
+++ b/tests/component/test_task_read_waveform_ai.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import pytest
+from nitypes.waveform import AnalogWaveform
+
+import nidaqmx
+import nidaqmx.system
+from nidaqmx.constants import AcquisitionType
+
+
+# Simulated DAQ voltage data is a noisy sinewave within the range of the minimum and maximum values
+# of the virtual channel. We can leverage this behavior to validate we get the correct data from
+# the Python bindings.
+def _get_voltage_offset_for_chan(chan_index: int) -> float:
+    return float(chan_index + 1)
+
+
+VOLTAGE_EPSILON = 1e-3
+
+
+@pytest.fixture
+def ai_single_channel_task(
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    offset = _get_voltage_offset_for_chan(0)
+    task.ai_channels.add_ai_voltage_chan(
+        sim_6363_device.ai_physical_chans[0].name,
+        min_val=offset,
+        max_val=offset + VOLTAGE_EPSILON,
+    )
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
+    return task
+
+
+@pytest.fixture
+def ai_multi_channel_task(
+    task: nidaqmx.Task, sim_6363_device: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    for chan_index in range(3):
+        offset = _get_voltage_offset_for_chan(chan_index)
+        chan = task.ai_channels.add_ai_voltage_chan(
+            sim_6363_device.ai_physical_chans[chan_index].name,
+            min_val=offset,
+            # min and max must be different, so add a small epsilon
+            max_val=offset + VOLTAGE_EPSILON,
+        )
+        # forcing the maximum range for binary read scaling to be predictable
+        chan.ai_rng_high = 10
+        chan.ai_rng_low = -10
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
+    return task
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_single_channel___read_waveform___returns_valid_waveform(
+    ai_single_channel_task: nidaqmx.Task,
+) -> None:
+    waveform = ai_single_channel_task.read_waveform()
+
+    assert isinstance(waveform, AnalogWaveform)
+    expected = _get_voltage_offset_for_chan(0)
+    assert waveform.sample_count == 50
+    assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_single_channel___read_waveform_one_sample___returns_waveform_with_one_sample(
+    ai_single_channel_task: nidaqmx.Task,
+) -> None:
+    waveform = ai_single_channel_task.read_waveform(1)
+
+    assert isinstance(waveform, AnalogWaveform)
+    expected = _get_voltage_offset_for_chan(0)
+    assert waveform.sample_count == 1
+    assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_single_channel___read_waveform_many_sample___returns_waveform_with_many_samples(
+    ai_single_channel_task: nidaqmx.Task,
+) -> None:
+    samples_to_read = 10
+
+    waveform = ai_single_channel_task.read_waveform(samples_to_read)
+
+    assert isinstance(waveform, AnalogWaveform)
+    expected = _get_voltage_offset_for_chan(0)
+    assert waveform.sample_count == samples_to_read
+    assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.xfail(
+    reason="Task.read_waveform doesn't handle short reads yet - TODO: AB#3228924",
+    raises=AssertionError,
+)
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_single_channel_finite___read_waveform_too_many_samples___returns_waveform_with_correct_number_of_samples(
+    ai_single_channel_task: nidaqmx.Task,
+) -> None:
+    samples_to_read = 100
+    samples_available = 50
+
+    waveform = ai_single_channel_task.read_waveform(samples_to_read)
+
+    assert isinstance(waveform, AnalogWaveform)
+    expected = _get_voltage_offset_for_chan(0)
+    assert waveform.sample_count == samples_available
+    assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_multi_channel___read_waveform___returns_valid_waveforms(
+    ai_multi_channel_task: nidaqmx.Task,
+) -> None:
+    num_channels = ai_multi_channel_task.number_of_channels
+
+    waveforms = ai_multi_channel_task.read_waveform()
+
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    assert all(isinstance(waveform, AnalogWaveform) for waveform in waveforms)
+    for chan_index, waveform in enumerate(waveforms):
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.sample_count == 50
+        assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_multi_channel___read_waveform_one_sample___returns_waveforms_with_single_sample(
+    ai_multi_channel_task: nidaqmx.Task,
+) -> None:
+    num_channels = ai_multi_channel_task.number_of_channels
+
+    waveforms = ai_multi_channel_task.read_waveform(1)
+
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    assert all(isinstance(waveform, AnalogWaveform) for waveform in waveforms)
+    for chan_index, waveform in enumerate(waveforms):
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.sample_count == 1
+        assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)
+
+
+@pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
+def test___analog_multi_channel___read_waveform_many_samples___returns_waveforms_with_many_samples(
+    ai_multi_channel_task: nidaqmx.Task,
+) -> None:
+    num_channels = ai_multi_channel_task.number_of_channels
+    samples_to_read = 10
+
+    waveforms = ai_multi_channel_task.read_waveform(samples_to_read)
+
+    assert isinstance(waveforms, list)
+    assert len(waveforms) == num_channels
+    assert all(isinstance(waveform, AnalogWaveform) for waveform in waveforms)
+    for chan_index, waveform in enumerate(waveforms):
+        expected = _get_voltage_offset_for_chan(chan_index)
+        assert waveform.sample_count == samples_to_read
+        assert waveform.raw_data[0] == pytest.approx(expected, abs=VOLTAGE_EPSILON)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~

- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

This adds `Task.read_waveform()`, which is similar to `Task.read()` in that the return type is automatically determined based on the task configuration. `Task.read_waveform()` will return a single waveform if there's a single channel, or a list of waveforms if there are multiple channels. Currently, only analog channels are supported. Digital channel support will be added in a future user story.

### Why should this Pull Request be merged?

Implements [AB#3233521](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3233521)

### What testing has been done?

```
test___analog_single_channel___read_waveform___returns_valid_waveform
test___analog_single_channel___read_waveform_one_sample___returns_waveform_with_one_sample
test___analog_single_channel___read_waveform_many_sample___returns_waveform_with_many_samples
test___analog_multi_channel___read_waveform___returns_valid_waveforms
test___analog_multi_channel___read_waveform_one_sample___returns_waveforms_with_single_sample
test___analog_multi_channel___read_waveform_many_samples___returns_waveforms_with_many_samples
```
