### PR TITLE
github: Use setup-python and setup-poetry for system tests

### DIFF
--- a/.github/workflows/run_system_tests.yml
+++ b/.github/workflows/run_system_tests.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Import DAQmx config
         run: C:\nidaqmxconfig\targets\win64U\x64\msvc-14.0\release\nidaqmxconfig.exe --eraseconfig --import tests\max_config\nidaqmxMaxConfig.ini
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@8554e7ef74e95c9762962205f45a1e10c48de671 # v0.5.1
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@8554e7ef74e95c9762962205f45a1e10c48de671 # v0.5.1
       - name: Cache virtualenvs
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Update `run_system_tests.yml` to use `ni/python-actions/setup-python` and `ni/python-actions/setup-poetry`.

### Why should this Pull Request be merged?

Allow `ni/python-actions` to specify the default Python and Poetry versions used to run Tox.

### What testing has been done?

PR build