### PR TITLE
Rename waveform.unit_description to units

### DIFF
--- a/examples/analog_in/voltage_acq_int_clk_wfm.py
+++ b/examples/analog_in/voltage_acq_int_clk_wfm.py
@@ -18,6 +18,6 @@ with nidaqmx.Task() as task:
     waveform = task.read_waveform()
     print(f"Acquired data: {waveform.scaled_data}")
     print(f"Channel name: {waveform.channel_name}")
-    print(f"Unit description: {waveform.unit_description}")
+    print(f"Units: {waveform.units}")
     print(f"t0: {waveform.timing.start_time}")
     print(f"dt: {waveform.timing.sample_interval}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1739,22 +1739,20 @@ toml = ">=0.10.1"
 
 [[package]]
 name = "nitypes"
-version = "0.1.0.dev6"
+version = "0.1.0.dev9"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "nitypes-0.1.0.dev6-py3-none-any.whl", hash = "sha256:44ecc849d4a26137919a5406cbb103281d965102d0061682a939d58668de44ea"},
-    {file = "nitypes-0.1.0.dev6.tar.gz", hash = "sha256:37ae3494ecaa98d866ebe3c27898c21961c4f47082cfb7a921dc842debd74526"},
+    {file = "nitypes-0.1.0.dev9-py3-none-any.whl", hash = "sha256:1e2928f9a2c57f289f5743433299e09d151ab4951bacffbf67238093a82c3f67"},
+    {file = "nitypes-0.1.0.dev9.tar.gz", hash = "sha256:bc36861cc4a5ff0cfe74050afeed82bcdd652fc4de36860cd43492beee388b5d"},
 ]
 
 [package.dependencies]
 hightime = ">=0.2.2"
 numpy = [
-    {version = ">=2.1", markers = "python_version >= \"3.10\" and python_version < \"3.11\" and implementation_name == \"pypy\" or python_version >= \"3.13\" and python_version < \"4.0\" and implementation_name != \"pypy\""},
-    {version = ">=1.26", markers = "python_version >= \"3.12\" and python_version < \"3.13\" and implementation_name != \"pypy\""},
-    {version = ">=2.3", markers = "implementation_name == \"pypy\" and python_version >= \"3.11\" and python_version < \"4.0\""},
-    {version = ">=1.22", markers = "implementation_name != \"pypy\" and python_version >= \"3.9\" and python_version < \"3.12\""},
+    {version = ">=1.22", markers = "python_version >= \"3.9\" and python_version < \"3.13\""},
+    {version = ">=2.1", markers = "python_version >= \"3.13\" and python_version < \"4.0\""},
 ]
 typing-extensions = ">=4.13.2"
 
@@ -2975,4 +2973,4 @@ grpc = ["grpcio", "protobuf"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "77509e9ae0471e50a399611107d5cbed7b2594edce41384aa4ea568fbeb804fc"
+content-hash = "8006d684051dae98d7d776ede3223e7c701c056378428efa5e6569bfd4ca9c36"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ python-decouple = ">=3.8"
 click = ">=8.0.0"
 distro = { version = ">=1.9.0", platform = "linux" }
 requests = ">=2.25.0"
-nitypes = {version=">=0.1.0dev3", allow-prereleases=true}
+nitypes = {version=">=0.1.0dev9", allow-prereleases=true}
 
 [tool.poetry.extras]
 grpc = ["grpcio", "protobuf"]

--- a/tests/component/test_stream_readers_ai.py
+++ b/tests/component/test_stream_readers_ai.py
@@ -192,7 +192,7 @@ def test___analog_single_channel_reader___read_waveform___returns_valid_waveform
     assert _is_timestamp_close_to_now(waveform.timing.timestamp)
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
     assert waveform.channel_name == ai_single_channel_task_with_timing.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
     assert waveform.sample_count == samples_to_read
 
 
@@ -211,7 +211,7 @@ def test___analog_single_channel_reader___read_waveform_no_args___returns_valid_
     assert _is_timestamp_close_to_now(waveform.timing.timestamp)
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
     assert waveform.channel_name == ai_single_channel_task_with_timing.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
     assert waveform.sample_count == 50
 
 
@@ -232,7 +232,7 @@ def test___analog_single_channel_reader___read_waveform_in_place___populates_val
     assert _is_timestamp_close_to_now(waveform.timing.timestamp)
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
     assert waveform.channel_name == ai_single_channel_task_with_timing.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
     assert waveform.sample_count == samples_to_read
 
 
@@ -300,7 +300,7 @@ def test___analog_single_channel_reader___read_waveform_high_sample_rate___retur
     assert _is_timestamp_close_to_now(waveform.timing.timestamp)
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 10_000_000)
     assert waveform.channel_name == ai_single_channel_task_with_high_rate.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
     assert waveform.sample_count == samples_to_read
 
 
@@ -324,7 +324,7 @@ def test___analog_single_channel_reader_with_timing_flag___read_waveform___only_
     assert waveform.timing.sample_interval_mode == SampleIntervalMode.REGULAR
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
     assert waveform.channel_name == ""
-    assert waveform.unit_description == ""
+    assert waveform.units == ""
 
 
 @pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
@@ -344,7 +344,7 @@ def test___analog_single_channel_reader_with_extended_properties_flag___read_wav
     assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
     assert waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
     assert waveform.channel_name == ai_single_channel_task_with_timing.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
 
 
 @pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
@@ -369,7 +369,7 @@ def test___analog_single_channel_reader_with_both_flags___read_waveform___includ
     assert waveform.timing.sample_interval_mode == SampleIntervalMode.REGULAR
     assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
     assert waveform.channel_name == ai_single_channel_task_with_timing.ai_channels[0].name
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
 
 
 @pytest.mark.grpc_skip(reason="read_analog_waveform not implemented in GRPC")
@@ -389,7 +389,7 @@ def test___analog_single_channel_reader_with_none_flag___read_waveform___minimal
     assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
     assert waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
     assert waveform.channel_name == ""
-    assert waveform.unit_description == ""
+    assert waveform.units == ""
 
 
 def test___analog_multi_channel_reader___read_one_sample___returns_valid_samples(
@@ -484,7 +484,7 @@ def test___analog_multi_channel_reader___read_waveforms___returns_valid_waveform
         assert (
             waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
         )
-        assert waveform.unit_description == "Volts"
+        assert waveform.units == "Volts"
         assert waveform.sample_count == samples_to_read
 
 
@@ -510,7 +510,7 @@ def test___analog_multi_channel_reader___read_waveforms_no_args___returns_valid_
         assert (
             waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
         )
-        assert waveform.unit_description == "Volts"
+        assert waveform.units == "Volts"
         assert waveform.sample_count == 50
 
 
@@ -542,7 +542,7 @@ def test___analog_multi_channel_reader___read_waveforms_in_place___populates_val
         assert (
             waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
         )
-        assert waveform.unit_description == "Volts"
+        assert waveform.units == "Volts"
         assert waveform.sample_count == samples_to_read
 
 
@@ -607,7 +607,7 @@ def test___analog_multi_channel_reader_with_timing_flag___read_waveforms___only_
         assert waveform.timing.sample_interval_mode == SampleIntervalMode.REGULAR
         assert waveform.timing.sample_interval == ht_timedelta(seconds=1 / 1000)
         assert waveform.channel_name == ""
-        assert waveform.unit_description == ""
+        assert waveform.units == ""
         assert waveform.sample_count == samples_to_read
 
 
@@ -634,7 +634,7 @@ def test___analog_multi_channel_reader_with_extended_properties_flag___read_wave
         assert (
             waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
         )
-        assert waveform.unit_description == "Volts"
+        assert waveform.units == "Volts"
         assert waveform.sample_count == samples_to_read
 
 
@@ -666,7 +666,7 @@ def test___analog_multi_channel_reader_with_both_flags___read_waveforms___includ
         assert (
             waveform.channel_name == ai_multi_channel_task_with_timing.ai_channels[chan_index].name
         )
-        assert waveform.unit_description == "Volts"
+        assert waveform.units == "Volts"
         assert waveform.sample_count == samples_to_read
 
 
@@ -691,7 +691,7 @@ def test___analog_multi_channel_reader_with_none_flag___read_waveforms___minimal
         assert waveform.scaled_data == pytest.approx(expected, abs=VOLTAGE_EPSILON)
         assert waveform.timing.sample_interval_mode == SampleIntervalMode.NONE
         assert waveform.channel_name == ""
-        assert waveform.unit_description == ""
+        assert waveform.units == ""
         assert waveform.sample_count == samples_to_read
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

In the latest version of nitypes, AnalogWaveform.unit_description has been renamed to "units". This PR uptakes the latest version, and fixes the usages.

### Why should this Pull Request be merged?

https://github.com/ni/nitypes-python/issues/168

### What testing has been done?

These tests now pass:
```
tests/component/test_stream_readers_ai.py:195: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:214: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:235: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:303: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:327: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:347: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:372: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:392: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:487: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:513: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:545: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:610: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:637: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:669: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
tests/component/test_stream_readers_ai.py:694: error: "AnalogWaveform[floating[_64Bit]]" has no attribute "unit_description"  [attr-defined]
```
