### PR TITLE
[26Q2]: Add Calculated Power Channel Python Example

### DIFF
--- a/examples/analog_in/calculated_power_acq_int_clk.py
+++ b/examples/analog_in/calculated_power_acq_int_clk.py
@@ -4,7 +4,8 @@ This example demonstrates how to acquire a finite amount
 of calculated power data using the DAQ device's internal clock.
 
 Supported Devices:
-    - PXIe-4311 (DAQmx 26.3.0 or later)
+
+- PXIe-4311 (DAQmx 26.3.0 or later)
 """
 
 import nidaqmx

--- a/examples/analog_in/cont_calculated_power_acq_int_clk.py
+++ b/examples/analog_in/cont_calculated_power_acq_int_clk.py
@@ -4,7 +4,8 @@ This example demonstrates how to acquire a continuous amount of
 calculated power data using the DAQ device's internal clock.
 
 Supported Devices:
-    - PXIe-4311 (DAQmx 26.3.0 or later)
+
+- PXIe-4311 (DAQmx 26.3.0 or later)
 """
 
 import nidaqmx


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).



~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~


- [x] I've added tests applicable for this pull request



### What does this Pull Request accomplish?

The calculated power channel feature python API has been added in https://github.com/ni/nidaqmx-python/pull/876, this PR is to add example to use calculated power channel in finite and continuous acquisition.

### Why should this Pull Request be merged?
Calculated power channel is a new API that is scheduled to be released by 26Q2, a new example to showcase how to use the new API is needed.

### What testing has been done?
- Test for finite acquisition example:
<img width="800" height="610" alt="image" src="https://github.com/user-attachments/assets/98cdc824-e700-4097-9e40-8df6c7e22c18" />

- Test for continuous acquisition example:
<img width="800" height="191" alt="image" src="https://github.com/user-attachments/assets/b7f8d061-213e-4e7b-be65-783f7a9e0d5a" />
