### PR TITLE
Fix tests that need 32 DIO lines incorrectly using device with less than 32 DIO lines

### DIFF
--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -665,6 +665,7 @@ def do_port0_task(
     _start_do_task(task, is_port=True)
     return task
 
+
 @pytest.fixture
 def do_port0_task_dio32(
     generate_task: Callable[[], nidaqmx.Task], real_x_series_device_32dio: nidaqmx.system.Device
@@ -678,6 +679,7 @@ def do_port0_task_dio32(
     )
     _start_do_task(task, is_port=True)
     return task
+
 
 @pytest.fixture
 def do_port1_task(

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -667,7 +667,7 @@ def do_port0_task(
 
 
 @pytest.fixture
-def do_port0_task_dio32(
+def do_port0_task_32dio(
     generate_task: Callable[[], nidaqmx.Task], real_x_series_device_32dio: nidaqmx.system.Device
 ) -> nidaqmx.Task:
     """Configure a single-channel DO task."""

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -665,6 +665,19 @@ def do_port0_task(
     _start_do_task(task, is_port=True)
     return task
 
+@pytest.fixture
+def do_port0_task_dio32(
+    generate_task: Callable[[], nidaqmx.Task], real_x_series_device_32dio: nidaqmx.system.Device
+) -> nidaqmx.Task:
+    """Configure a single-channel DO task."""
+    task = generate_task()
+    # Select X Series port 0 32 lines
+    task.do_channels.add_do_chan(
+        real_x_series_device_32dio.do_ports[0].name,
+        line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+    )
+    _start_do_task(task, is_port=True)
+    return task
 
 @pytest.fixture
 def do_port1_task(

--- a/tests/component/stream_writers/test_digital_single_channel_writer.py
+++ b/tests/component/stream_writers/test_digital_single_channel_writer.py
@@ -430,17 +430,17 @@ def test___digital_single_channel_writer___write_waveform_port_uint8___outputs_m
 
 
 def test___digital_single_channel_writer___write_waveform_port_uint32___outputs_match_final_values(
-    do_port0_task_dio32: nidaqmx.Task,
+    do_port0_task_32dio: nidaqmx.Task,
     di_port0_loopback_task_32dio: nidaqmx.Task,
 ) -> None:
-    writer = DigitalSingleChannelWriter(do_port0_task_dio32.out_stream)
+    writer = DigitalSingleChannelWriter(do_port0_task_32dio.out_stream)
     # Since digital outputs don't have built-in loopback channels like analog outputs,
     # we can only read back the last value. So to verify the whole signal, we must
     # write waveforms of increasing length and verify the final value each time.
     for i in range(1, 10):
         num_samples = i
         num_lines = 32
-        assert num_lines == _get_num_do_lines_in_task(do_port0_task_dio32)
+        assert num_lines == _get_num_do_lines_in_task(do_port0_task_32dio)
         waveform = _create_digital_waveform_uint8(num_samples, num_lines)
 
         samples_written = writer.write_waveform(waveform)

--- a/tests/component/stream_writers/test_digital_single_channel_writer.py
+++ b/tests/component/stream_writers/test_digital_single_channel_writer.py
@@ -430,17 +430,17 @@ def test___digital_single_channel_writer___write_waveform_port_uint8___outputs_m
 
 
 def test___digital_single_channel_writer___write_waveform_port_uint32___outputs_match_final_values(
-    do_port0_task: nidaqmx.Task,
+    do_port0_task_dio32: nidaqmx.Task,
     di_port0_loopback_task: nidaqmx.Task,
 ) -> None:
-    writer = DigitalSingleChannelWriter(do_port0_task.out_stream)
+    writer = DigitalSingleChannelWriter(do_port0_task_dio32.out_stream)
     # Since digital outputs don't have built-in loopback channels like analog outputs,
     # we can only read back the last value. So to verify the whole signal, we must
     # write waveforms of increasing length and verify the final value each time.
     for i in range(1, 10):
         num_samples = i
         num_lines = 32
-        assert num_lines == _get_num_do_lines_in_task(do_port0_task)
+        assert num_lines == _get_num_do_lines_in_task(do_port0_task_dio32)
         waveform = _create_digital_waveform_uint8(num_samples, num_lines)
 
         samples_written = writer.write_waveform(waveform)

--- a/tests/component/stream_writers/test_digital_single_channel_writer.py
+++ b/tests/component/stream_writers/test_digital_single_channel_writer.py
@@ -431,7 +431,7 @@ def test___digital_single_channel_writer___write_waveform_port_uint8___outputs_m
 
 def test___digital_single_channel_writer___write_waveform_port_uint32___outputs_match_final_values(
     do_port0_task_dio32: nidaqmx.Task,
-    di_port0_loopback_task: nidaqmx.Task,
+    di_port0_loopback_task_32dio: nidaqmx.Task,
 ) -> None:
     writer = DigitalSingleChannelWriter(do_port0_task_dio32.out_stream)
     # Since digital outputs don't have built-in loopback channels like analog outputs,
@@ -445,7 +445,7 @@ def test___digital_single_channel_writer___write_waveform_port_uint32___outputs_
 
         samples_written = writer.write_waveform(waveform)
 
-        actual_value = di_port0_loopback_task.read()
+        actual_value = di_port0_loopback_task_32dio.read()
         assert samples_written == num_samples
         assert waveform.signal_count == num_lines
         assert actual_value == _get_waveform_port_data(waveform)[i - 1]

--- a/tests/component/task/test_task_write_waveform_do.py
+++ b/tests/component/task/test_task_write_waveform_do.py
@@ -283,7 +283,7 @@ def test___task___write_waveform_port_uint8___outputs_match_final_values(
 
 
 def test___task___write_waveform_port_uint32___outputs_match_final_values(
-    do_port0_task_dio32: nidaqmx.Task,
+    do_port0_task_32dio: nidaqmx.Task,
     di_port0_loopback_task_32dio: nidaqmx.Task,
 ) -> None:
     # Since digital outputs don't have built-in loopback channels like analog outputs,
@@ -294,7 +294,7 @@ def test___task___write_waveform_port_uint32___outputs_match_final_values(
         num_lines = 32
         waveform = _create_digital_waveform_uint8(num_samples, num_lines)
 
-        samples_written = do_port0_task_dio32.write_waveform(waveform)
+        samples_written = do_port0_task_32dio.write_waveform(waveform)
 
         assert samples_written == num_samples
         actual_value = di_port0_loopback_task_32dio.read()

--- a/tests/component/task/test_task_write_waveform_do.py
+++ b/tests/component/task/test_task_write_waveform_do.py
@@ -283,7 +283,7 @@ def test___task___write_waveform_port_uint8___outputs_match_final_values(
 
 
 def test___task___write_waveform_port_uint32___outputs_match_final_values(
-    do_port0_task: nidaqmx.Task,
+    do_port0_task_dio32: nidaqmx.Task,
     di_port0_loopback_task: nidaqmx.Task,
 ) -> None:
     # Since digital outputs don't have built-in loopback channels like analog outputs,
@@ -294,7 +294,7 @@ def test___task___write_waveform_port_uint32___outputs_match_final_values(
         num_lines = 32
         waveform = _create_digital_waveform_uint8(num_samples, num_lines)
 
-        samples_written = do_port0_task.write_waveform(waveform)
+        samples_written = do_port0_task_dio32.write_waveform(waveform)
 
         assert samples_written == num_samples
         actual_value = di_port0_loopback_task.read()

--- a/tests/component/task/test_task_write_waveform_do.py
+++ b/tests/component/task/test_task_write_waveform_do.py
@@ -284,7 +284,7 @@ def test___task___write_waveform_port_uint8___outputs_match_final_values(
 
 def test___task___write_waveform_port_uint32___outputs_match_final_values(
     do_port0_task_dio32: nidaqmx.Task,
-    di_port0_loopback_task: nidaqmx.Task,
+    di_port0_loopback_task_32dio: nidaqmx.Task,
 ) -> None:
     # Since digital outputs don't have built-in loopback channels like analog outputs,
     # we can only read back the last value. So to verify the whole signal, we must
@@ -297,7 +297,7 @@ def test___task___write_waveform_port_uint32___outputs_match_final_values(
         samples_written = do_port0_task_dio32.write_waveform(waveform)
 
         assert samples_written == num_samples
-        actual_value = di_port0_loopback_task.read()
+        actual_value = di_port0_loopback_task_32dio.read()
         assert actual_value == _get_waveform_port_data(waveform)[i - 1]
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).

- ~~[ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~

- ~~[ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?
Add a fixture for DO to use only X series device with >= 32 DIO lines  
Update the currently failing tests that need 32 lines to use the above fixture.

### Why should this Pull Request be merged?
[AB#3978397](https://dev.azure.com/ni/DevCentral/_workitems/edit/3978397)

To handle testing in a setup where there is a X series device with < 32 DIO lines.

### What testing has been done?
Tested on a controller setup with PXIe-6375 and PXIe-6363. Place PXIe-6375 in a slot ahead of PXIe-6363. This is so that PXIe-6375 is chosen as the first possible X series device if there is no requirement of 32 DIO lines. No failure is observed when running pytest.

Tested on a controller with PXIe-6363 only. No failure is observed when running pytest.