### PR TITLE
Use the new waveform.start_index instead of _start_index

### DIFF
--- a/generated/nidaqmx/stream_readers/_analog_multi_channel_reader.py
+++ b/generated/nidaqmx/stream_readers/_analog_multi_channel_reader.py
@@ -214,12 +214,12 @@ class AnalogMultiChannelReader(ChannelReaderBase):
                 DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
         
         for i, waveform in enumerate(waveforms):
-            if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+            if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
                 if reallocation_policy == ReallocationPolicy.TO_GROW:
-                    waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                    waveform.capacity = waveform.start_index + number_of_samples_per_channel
                 else:
                     raise DaqError(
-                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                         f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
                         'waveforms or adjust the number of samples requested.',
                         DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/generated/nidaqmx/stream_readers/_analog_single_channel_reader.py
+++ b/generated/nidaqmx/stream_readers/_analog_single_channel_reader.py
@@ -174,12 +174,12 @@ class AnalogSingleChannelReader(ChannelReaderBase):
             self._task._calculate_num_samps_per_chan(
                 number_of_samples_per_channel))
 
-        if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+        if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
             if reallocation_policy == ReallocationPolicy.TO_GROW:
-                waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                waveform.capacity = waveform.start_index + number_of_samples_per_channel
             else:
                 raise DaqError(
-                    f'The provided waveform does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                    f'The provided waveform does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                     f'the requested number of samples ({number_of_samples_per_channel}). Please provide a larger '
                     'waveform or adjust the number of samples requested.',
                 DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/generated/nidaqmx/stream_readers/_digital_multi_channel_reader.py
+++ b/generated/nidaqmx/stream_readers/_digital_multi_channel_reader.py
@@ -551,12 +551,12 @@ class DigitalMultiChannelReader(ChannelReaderBase):
                 DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
 
         for i, waveform in enumerate(waveforms):
-            if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+            if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
                 if reallocation_policy == ReallocationPolicy.TO_GROW:
-                    waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                    waveform.capacity = waveform.start_index + number_of_samples_per_channel
                 else:
                     raise DaqError(
-                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                         f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
                         'waveforms or adjust the number of samples requested.',
                         DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/generated/nidaqmx/stream_readers/_digital_single_channel_reader.py
+++ b/generated/nidaqmx/stream_readers/_digital_single_channel_reader.py
@@ -444,12 +444,12 @@ class DigitalSingleChannelReader(ChannelReaderBase):
             self._task._calculate_num_samps_per_chan(
                 number_of_samples_per_channel))
         
-        if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+        if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
             if reallocation_policy == ReallocationPolicy.TO_GROW:
-                waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                waveform.capacity = waveform.start_index + number_of_samples_per_channel
             else:
                 raise DaqError(
-                    f'The waveform does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                    f'The waveform does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                     f'the requested number of samples ({number_of_samples_per_channel}). Please '
                     'provide a larger waveform or adjust the number of samples requested.',
                     DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2972,4 +2972,4 @@ grpc = ["grpcio", "protobuf"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d19293f2cedc75b2001b325764a8a319d8b181ed55c4c2332b63cf72a1be38b8"
+content-hash = "6ffa32681a088a5c50e1bcfe4197a3f45cc695143f011cfaca089b03b6738df6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1739,13 +1739,13 @@ toml = ">=0.10.1"
 
 [[package]]
 name = "nitypes"
-version = "0.1.0.dev9"
+version = "0.1.0.dev10"
 description = "Data types for NI Python APIs"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "nitypes-0.1.0.dev9-py3-none-any.whl", hash = "sha256:1e2928f9a2c57f289f5743433299e09d151ab4951bacffbf67238093a82c3f67"},
-    {file = "nitypes-0.1.0.dev9.tar.gz", hash = "sha256:bc36861cc4a5ff0cfe74050afeed82bcdd652fc4de36860cd43492beee388b5d"},
+    {file = "nitypes-0.1.0.dev10-py3-none-any.whl", hash = "sha256:c4f097ffdeaf05697a7752a1e2b712760b28e84a4f6f446b4b7b76b349927490"},
+    {file = "nitypes-0.1.0.dev10.tar.gz", hash = "sha256:e319ebbdefca63db8e879b9f119cc4f76a086c550931dea2be0e33e9c10e9d9f"},
 ]
 
 [package.dependencies]
@@ -1754,7 +1754,6 @@ numpy = [
     {version = ">=1.22", markers = "python_version >= \"3.9\" and python_version < \"3.13\""},
     {version = ">=2.1", markers = "python_version >= \"3.13\" and python_version < \"4.0\""},
 ]
-typing-extensions = ">=4.13.2"
 
 [[package]]
 name = "nptdms"
@@ -2973,4 +2972,4 @@ grpc = ["grpcio", "protobuf"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8006d684051dae98d7d776ede3223e7c701c056378428efa5e6569bfd4ca9c36"
+content-hash = "d19293f2cedc75b2001b325764a8a319d8b181ed55c4c2332b63cf72a1be38b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ python-decouple = ">=3.8"
 click = ">=8.0.0"
 distro = { version = ">=1.9.0", platform = "linux" }
 requests = ">=2.25.0"
+typing_extensions = { version = ">=4.0.0" }
 nitypes = {version=">=0.1.0dev10", allow-prereleases=true}
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ python-decouple = ">=3.8"
 click = ">=8.0.0"
 distro = { version = ">=1.9.0", platform = "linux" }
 requests = ">=2.25.0"
-nitypes = {version=">=0.1.0dev9", allow-prereleases=true}
+nitypes = {version=">=0.1.0dev10", allow-prereleases=true}
 
 [tool.poetry.extras]
 grpc = ["grpcio", "protobuf"]

--- a/src/handwritten/stream_readers/_analog_multi_channel_reader.py
+++ b/src/handwritten/stream_readers/_analog_multi_channel_reader.py
@@ -214,12 +214,12 @@ class AnalogMultiChannelReader(ChannelReaderBase):
                 DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
         
         for i, waveform in enumerate(waveforms):
-            if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+            if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
                 if reallocation_policy == ReallocationPolicy.TO_GROW:
-                    waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                    waveform.capacity = waveform.start_index + number_of_samples_per_channel
                 else:
                     raise DaqError(
-                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                         f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
                         'waveforms or adjust the number of samples requested.',
                         DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/src/handwritten/stream_readers/_analog_single_channel_reader.py
+++ b/src/handwritten/stream_readers/_analog_single_channel_reader.py
@@ -174,12 +174,12 @@ class AnalogSingleChannelReader(ChannelReaderBase):
             self._task._calculate_num_samps_per_chan(
                 number_of_samples_per_channel))
 
-        if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+        if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
             if reallocation_policy == ReallocationPolicy.TO_GROW:
-                waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                waveform.capacity = waveform.start_index + number_of_samples_per_channel
             else:
                 raise DaqError(
-                    f'The provided waveform does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                    f'The provided waveform does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                     f'the requested number of samples ({number_of_samples_per_channel}). Please provide a larger '
                     'waveform or adjust the number of samples requested.',
                 DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/src/handwritten/stream_readers/_digital_multi_channel_reader.py
+++ b/src/handwritten/stream_readers/_digital_multi_channel_reader.py
@@ -551,12 +551,12 @@ class DigitalMultiChannelReader(ChannelReaderBase):
                 DAQmxErrors.MISMATCHED_INPUT_ARRAY_SIZES, task_name=self._task.name)
 
         for i, waveform in enumerate(waveforms):
-            if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+            if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
                 if reallocation_policy == ReallocationPolicy.TO_GROW:
-                    waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                    waveform.capacity = waveform.start_index + number_of_samples_per_channel
                 else:
                     raise DaqError(
-                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                        f'The waveform at index {i} does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                         f'the requested number of samples ({number_of_samples_per_channel}). Please provide larger '
                         'waveforms or adjust the number of samples requested.',
                         DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)

--- a/src/handwritten/stream_readers/_digital_single_channel_reader.py
+++ b/src/handwritten/stream_readers/_digital_single_channel_reader.py
@@ -444,12 +444,12 @@ class DigitalSingleChannelReader(ChannelReaderBase):
             self._task._calculate_num_samps_per_chan(
                 number_of_samples_per_channel))
         
-        if waveform._start_index + number_of_samples_per_channel > waveform.capacity:
+        if waveform.start_index + number_of_samples_per_channel > waveform.capacity:
             if reallocation_policy == ReallocationPolicy.TO_GROW:
-                waveform.capacity = waveform._start_index + number_of_samples_per_channel
+                waveform.capacity = waveform.start_index + number_of_samples_per_channel
             else:
                 raise DaqError(
-                    f'The waveform does not have enough space ({waveform.capacity - waveform._start_index}) to hold '
+                    f'The waveform does not have enough space ({waveform.capacity - waveform.start_index}) to hold '
                     f'the requested number of samples ({number_of_samples_per_channel}). Please '
                     'provide a larger waveform or adjust the number of samples requested.',
                     DAQmxErrors.READ_BUFFER_TOO_SMALL, task_name=self._task.name)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Uses the new public `waveform.start_index` instead of the private `waveform._start_index`.

### Why should this Pull Request be merged?

We shouldn't use private fields.

### What testing has been done?

Ran autotests
