### PR TITLE
Update README with gRPC installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,11 @@ You can use `pip <http://pypi.python.org/pypi/pip>`_ to download **nidaqmx** fro
 
   $ python -m pip install nidaqmx
 
+To use **nidaqmx** with gRPC, install it with the ``grpc`` extra to include the
+required dependencies::
+
+  $ python -m pip install nidaqmx[grpc]
+
 Automatic Driver Installation
 -----------------------------
 


### PR DESCRIPTION
Added instructions for installing nidaqmx with gRPC support.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~

~- [ ] I've added tests applicable for this pull request~


### What does this Pull Request accomplish?
Adds documentation to the Installation section of the README explaining how to install nidaqmx with gRPC support using pip install nidaqmx[grpc]. This information was previously undocumented, causing confusion for users who encountered missing dependency errors (e.g., session_pb2) when trying to use nidaqmx over gRPC.
Related bug: https://github.com/ni/nidaqmx-python/issues/916

### Why should this Pull Request be merged?
 The [grpc] install extra is the intended way to pull in the required gRPC dependencies, but this was not documented anywhere in the README. 

### What testing has been done?
This is a documentation change to README.rst. The RST syntax has been visually verified to be consistent with the existing formatting in the file. 
<img width="1069" height="350" alt="image" src="https://github.com/user-attachments/assets/17213680-d13b-4688-9293-ecde2a7b9ea8" />
