### PR TITLE
Add Waveform Examples

### DIFF
--- a/examples/analog_in/voltage_acq_int_clk_plot_wfm.py
+++ b/examples/analog_in/voltage_acq_int_clk_plot_wfm.py
@@ -1,0 +1,29 @@
+﻿"""Example of generating visualizations for acquired data using the AnalogWaveform data type.
+
+This example demonstrates how to plot the acquired waveform data.
+This example requires the matplotlib module.
+Run 'pip install matplotlib' to install the matplotlib module.
+"""
+
+import os
+
+os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
+
+import matplotlib.pyplot as plot  # noqa: E402 # Must import after setting environment variable
+
+import nidaqmx  # noqa: E402
+from nidaqmx.constants import READ_ALL_AVAILABLE, AcquisitionType  # noqa: E402
+
+with nidaqmx.Task() as task:
+    task.ai_channels.add_ai_voltage_chan("Dev1/ai0")
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=50)
+
+    waveform = task.read_waveform(READ_ALL_AVAILABLE)
+
+    plot.plot(waveform.scaled_data)
+    plot.xlabel("Sample Number")
+    plot.ylabel(waveform.units)
+    plot.title(waveform.channel_name)
+    plot.grid(True)
+
+    plot.show()

--- a/examples/analog_out/gen_voltage_wfm_int_clk.py
+++ b/examples/analog_out/gen_voltage_wfm_int_clk.py
@@ -5,19 +5,27 @@ voltage samples to an Analog Output Channel using an internal
 sample clock.
 """
 
-import nidaqmx
-from nidaqmx.constants import AcquisitionType
+import os
+
+os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
+
+from nitypes.waveform import AnalogWaveform  # noqa: E402
+
+import nidaqmx  # noqa: E402 # Must import after setting environment variable
+from nidaqmx.constants import AcquisitionType  # noqa: E402
 
 with nidaqmx.Task() as task:
-    data = []
     total_samples = 1000
     task.ao_channels.add_ao_voltage_chan("Dev1/ao0")
     task.timing.cfg_samp_clk_timing(
         1000.0, sample_mode=AcquisitionType.FINITE, samps_per_chan=total_samples
     )
 
-    data = [5.0 * i / total_samples for i in range(total_samples)]
-    number_of_samples_written = task.write(data, auto_start=True)
+    waveform = AnalogWaveform(sample_count=total_samples)
+    waveform.raw_data[:] = [5.0 * i / total_samples for i in range(total_samples)]
+    waveform.units = "Volts"
+
+    number_of_samples_written = task.write(waveform, auto_start=True)
     print(f"Generating {number_of_samples_written} voltage samples.")
     task.wait_until_done()
     task.stop()

--- a/examples/digital_out/cont_gen_dig_port_int_clk_wfm.py
+++ b/examples/digital_out/cont_gen_dig_port_int_clk_wfm.py
@@ -1,0 +1,29 @@
+"""Example for generating digital signals using the DigitalWaveform data type.
+
+This example demonstrates how to output a continuous digital
+pattern using the DAQ device's clock.
+"""
+
+import os
+
+os.environ["NIDAQMX_ENABLE_WAVEFORM_SUPPORT"] = "1"
+
+from nitypes.waveform import DigitalWaveform  # noqa: E402
+
+import nidaqmx  # noqa: E402 # Must import after setting environment variable
+from nidaqmx.constants import AcquisitionType, LineGrouping  # noqa: E402
+
+with nidaqmx.Task() as task:
+    waveform = DigitalWaveform(sample_count=100, signal_count=16)
+    for i in range(100):
+        for j in range(16):
+            waveform.data[i][j] = (i >> j) & 1
+
+    task.do_channels.add_do_chan("Dev1/port0", line_grouping=LineGrouping.CHAN_FOR_ALL_LINES)
+    task.timing.cfg_samp_clk_timing(1000.0, sample_mode=AcquisitionType.CONTINUOUS)
+    task.write(waveform)
+    task.start()
+
+    input("Generating voltage continuously. Press Enter to stop.\n")
+
+    task.stop()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- ~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- ~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

This PR ensures there are examples for how to use Waveforms for: analog in, analog out, digital in, and digital out.

Preexisting examples:
examples\analog_in\voltage_acq_int_clk_wfm.py
examples\digital_in\acq_dig_port_int_clk_wfm.py

Added examples:
examples/analog_in/voltage_acq_int_clk_plot_wfm.py
examples/digital_out/cont_gen_dig_port_int_clk_wfm.py

Updated examples to use waveform:
examples/analog_out/gen_voltage_wfm_int_clk.py

### Why should this Pull Request be merged?

AB#3315079

### What testing has been done?

All the examples have been run.
