### PR TITLE
docs: Add info on ni.grpcdevice.v1.proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ All notable changes to this project will be documented in this file.
     * Upgrade to Poetry 2.x and migrate `pyproject.toml` format.
     * Add support for Python 3.14.
     * Add https://github.com/ni/ni-apis as a submodule of nidaqmx-python.
+    * Add an optional dependency on `ni.grpcdevice.v1.proto`.
+        * The internal `session_pb2` submodule has been moved to the shared package `ni.grpcdevice.v1.proto`. Installing the `nidaqmx` package's `grpc` extra will automatically install this package.
+        * If you get `ModuleNotFoundError: No module named 'session_pb2'`, make sure you are installing the `nidaqmx` package's `grpc` extra.
 
 * ### Known Issues
     * ...


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Add info on the `session_pb2` -> `ni.grpcdevice.v1.proto` migration.

### Why should this Pull Request be merged?

Users who install `grpcio` directly without using the `nidaqmx` package's `grpc` extra will likely get import errors.

### What testing has been done?

N/A