### PR TITLE
tests: Enable Python 3.14 for system tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@
 isolated_build = true
 # grpcio does not have binary wheels for pypy or free-threading, as of version 1.75.1.
 # nidaqmxbot does not have pypy yet.
-envlist = clean, py{39,310,311,312,313,314,314t}-base, py{39,310,311,312,313,314}-grpc, py39-base-nicaiu, py39-base-nicai_utf8, py39-base-benchmark, report, docs
+# TODO: Get system tests running on Python 3.14t (free-threaded) - https://github.com/ni/nidaqmx-python/issues/853 
+envlist = clean, py{39,310,311,312,313,314,314}-base, py{39,310,311,312,313,314}-grpc, py39-base-nicaiu, py39-base-nicai_utf8, py39-base-benchmark, report, docs
 
 [testenv]
 skip_install = true
@@ -23,7 +24,7 @@ platform =
    nicaiu: win32
    nicai_utf8: win32
 commands =
-   poetry run python --version
+   poetry run python -VV
    poetry install -v {env:INSTALL_OPTS}
    poetry run python -c "from nidaqmx._lib import lib_importer; print(f'Library: {lib_importer.windll._library._name}\nLibrary encoding: {lib_importer.encoding}')"
    !benchmark: poetry run pytest --quiet --cov=generated/nidaqmx --cov-append --cov-report= --junitxml=test_results/system-{envname}.xml {env:PYTEST_OPTS} {posargs}
@@ -41,7 +42,7 @@ commands =
 # base_python should match the version specified in .readthedocs.yml and the PR workflow.
 base_python = python3.11
 commands =
-   poetry run python --version
+   poetry run python -VV
    poetry install -v --only main,docs
    # Use -W to treat warnings as errors.
    poetry run sphinx-build -b html -W docs docs/_build


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- ~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- ~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Add `py314-base` and `py314-grpc` Tox envs.

I tried adding `py314t-base`, but I ran into problems, so I filed #853 .

Change `python --version` to `python -VV` so it shows whether it's the free-threaded build or not.

### Why should this Pull Request be merged?

Add test coverage for Python 3.14.

### What testing has been done?

Ran PR workflow.