### PR TITLE
Update installer metadata for version 26.3.0 and release 2026Q2

### DIFF
--- a/generated/nidaqmx/_installer_metadata.json
+++ b/generated/nidaqmx/_installer_metadata.json
@@ -1,9 +1,9 @@
 {
     "Windows": [
         {
-            "Version": "26.0.0",
-            "Release": "2026Q1",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.0/online/ni-daqmx_26.0_online.exe",
+            "Version": "26.3.0",
+            "Release": "2026Q2",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.3/online/ni-daqmx_26.3_online.exe",
             "supportedOS": [
                 "Windows 11",
                 "Windows Server 2025",
@@ -14,17 +14,17 @@
     ],
     "Linux": [
         {
-            "Version": "26.0.0",
-            "Release": "2026Q1",
+            "Version": "26.3.0",
+            "Release": "2026Q2",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q1/NILinux2026Q1DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q2/NILinux2026Q2DeviceDrivers.zip",
             "supportedOS": [
                 "ubuntu 22.04",
                 "ubuntu 24.04",
-                "rhel 8",
                 "rhel 9",
-                "opensuse 15.5",
-                "opensuse 15.6"
+                "rhel 10",
+                "opensuse 15.6",
+                "opensuse 16.0"
             ]
         }
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nidaqmx"
 description = "NI-DAQmx Python API"
 license = "MIT"
 keywords = ["nidaqmx", "nidaq", "daqmx", "daq"]
-version = "1.5.0.dev0"
+version = "1.5.0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",

--- a/src/handwritten/_installer_metadata.json
+++ b/src/handwritten/_installer_metadata.json
@@ -1,9 +1,9 @@
 {
     "Windows": [
         {
-            "Version": "26.0.0",
-            "Release": "2026Q1",
-            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.0/online/ni-daqmx_26.0_online.exe",
+            "Version": "26.3.0",
+            "Release": "2026Q2",
+            "Location": "https://download.ni.com/support/nipkg/products/ni-d/ni-daqmx/26.3/online/ni-daqmx_26.3_online.exe",
             "supportedOS": [
                 "Windows 11",
                 "Windows Server 2025",
@@ -14,17 +14,17 @@
     ],
     "Linux": [
         {
-            "Version": "26.0.0",
-            "Release": "2026Q1",
+            "Version": "26.3.0",
+            "Release": "2026Q2",
             "_comment": "Location url must be of the format 'https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers<Release>/NILinux<Release>DeviceDrivers.zip'. Any change to the format will require a change in the code.",
-            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q1/NILinux2026Q1DeviceDrivers.zip",
+            "Location": "https://download.ni.com/support/softlib/MasterRepository/LinuxDrivers2026Q2/NILinux2026Q2DeviceDrivers.zip",
             "supportedOS": [
                 "ubuntu 22.04",
                 "ubuntu 24.04",
-                "rhel 8",
                 "rhel 9",
-                "opensuse 15.5",
-                "opensuse 15.6"
+                "rhel 10",
+                "opensuse 15.6",
+                "opensuse 16.0"
             ]
         }
     ]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Update driver installer download links for both Windows (2026 Q2) and Linux (2026 Q2).

### Why should this Pull Request be merged?

For DAQmx python 1.5.0 release.

### What testing has been done?
<img width="792" height="59" alt="image" src="https://github.com/user-attachments/assets/1f42da3b-a750-42d0-b90f-01386596ab4e" />

