### PR TITLE
chore: Switch to normalized dev version format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nidaqmx"
 description = "NI-DAQmx Python API"
 license = "MIT"
 keywords = ["nidaqmx", "nidaq", "daqmx", "daq"]
-version = "1.4.0-dev0"
+version = "1.4.0.dev0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
- [ ] ~~I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Switch from `-dev0` to `.dev0`

### Why should this Pull Request be merged?

`.dev0` is the canonical syntax defined by [PEP 440](https://peps.python.org/pep-0440/).

When Poetry supports bumping from final to dev, it will likely use the dot syntax, so we might as well get used to it.

### What testing has been done?

N/A