### PR TITLE
Update installer metadata for version 26.0.0 and release 2026Q1

### DIFF
--- a/generated/nidaqmx/_installer_metadata.json
+++ b/generated/nidaqmx/_installer_metadata.json
@@ -1,32 +1,30 @@
 {
     "Windows": [
         {
-            "Version": "25.8.0",
-            "Release": "2025Q4",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.8/online/ni-daqmx_25.8_online.exe",
+            "Version": "26.0.0",
+            "Release": "2026Q1",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.0/online/ni-daqmx_26.0_online.exe",
             "supportedOS": [
                 "Windows 11",
+                "Windows Server 2025",
                 "Windows Server 2022 64-bit",
-                "Windows 10 64-bit",
-                "Windows Server 2016 64-bit",
-                "Windows Server 2019 64-bit"
+                "Windows 10 IoT Enterprise 2021"
             ]
         }
     ],
     "Linux": [
         {
-            "Version": "25.8.0",
-            "Release": "2025Q4",
+            "Version": "26.0.0",
+            "Release": "2026Q1",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q4/NILinux2025Q4DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q1/NILinux2026Q1DeviceDrivers.zip",
             "supportedOS": [
-                "ubuntu 20.04",
                 "ubuntu 22.04",
                 "ubuntu 24.04",
                 "rhel 8",
                 "rhel 9",
-                "opensuse 15.4",
-                "opensuse 15.5"
+                "opensuse 15.5",
+                "opensuse 15.6"
             ]
         }
     ]

--- a/src/handwritten/_installer_metadata.json
+++ b/src/handwritten/_installer_metadata.json
@@ -1,32 +1,30 @@
 {
     "Windows": [
         {
-            "Version": "25.8.0",
-            "Release": "2025Q4",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/25.8/online/ni-daqmx_25.8_online.exe",
+            "Version": "26.0.0",
+            "Release": "2026Q1",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.0/online/ni-daqmx_26.0_online.exe",
             "supportedOS": [
                 "Windows 11",
+                "Windows Server 2025",
                 "Windows Server 2022 64-bit",
-                "Windows 10 64-bit",
-                "Windows Server 2016 64-bit",
-                "Windows Server 2019 64-bit"
+                "Windows 10 IoT Enterprise 2021"
             ]
         }
     ],
     "Linux": [
         {
-            "Version": "25.8.0",
-            "Release": "2025Q4",
+            "Version": "26.0.0",
+            "Release": "2026Q1",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2025Q4/NILinux2025Q4DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q1/NILinux2026Q1DeviceDrivers.zip",
             "supportedOS": [
-                "ubuntu 20.04",
                 "ubuntu 22.04",
                 "ubuntu 24.04",
                 "rhel 8",
                 "rhel 9",
-                "opensuse 15.4",
-                "opensuse 15.5"
+                "opensuse 15.5",
+                "opensuse 15.6"
             ]
         }
     ]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update driver installer download links for both Windows (2026 Q1) and Linux (2026 Q1).

### Why should this Pull Request be merged?

For DAQmx python 1.4.1 release. This will be cherry picked to releases/1.4.0 branch after PR complete.

### What testing has been done?
- Download links are working.
- Cross checked the supported OS with official DAQmx installation page https://www.ni.com/en/support/downloads/drivers/download.ni-daq-mx.html#585854
