### PR TITLE
add clear task method and made close an alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 
 * ### Major Changes
     * [zizmor](https://zizmor.sh/) is now used for GitHub Actions static analysis.
+    * [1000: add clear task method and made close an alias](https://github.com/ni/nidaqmx-python/pull/1000)
 
 * ### Known Issues
     * ...

--- a/generated/nidaqmx/task/_task.py
+++ b/generated/nidaqmx/task/_task.py
@@ -322,7 +322,7 @@ class Task:
 
         self._interpreter.add_global_chans_to_task(self._handle, channels)
 
-    def close(self):
+    def clear(self):
         """Clears the task.
 
         Before clearing, this method aborts the task, if necessary,
@@ -360,6 +360,12 @@ class Task:
 
         if first_exception:
             raise first_exception
+
+    close = clear
+    """Clears the task.
+
+    :meth:`close` is an alias for :meth:`clear`.
+    """
 
     def control(self, action):
         """Alters the state of a task according to the action you specify.

--- a/src/handwritten/task/_task.py
+++ b/src/handwritten/task/_task.py
@@ -322,7 +322,7 @@ class Task:
 
         self._interpreter.add_global_chans_to_task(self._handle, channels)
 
-    def close(self):
+    def clear(self):
         """Clears the task.
 
         Before clearing, this method aborts the task, if necessary,
@@ -360,6 +360,12 @@ class Task:
 
         if first_exception:
             raise first_exception
+
+    close = clear
+    """Clears the task.
+
+    :meth:`close` is an alias for :meth:`clear`.
+    """
 
     def control(self, action):
         """Alters the state of a task according to the action you specify.

--- a/tests/unit/test_task.py
+++ b/tests/unit/test_task.py
@@ -111,6 +111,20 @@ def test___call_alternate_constructor___create_task_not_called(
 
 
 @pytest.mark.parametrize("close_on_exit", [False, True])
+def test___varying_close_on_exit___clear___clear_task_called(
+    interpreter: Mock, close_on_exit: bool
+):
+    expect_create_task(interpreter, "MyTaskHandle", close_on_exit)
+    expect_get_task_name(interpreter, "MyTask")
+    task = Task("MyTask")
+    task_handle = task._handle
+
+    task.clear()
+
+    interpreter.clear_task.assert_called_with(task_handle)
+
+
+@pytest.mark.parametrize("close_on_exit", [False, True])
 def test___varying_close_on_exit___close___clear_task_called(
     interpreter: Mock, close_on_exit: bool
 ):
@@ -119,6 +133,7 @@ def test___varying_close_on_exit___close___clear_task_called(
     task = Task("MyTask")
     task_handle = task._handle
 
+    # close is an alias for clear
     task.close()
 
     interpreter.clear_task.assert_called_with(task_handle)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
- [x] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.
- [x] I've added tests applicable for this pull request

### What does this Pull Request accomplish?

I had some customer feedback that `clear` task was more familiar for people coming from other DAQmx APIs, which I agree with. In practice, tasks should almost always be used with Python context managers, but in the rare cases where they aren't, this method could be useful.

### Why should this Pull Request be merged?

Simple rename of an existing method with an alias to the old name to not break compatibility.

### What testing has been done?

Added a unit test, and ran all the existing ones. griffe says:

```
>poetry run griffe check -s generated\ -a 1.5.0 --verbose nidaqmx
generated\nidaqmx\task\_task.py:364: Task.close:
Public object points to a different kind of object:
  Old: function
  New: attribute
```

Their [documentation](https://mkdocstrings.github.io/griffe/guide/users/checking/#object-changed-kind) says:

> Changing the kind of an object is not really an API breakage, depending on our definition of API, since this won't always raise immediate errors like TypeError. The object is still here and accessed: the contract is fulfilled. But developers sometimes rely on the kind of an object, so changing it will lead to incorrect behavior, potentially making it difficult to detect, understand and fix the issue. That is why it is important to warn developers about such changes.
