### PR TITLE
Fixing calculated_power example test failure

### DIFF
--- a/examples/analog_in/calculated_power_acq_int_clk.py
+++ b/examples/analog_in/calculated_power_acq_int_clk.py
@@ -13,8 +13,8 @@ from nidaqmx.constants import READ_ALL_AVAILABLE, AcquisitionType
 
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_calculated_power_chan(
-        voltage_physical_channel="Dev1/ai0",
-        current_physical_channel="Dev1/ai1",
+        voltage_physical_channel="PXI1Slot4/ai0",
+        current_physical_channel="PXI1Slot4/ai1",
         voltage_min_val=0.0,
         voltage_max_val=5.0,
         current_min_val=0.0,

--- a/examples/analog_in/cont_calculated_power_acq_int_clk.py
+++ b/examples/analog_in/cont_calculated_power_acq_int_clk.py
@@ -13,8 +13,8 @@ from nidaqmx.constants import AcquisitionType
 
 with nidaqmx.Task() as task:
     task.ai_channels.add_ai_calculated_power_chan(
-        voltage_physical_channel="Dev1/ai0",
-        current_physical_channel="Dev1/ai1",
+        voltage_physical_channel="PXI1Slot4/ai0",
+        current_physical_channel="PXI1Slot4/ai1",
         voltage_min_val=0.0,
         voltage_max_val=5.0,
         current_min_val=0.0,

--- a/tests/max_config/examplesMaxConfig.ini
+++ b/tests/max_config/examplesMaxConfig.ini
@@ -39,6 +39,15 @@ BusType = PXIe
 PXI.ChassisNum = 1
 PXI.SlotNum = 3
 
+[DAQmxDevice PXI1Slot4]
+ProductType = PXIe-4311
+DevSerialNum = 0x0
+DevIsSimulated = 1
+ProductNum = 0x7B90C4C4
+BusType = PXIe
+PXI.ChassisNum = 1
+PXI.SlotNum = 4
+
 [DAQmxDevice PXI1Slot7]
 ProductType = PXIe-6368
 DevSerialNum = 0x0


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nidaqmx-python/blob/master/CONTRIBUTING.md).
~~- [ ] I've updated [CHANGELOG.md](https://github.com/ni/nidaqmx-python/blob/master/CHANGELOG.md) if applicable.~~
~~- [ ] I've added tests applicable for this pull request~~

### What does this Pull Request accomplish?

Fix the calculated_power example test failure as reported in https://github.com/ni/nidaqmx-python/issues/1015

### Why should this Pull Request be merged?

So that the calculated_power example test is able to run and the workflow of importing `tests\max_config\examplesMaxConfig.ini` then run pytest (listed in CONTRIBUTING.md) is passing.

### What testing has been done?
- After imported the updated `examplesMaxConfig.ini` to NI-MAX, `poetry run pytest` is passing
   <img width="1087" height="37" alt="image" src="https://github.com/user-attachments/assets/c9d612c0-4a63-43e2-989d-1f84123fc58e" />
   <img width="1078" height="22" alt="image" src="https://github.com/user-attachments/assets/bf140a96-695c-463f-8cd9-a4382ec99917" />
- `poetry run ni-python-styleguide lint`, `poetry run mypy` and `npx cspell "**" --no-progress` completed without issue.